### PR TITLE
fix XML External Entity vulnerability.

### DIFF
--- a/core/src/org/sbml/jsbml/xml/stax/SBMLReader.java
+++ b/core/src/org/sbml/jsbml/xml/stax/SBMLReader.java
@@ -36,6 +36,7 @@ import java.util.Stack;
 
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.Attribute;
 import javax.xml.stream.events.Characters;
@@ -539,6 +540,9 @@ public class SBMLReader {
   public SBMLDocument readSBMLFromStream(InputStream stream, TreeNodeChangeListener listener)
       throws XMLStreamException {
     WstxInputFactory inputFactory = new WstxInputFactory();
+    // see https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md
+    inputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+    inputFactory.setProperty("javax.xml.stream.isSupportingExternalEntities", false);
     XMLEventReader xmlEventReader = inputFactory.createXMLEventReader(stream);
     return (SBMLDocument) readXMLFromXMLEventReader(xmlEventReader, listener);
   }
@@ -566,9 +570,13 @@ public class SBMLReader {
       throws XMLStreamException {
     WstxInputFactory inputFactory = new WstxInputFactory();
 
-    // see https://groups.google.com/d/msg/jsbml-development/cckEJPYNzQY/5ynmIbqNCAAJ for why we did set this value
     try {
+      // see https://groups.google.com/d/msg/jsbml-development/cckEJPYNzQY/5ynmIbqNCAAJ for why we did set this value
       inputFactory.setProperty(WstxInputProperties.P_MAX_ELEMENT_DEPTH, 5000);
+
+      // see https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md
+      inputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+      inputFactory.setProperty("javax.xml.stream.isSupportingExternalEntities", false);
     } catch(IllegalArgumentException e) {
       // do nothing - the XML libraries used do not support this property for some reason
     }

--- a/core/test/org/sbml/jsbml/xml/test/Tests.java
+++ b/core/test/org/sbml/jsbml/xml/test/Tests.java
@@ -38,7 +38,7 @@ import org.sbml.jsbml.test.RemoveFromParentTest;
 @SuiteClasses(value={SBML_L1VxTests.class, SBML_L2V1Test.class, CheckConsistencyTests.class, GetNotesStringTests.class,
   UnregisterTests.class, RemoveFromParentTest.class, CVTermTests.class, RemoveFromParentTest.class, ASTNodeTest.class,
   ASTNodeInfixParsingTest.class, TestInfixOperatorPrecedence.class, IdRegistrationTest.class, XMLTokenTest.class,
-  CreatorTests.class, NestedCVTermTests.class})
+  CreatorTests.class, NestedCVTermTests.class, XXEInjectionTests.class})
 public class Tests {
 
 }

--- a/core/test/org/sbml/jsbml/xml/test/XXEInjectionTests.java
+++ b/core/test/org/sbml/jsbml/xml/test/XXEInjectionTests.java
@@ -1,0 +1,67 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ *
+ * Copyright (C) 2009-2019 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The University of California, San Diego, La Jolla, CA, USA
+ * 5. The Babraham Institute, Cambridge, UK
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+package org.sbml.jsbml.xml.test;
+
+import com.ctc.wstx.exc.WstxParsingException;
+import org.junit.Test;
+import org.sbml.jsbml.SBMLReader;
+
+import javax.xml.stream.XMLStreamException;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for <a href="https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Processing">XML External Entity Injection</a> attacks.
+ *
+ * @author <a href="mailto:mglont@ebi.ac.uk">Mihai Glont</a>
+ * @since 1.5
+ */
+public class XXEInjectionTests {
+    @Test()
+    public void readingModelsContainingExternalEntitiesThrowsAnException() {
+        final String modelPath = "/org/sbml/jsbml/xml/test/data/l2v1/BIOMD0000000025-xxe.xml";
+        InputStream modelStream = getClass().getResourceAsStream(modelPath);
+
+        try {
+            // this should throw a WstxParsingException
+            new SBMLReader().readSBMLFromStream(modelStream);
+            fail("Document containing XXE injection did not throw a parsing exception -- possible vulnerability detected!");
+        } catch (XMLStreamException expected) {
+            if (!(expected instanceof WstxParsingException)) {
+                String err = String.format("Could not parse SBML document %s: %s", modelPath, expected.toString());
+                fail(err);
+            }
+            String expectedMsg = String.format("Undeclared general entity \"xxe\"%n at [row,col {unknown-source}]: [5,10]");
+            assertEquals("The location of the external entity in the file is correctly reported",
+                    expectedMsg, expected.getMessage());
+        } finally {
+            if (null != modelStream) {
+                try {
+                    modelStream.close();
+                } catch (IOException e) {
+                    String err = String.format("Could not close stream %s: %s", modelPath, e.toString());
+                    fail(err);
+                }
+            }
+        }
+    }
+}

--- a/core/test/org/sbml/jsbml/xml/test/data/l2v1/BIOMD0000000025-xxe.xml
+++ b/core/test/org/sbml/jsbml/xml/test/data/l2v1/BIOMD0000000025-xxe.xml
@@ -1,0 +1,346 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE foo [
+  <!ELEMENT foo ANY >
+  <!ENTITY xxe SYSTEM "file:///dev/random" >]>
+<foo>&xxe;</foo>
+<sbml xmlns="http://www.sbml.org/sbml/level2" metaid="metaid_0000001" level="2" version="1">
+  <model metaid="metaid_0000002" id="Smolen2002" name="Smolen2002_CircClock">
+    <notes>
+      <body xmlns="http://www.w3.org/1999/xhtml">
+        <p>This model originates from BioModels Database: A Database of Annotated Published Models. It is copyright (c) 2005-2009 The BioModels Team.<br/>For more information see the <a href="http://www.ebi.ac.uk/biomodels/legal.html" target="_blank">terms of use</a>.<br/>To cite BioModels Database, please use <a href="http://www.pubmedcentral.nih.gov/articlerender.fcgi?tool=pubmed&amp;pubmedid=16381960" target="_blank">Le Novère N., Bornstein B., Broicher A., Courtot M., Donizelli M., Dharuri H., Li L., Sauro H., Schilstra M., Shapiro B., Snoep J.L., Hucka M. (2006) BioModels Database: A Free, Centralized Database of Curated, Published, Quantitative Kinetic Models of Biochemical and Cellular Systems Nucleic Acids Res., 34: D689-D691.</a>
+      </p>
+    </body>
+  </notes>
+  <annotation>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+      <rdf:Description rdf:about="#metaid_0000002">
+        <dc:creator rdf:parseType="Resource">
+          <rdf:Bag>
+            <rdf:li rdf:parseType="Resource">
+              <vCard:N rdf:parseType="Resource">
+                <vCard:Family>Le Novère</vCard:Family>
+                <vCard:Given>Nicolas</vCard:Given>
+              </vCard:N>
+              <vCard:EMAIL>lenov@ebi.ac.uk</vCard:EMAIL>
+              <vCard:ORG>
+                <vCard:Orgname>EMBL-EBI</vCard:Orgname>
+              </vCard:ORG>
+            </rdf:li>
+          </rdf:Bag>
+        </dc:creator>
+        <dcterms:created rdf:parseType="Resource">
+          <dcterms:W3CDTF>2005-06-29T11:01:49Z</dcterms:W3CDTF>
+        </dcterms:created>
+        <dcterms:modified rdf:parseType="Resource">
+          <dcterms:W3CDTF>2008-08-21T11:47:14Z</dcterms:W3CDTF>
+        </dcterms:modified>
+        <bqmodel:is>
+          <rdf:Bag>
+            <rdf:li rdf:resource="urn:miriam:biomodels.db:BIOMD0000000025"/>
+          </rdf:Bag>
+        </bqmodel:is>
+        <bqmodel:isDescribedBy>
+          <rdf:Bag>
+            <rdf:li rdf:resource="urn:miriam:pubmed:12414672"/>
+          </rdf:Bag>
+        </bqmodel:isDescribedBy>
+        <bqbiol:isVersionOf>
+          <rdf:Bag>
+            <rdf:li rdf:resource="urn:miriam:obo.go:GO%3A0007623"/>
+          </rdf:Bag>
+        </bqbiol:isVersionOf>
+        <bqbiol:is>
+          <rdf:Bag>
+            <rdf:li rdf:resource="urn:miriam:taxonomy:7227"/>
+            <rdf:li rdf:resource="urn:miriam:kegg.pathway:dme04710"/>
+          </rdf:Bag>
+        </bqbiol:is>
+      </rdf:Description>
+    </rdf:RDF>
+  </annotation>
+  <listOfUnitDefinitions>
+    <unitDefinition metaid="metaid_0000017" id="time" name="hour (new default)">
+      <listOfUnits>
+        <unit kind="second" multiplier="3600"/>
+      </listOfUnits>
+    </unitDefinition>
+    <unitDefinition metaid="metaid_0000018" id="substance" name="nanomole (new default)">
+      <listOfUnits>
+        <unit kind="mole" scale="-9"/>
+      </listOfUnits>
+    </unitDefinition>
+  </listOfUnitDefinitions>
+  <listOfCompartments>
+    <compartment metaid="metaid_0000005" id="CELL" size="1e-15">
+      <annotation>
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+          <rdf:Description rdf:about="#metaid_0000005">
+            <bqbiol:is>
+              <rdf:Bag>
+                <rdf:li rdf:resource="urn:miriam:obo.go:GO%3A0005623"/>
+              </rdf:Bag>
+            </bqbiol:is>
+          </rdf:Description>
+        </rdf:RDF>
+      </annotation>
+    </compartment>
+  </listOfCompartments>
+  <listOfSpecies>
+    <species metaid="metaid_0000007" id="EmptySet" compartment="CELL" initialAmount="0" boundaryCondition="true" constant="true"/>
+    <species metaid="metaid_0000008" id="Per" compartment="CELL" initialAmount="5e-16">
+      <annotation>
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+          <rdf:Description rdf:about="#metaid_0000008">
+            <bqbiol:is>
+              <rdf:Bag>
+                <rdf:li rdf:resource="urn:miriam:uniprot:P07663"/>
+              </rdf:Bag>
+            </bqbiol:is>
+          </rdf:Description>
+        </rdf:RDF>
+      </annotation>
+    </species>
+    <species metaid="metaid_0000009" id="dClk" compartment="CELL" initialAmount="1e-16">
+      <annotation>
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+          <rdf:Description rdf:about="#metaid_0000009">
+            <bqbiol:hasPart>
+              <rdf:Bag>
+                <rdf:li rdf:resource="urn:miriam:uniprot:O61735"/>
+                <rdf:li rdf:resource="urn:miriam:uniprot:P07663"/>
+              </rdf:Bag>
+            </bqbiol:hasPart>
+          </rdf:Description>
+        </rdf:RDF>
+      </annotation>
+    </species>
+    <species metaid="metaid_0000010" id="dClkF" name="free dClk" compartment="CELL" initialAmount="0">
+      <annotation>
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+          <rdf:Description rdf:about="#metaid_0000010">
+            <bqbiol:is>
+              <rdf:Bag>
+                <rdf:li rdf:resource="urn:miriam:uniprot:O61735"/>
+              </rdf:Bag>
+            </bqbiol:is>
+          </rdf:Description>
+        </rdf:RDF>
+      </annotation>
+    </species>
+  </listOfSpecies>
+  <listOfReactions>
+    <reaction metaid="metaid_0000011" id="rPer" name="Per production">
+      <annotation>
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+          <rdf:Description rdf:about="#metaid_0000011">
+            <bqbiol:isVersionOf>
+              <rdf:Bag>
+                <rdf:li rdf:resource="urn:miriam:obo.go:GO%3A0043037"/>
+              </rdf:Bag>
+            </bqbiol:isVersionOf>
+          </rdf:Description>
+        </rdf:RDF>
+      </annotation>
+      <listOfReactants>
+        <speciesReference species="EmptySet"/>
+      </listOfReactants>
+      <listOfProducts>
+        <speciesReference species="Per"/>
+      </listOfProducts>
+      <listOfModifiers>
+        <modifierSpeciesReference species="dClkF"/>
+      </listOfModifiers>
+      <kineticLaw>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <apply>
+            <times/>
+            <ci> V </ci>
+            <apply>
+              <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/delay"> delay </csymbol>
+              <apply>
+                <divide/>
+                <ci> dClkF </ci>
+                <apply>
+                  <plus/>
+                  <ci> K </ci>
+                  <ci> dClkF </ci>
+                </apply>
+              </apply>
+              <ci> parameter_0000008 </ci>
+            </apply>
+            <ci> CELL </ci>
+          </apply>
+        </math>
+        <listOfParameters>
+          <parameter id="V" name="Vsp" value="0.5"/>
+          <parameter id="K" name="K1" value="0.3"/>
+          <parameter id="parameter_0000008" name="tau1" value="10"/>
+        </listOfParameters>
+      </kineticLaw>
+    </reaction>
+    <reaction metaid="metaid_0000012" id="rdClk" name="dClk production">
+      <annotation>
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+          <rdf:Description rdf:about="#metaid_0000012">
+            <bqbiol:isVersionOf>
+              <rdf:Bag>
+                <rdf:li rdf:resource="urn:miriam:obo.go:GO%3A0043037"/>
+              </rdf:Bag>
+            </bqbiol:isVersionOf>
+          </rdf:Description>
+        </rdf:RDF>
+      </annotation>
+      <listOfReactants>
+        <speciesReference species="EmptySet"/>
+      </listOfReactants>
+      <listOfProducts>
+        <speciesReference species="dClk"/>
+      </listOfProducts>
+      <listOfModifiers>
+        <modifierSpeciesReference species="dClkF"/>
+      </listOfModifiers>
+      <kineticLaw>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <apply>
+            <times/>
+            <ci> CELL </ci>
+            <ci> V </ci>
+            <apply>
+              <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/delay"> delay </csymbol>
+              <apply>
+                <divide/>
+                <ci> K </ci>
+                <apply>
+                  <plus/>
+                  <ci> K </ci>
+                  <ci> dClkF </ci>
+                </apply>
+              </apply>
+              <ci> parameter_0000009 </ci>
+            </apply>
+          </apply>
+        </math>
+        <listOfParameters>
+          <parameter id="V" name="Vsc" value="0.25"/>
+          <parameter id="K" name="K2" value="0.1"/>
+          <parameter id="parameter_0000009" name="tau2" value="10"/>
+        </listOfParameters>
+      </kineticLaw>
+    </reaction>
+    <reaction metaid="metaid_0000013" id="rPerD" name="Per degradation">
+      <annotation>
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+          <rdf:Description rdf:about="#metaid_0000013">
+            <bqbiol:isVersionOf>
+              <rdf:Bag>
+                <rdf:li rdf:resource="urn:miriam:obo.go:GO%3A0030163"/>
+              </rdf:Bag>
+            </bqbiol:isVersionOf>
+          </rdf:Description>
+        </rdf:RDF>
+      </annotation>
+      <listOfReactants>
+        <speciesReference species="Per"/>
+      </listOfReactants>
+      <listOfProducts>
+        <speciesReference species="EmptySet"/>
+      </listOfProducts>
+      <kineticLaw>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <apply>
+            <times/>
+            <ci> D </ci>
+            <ci> Per </ci>
+            <ci> CELL </ci>
+          </apply>
+        </math>
+        <listOfParameters>
+          <parameter id="D" name="kdc" value="0.5"/>
+        </listOfParameters>
+      </kineticLaw>
+    </reaction>
+    <reaction metaid="metaid_0000014" id="rdClkD" name="dClk degradation">
+      <annotation>
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+          <rdf:Description rdf:about="#metaid_0000014">
+            <bqbiol:isVersionOf>
+              <rdf:Bag>
+                <rdf:li rdf:resource="urn:miriam:obo.go:GO%3A0030163"/>
+              </rdf:Bag>
+            </bqbiol:isVersionOf>
+          </rdf:Description>
+        </rdf:RDF>
+      </annotation>
+      <listOfReactants>
+        <speciesReference species="dClk"/>
+      </listOfReactants>
+      <listOfProducts>
+        <speciesReference species="EmptySet"/>
+      </listOfProducts>
+      <kineticLaw>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <apply>
+            <times/>
+            <ci> D </ci>
+            <ci> dClk </ci>
+            <ci> CELL </ci>
+          </apply>
+        </math>
+        <listOfParameters>
+          <parameter id="D" name="kdp" value="0.5"/>
+        </listOfParameters>
+      </kineticLaw>
+    </reaction>
+  </listOfReactions>
+  <listOfEvents>
+    <event metaid="metaid_0000015">
+      <trigger>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <apply>
+            <lt/>
+            <apply>
+              <minus/>
+              <ci> dClk </ci>
+              <ci> Per </ci>
+            </apply>
+            <cn> 0 </cn>
+          </apply>
+        </math>
+      </trigger>
+      <listOfEventAssignments>
+        <eventAssignment variable="dClkF">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <cn> 0 </cn>
+          </math>
+        </eventAssignment>
+      </listOfEventAssignments>
+    </event>
+    <event metaid="metaid_0000016">
+      <trigger>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <apply>
+            <geq/>
+            <apply>
+              <minus/>
+              <ci> dClk </ci>
+              <ci> Per </ci>
+            </apply>
+            <cn> 0 </cn>
+          </apply>
+        </math>
+      </trigger>
+      <listOfEventAssignments>
+        <eventAssignment variable="dClkF">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <minus/>
+              <ci> dClk </ci>
+              <ci> Per </ci>
+            </apply>
+          </math>
+        </eventAssignment>
+      </listOfEventAssignments>
+    </event>
+  </listOfEvents>
+</model>
+</sbml>


### PR DESCRIPTION
Disallow external entity definitions inside SBML files. This prevents
attackers from loading potentially sensitive files (e.g. /etc/passwd)
into the content of the model.