### PR TITLE
Fixed an incorrect error code in QualModelPluginConstraints.java

### DIFF
--- a/core/.gitignore
+++ b/core/.gitignore
@@ -1,2 +1,3 @@
 /target/
 /.DS_Store
+/.apt_generated_tests/

--- a/extensions/qual/src/org/sbml/jsbml/validator/offline/constraints/QualModelPluginConstraints.java
+++ b/extensions/qual/src/org/sbml/jsbml/validator/offline/constraints/QualModelPluginConstraints.java
@@ -53,7 +53,7 @@ public class QualModelPluginConstraints extends AbstractConstraintDeclaration {
 		switch (category) {
 		case GENERAL_CONSISTENCY:
 		  if (level >= 3) {
-		    addRangeToSet(set, QUAL_10101, QUAL_20102);
+		    addRangeToSet(set, QUAL_10101, QUAL_10102);
 		    set.add(QUAL_10301);
 		    addRangeToSet(set, QUAL_20201, QUAL_20206);
 		  }		  


### PR DESCRIPTION
QUAL_20102 was not a related rule and was changed to QUAL_20101.
Avoids addition of unnecessary error codes. 