### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ Article citations are **critical** for us to be able to continue support for JSB
 Please also indicate the specific version of JSBML you use, to improve other people's ability to reproduce your results.  You can use the Zenodo DOIs we provide for this purpose:
 
 * JSBML release 1.3.1 &rArr; [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1118387.svg)](https://doi.org/10.5281/zenodo.1118387)
-* JSBML release 1.2 &rArr; [10.5281/zenodo.200544](http://doi.org/10.5281/zenodo.200544)
-* JSBML release 1.1 &rArr; [10.5281/zenodo.55323](http://dx.doi.org/10.5281/zenodo.55323)
-* JSBML release 1.0 &rArr; [10.5281/zenodo.55635](http://dx.doi.org/10.5281/zenodo.55635)
-* JSBML release 0.8 &rArr; [10.5281/zenodo.55636](http://dx.doi.org/10.5281/zenodo.55636)
+* JSBML release 1.2 &rArr; [10.5281/zenodo.200544](https://doi.org/10.5281/zenodo.200544)
+* JSBML release 1.1 &rArr; [10.5281/zenodo.55323](https://doi.org/10.5281/zenodo.55323)
+* JSBML release 1.0 &rArr; [10.5281/zenodo.55635](https://doi.org/10.5281/zenodo.55635)
+* JSBML release 0.8 &rArr; [10.5281/zenodo.55636](https://doi.org/10.5281/zenodo.55636)
 
 
 📰 Recent news and activities

--- a/core/test/org/sbml/jsbml/xml/test/data/l2v4/BIOMD0000000228.xml
+++ b/core/test/org/sbml/jsbml/xml/test/data/l2v4/BIOMD0000000228.xml
@@ -7,7 +7,7 @@
       This is the extended model described the article: <br/>
         <strong>Bifurcation analysis of the regulatory modules of the mammalian G1/S transition. </strong>
         <br/>Swat M, Kel A, Herzel H. <em>Bioinformatics</em> 2004 Jul 10;20(10):1506-11. PMID: 
-      <a href="http://www.ncbi.nlm.nih.gov/pubmed/15231543">15231543</a>, doi:<a href="http://dx.doi.org/10.1016/S0006-3495(03)74460-9">10.1016/S0006-3495(03)74460-9</a>
+      <a href="http://www.ncbi.nlm.nih.gov/pubmed/15231543">15231543</a>, doi:<a href="https://doi.org/10.1016/S0006-3495(03)74460-9">10.1016/S0006-3495(03)74460-9</a>
         <br/>
         <strong>Abstract:</strong>
         <br/>

--- a/doc/common/tex/literature.bib
+++ b/doc/common/tex/literature.bib
@@ -61,7 +61,7 @@
   doi = {10.1038/msb.2011.77},
   keywords = {dynamics; kinetics; model; ontology; simulation},
   pdf = {http://www.nature.com/msb/journal/v7/n1/pdf/msb201177.pdf},
-  url = {http://dx.doi.org/10.1038/msb.2011.77}
+  url = {https://doi.org/10.1038/msb.2011.77}
 }
 
 @ARTICLE{Draeger2011b,
@@ -276,7 +276,7 @@
 	can be found at the project homepage (URL found in the Availability
 	and requirements section).},
   doi = {10.1186/1752-0509-2-39},
-  url = {http://dx.doi.org/10.1186/1752-0509-2-39}
+  url = {https://doi.org/10.1186/1752-0509-2-39}
 }
 
 @ARTICLE{Funahashi2003,
@@ -333,7 +333,7 @@
   year = {1973},
   volume = {2},
   pages = {225},
-  doi = {http://dx.doi.org/10.1137/0202019}
+  doi = {https://doi.org/10.1137/0202019}
 }
 
 @TECHREPORT{Hucka2010a,
@@ -395,7 +395,7 @@
 	are also available from the SBML project web site, http://sbml.org/.},
   doi = {doi:10.1038/npre.2008.2715.1},
   journal = {Nature Precedings},
-  url = {http://dx.doi.org/10.1038/npre.2008.2715.1},
+  url = {https://doi.org/10.1038/npre.2008.2715.1},
   volume = {58}
 }
 
@@ -541,7 +541,7 @@
   doi = {10.1186/1471-2202-7-S1-S11},
   pii = {1471-2202-7-S1-S11},
   pmid = {17118155},
-  url = {http://dx.doi.org/10.1186/1471-2202-7-S1-S11}
+  url = {https://doi.org/10.1186/1471-2202-7-S1-S11}
 }
 
 @INPROCEEDINGS{Novere2006b,


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8) and Zenodo started using it for its badges as well. Accordingly, this PR updates all DOI links.

Cheers!