### PR TITLE
added implementation for MULTI_20201

### DIFF
--- a/extensions/multi/src/org/sbml/jsbml/validator/offline/constraints/MultiModelPluginConstraints.java
+++ b/extensions/multi/src/org/sbml/jsbml/validator/offline/constraints/MultiModelPluginConstraints.java
@@ -21,7 +21,6 @@ package org.sbml.jsbml.validator.offline.constraints;
 import java.util.Set;
 
 import org.sbml.jsbml.ListOf;
-import org.sbml.jsbml.SBMLDocument;
 import org.sbml.jsbml.ext.multi.MultiCompartmentPlugin;
 import org.sbml.jsbml.ext.multi.MultiConstants;
 import org.sbml.jsbml.ext.multi.MultiModelPlugin;
@@ -29,7 +28,6 @@ import org.sbml.jsbml.ext.multi.MultiSpeciesType;
 import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
 import org.sbml.jsbml.validator.offline.ValidationContext;
 import org.sbml.jsbml.validator.offline.constraints.helper.DuplicatedElementValidationFunction;
-import org.sbml.jsbml.validator.offline.constraints.helper.UnknownAttributeValidationFunction;
 import org.sbml.jsbml.validator.offline.constraints.helper.UnknownElementValidationFunction;
 
 /**
@@ -90,16 +88,9 @@ public class MultiModelPluginConstraints extends AbstractConstraintDeclaration{
 
     case MULTI_20201:
     {
-      func = new UnknownAttributeValidationFunction<MultiModelPlugin>() {
-        @Override
-        public boolean check(ValidationContext ctx, MultiModelPlugin multiM) {
-        	
-          // There may be at most one ListOfSpeciesTypes container object within a Model object
-          ValidationFunction<SBMLDocument> f = new DuplicatedElementValidationFunction<SBMLDocument>(MultiConstants.listOfSpeciesTypes);
-             
-          return f.check(ctx, multiM.getParent());
-        }
-      };
+      // There may be at most one ListOfSpeciesTypes container object within a Model object
+      func = new DuplicatedElementValidationFunction<MultiModelPlugin>(MultiConstants.listOfSpeciesTypes);
+     
       break;
     }
     case MULTI_20202:

--- a/extensions/multi/src/org/sbml/jsbml/validator/offline/constraints/MultiModelPluginConstraints.java
+++ b/extensions/multi/src/org/sbml/jsbml/validator/offline/constraints/MultiModelPluginConstraints.java
@@ -21,11 +21,14 @@ package org.sbml.jsbml.validator.offline.constraints;
 import java.util.Set;
 
 import org.sbml.jsbml.ListOf;
+import org.sbml.jsbml.SBMLDocument;
 import org.sbml.jsbml.ext.multi.MultiCompartmentPlugin;
+import org.sbml.jsbml.ext.multi.MultiConstants;
 import org.sbml.jsbml.ext.multi.MultiModelPlugin;
 import org.sbml.jsbml.ext.multi.MultiSpeciesType;
 import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
 import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.DuplicatedElementValidationFunction;
 import org.sbml.jsbml.validator.offline.constraints.helper.UnknownAttributeValidationFunction;
 import org.sbml.jsbml.validator.offline.constraints.helper.UnknownElementValidationFunction;
 
@@ -90,10 +93,11 @@ public class MultiModelPluginConstraints extends AbstractConstraintDeclaration{
       func = new UnknownAttributeValidationFunction<MultiModelPlugin>() {
         @Override
         public boolean check(ValidationContext ctx, MultiModelPlugin multiM) {
-
-          // TODO
+        	
           // There may be at most one ListOfSpeciesTypes container object within a Model object
-          return true;
+          ValidationFunction<SBMLDocument> f = new DuplicatedElementValidationFunction<SBMLDocument>(MultiConstants.listOfSpeciesTypes);
+             
+          return f.check(ctx, multiM.getParent());
         }
       };
       break;

--- a/extensions/multi/src/org/sbml/jsbml/xml/parsers/MultiParser.java
+++ b/extensions/multi/src/org/sbml/jsbml/xml/parsers/MultiParser.java
@@ -177,7 +177,9 @@ public class MultiParser extends AbstractReaderWriter implements PackageParser {
     {
       Model model = (Model) contextObject;
       MultiModelPlugin multiModel = (MultiModelPlugin) model.getPlugin(shortLabel);
-
+      
+      AbstractReaderWriter.storeElementsOrder(elementName, multiModel);
+      
       if (elementName.equals(listOfSpeciesTypes))
       {
         return multiModel.getListOfSpeciesTypes();


### PR DESCRIPTION
Implementing logic for rule MULTI_20201 in ```MultiModelPluginConstraints```.
Reference taken from a similar implementation in ```MultiCompartmentPluginConstraints``` (Rule MULTI_20306) 