### PR TITLE
Finalized rules spatial-207XX, spatial-209XX, spatial-210XX, spatial-212XX

### DIFF
--- a/core/src/org/sbml/jsbml/util/StringTools.java
+++ b/core/src/org/sbml/jsbml/util/StringTools.java
@@ -436,6 +436,38 @@ public class StringTools {
   }
 
   /**
+   * Parses a String into a double number following the rules of the SBML
+   * specifications, section 3.1.5.
+   * 
+   * @param valueAsStr
+   *            a double as a String
+   * @return the String as a double. If the String is not a valid double number,
+   *         an exception is returned.
+   * @throws IllegalArgumentException if the String cannot be converted into a double.
+   */
+  public static double parseSBMLDoubleStrict(String valueAsStr) {
+
+    double value = Double.NaN;
+    String toTest = valueAsStr.trim();
+
+    try {
+      value = Double.parseDouble(toTest);
+    } catch (NumberFormatException e) {
+      if (toTest.equalsIgnoreCase("INF")) {
+        value = Double.POSITIVE_INFINITY;
+      } else if (toTest.equalsIgnoreCase("-INF")) {
+        value = Double.NEGATIVE_INFINITY;
+      } else {
+    	  Logger logger = Logger.getLogger(StringTools.class);
+          logger.warn("Could not create a double from the string '" + valueAsStr + "'");
+    	  throw new IllegalArgumentException("Could not create a double from the string " + valueAsStr);
+      }
+    }
+
+    return value;
+  }  
+  
+  /**
    * Parses a {@link String} into an int number following the rules of the SBML
    * specifications, section 3.1.3.
    * 

--- a/extensions/spatial/src/org/sbml/jsbml/ext/spatial/Boundary.java
+++ b/extensions/spatial/src/org/sbml/jsbml/ext/spatial/Boundary.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.apache.log4j.Logger;
 import org.sbml.jsbml.PropertyUndefinedError;
 import org.sbml.jsbml.util.StringTools;
+import org.sbml.jsbml.xml.parsers.AbstractReaderWriter;
 
 /**
  * @author Alex Thomas
@@ -233,13 +234,14 @@ public class Boundary extends AbstractSpatialNamedSBase {
    */
   @Override
   public boolean readAttribute(String attributeName, String prefix, String value) {
-    boolean isAttributeRead = super.readAttribute(attributeName, prefix, value) && (SpatialConstants.shortLabel == prefix);
+    boolean isAttributeRead = super.readAttribute(attributeName, prefix, value);
     if (!isAttributeRead) {
       isAttributeRead = true;
       if (attributeName.equals(SpatialConstants.value)) {
         try{
-          setValue(StringTools.parseSBMLDouble(value));
+          setValue(StringTools.parseSBMLDoubleStrict(value));
         } catch (Exception e) {
+          AbstractReaderWriter.processInvalidAttribute(attributeName, null, value, prefix, this);
           logger.warn(MessageFormat.format(
             SpatialConstants.bundle.getString("COULD_NOT_READ_ATTRIBUTE"), value, SpatialConstants.value, getElementName()));
         }

--- a/extensions/spatial/src/org/sbml/jsbml/ext/spatial/DomainType.java
+++ b/extensions/spatial/src/org/sbml/jsbml/ext/spatial/DomainType.java
@@ -26,6 +26,7 @@ import org.apache.log4j.Logger;
 import org.sbml.jsbml.PropertyUndefinedError;
 import org.sbml.jsbml.SBMLException;
 import org.sbml.jsbml.util.StringTools;
+import org.sbml.jsbml.xml.parsers.AbstractReaderWriter;
 
 
 /**
@@ -206,6 +207,7 @@ public class DomainType extends AbstractSpatialNamedSBase {
         try {
           setSpatialDimensions(StringTools.parseSBMLInt(value));
         } catch (Exception e) {
+          AbstractReaderWriter.processInvalidAttribute(attributeName, null, value, prefix, this);
           logger.warn(MessageFormat.format(
             SpatialConstants.bundle.getString("COULD_NOT_READ_ATTRIBUTE"), value, SpatialConstants.spatialDimensions, getElementName()));
           isAttributeRead = false;

--- a/extensions/spatial/src/org/sbml/jsbml/ext/spatial/GeometryDefinition.java
+++ b/extensions/spatial/src/org/sbml/jsbml/ext/spatial/GeometryDefinition.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.apache.log4j.Logger;
 import org.sbml.jsbml.PropertyUndefinedError;
 import org.sbml.jsbml.util.StringTools;
+import org.sbml.jsbml.xml.parsers.AbstractReaderWriter;
 
 /**
  * @author Alex Thomas
@@ -188,14 +189,15 @@ public abstract class GeometryDefinition extends AbstractSpatialNamedSBase {
    */
   @Override
   public boolean readAttribute(String attributeName, String prefix, String value) {
-    boolean isAttributeRead = (super.readAttribute(attributeName, prefix, value))
-        && (SpatialConstants.shortLabel == prefix);
+    boolean isAttributeRead = (super.readAttribute(attributeName, prefix, value));
+        // && (SpatialConstants.shortLabel == prefix);
     if (!isAttributeRead) {
       isAttributeRead = true;
       if (attributeName.equals(SpatialConstants.isActive)) {
         try {
-          setIsActive(StringTools.parseSBMLBoolean(value));
+          setIsActive(StringTools.parseSBMLBooleanStrict(value));
         } catch (Exception e) {
+          AbstractReaderWriter.processInvalidAttribute(attributeName, null, value, prefix, this);
           logger.warn(MessageFormat.format(
             SpatialConstants.bundle.getString("COULD_NOT_READ_ATTRIBUTE"), value, SpatialConstants.isActive, getElementName()));
         }

--- a/extensions/spatial/src/org/sbml/jsbml/ext/spatial/GeometryDefinition.java
+++ b/extensions/spatial/src/org/sbml/jsbml/ext/spatial/GeometryDefinition.java
@@ -190,7 +190,6 @@ public abstract class GeometryDefinition extends AbstractSpatialNamedSBase {
   @Override
   public boolean readAttribute(String attributeName, String prefix, String value) {
     boolean isAttributeRead = (super.readAttribute(attributeName, prefix, value));
-        // && (SpatialConstants.shortLabel == prefix);
     if (!isAttributeRead) {
       isAttributeRead = true;
       if (attributeName.equals(SpatialConstants.isActive)) {

--- a/extensions/spatial/src/org/sbml/jsbml/ext/spatial/InteriorPoint.java
+++ b/extensions/spatial/src/org/sbml/jsbml/ext/spatial/InteriorPoint.java
@@ -28,6 +28,7 @@ import org.apache.log4j.Logger;
 import org.sbml.jsbml.AbstractSBase;
 import org.sbml.jsbml.PropertyUndefinedError;
 import org.sbml.jsbml.util.StringTools;
+import org.sbml.jsbml.xml.parsers.AbstractReaderWriter;
 
 /**
  * @author Alex Thomas
@@ -358,30 +359,32 @@ public class InteriorPoint extends AbstractSBase {
    */
   @Override
   public boolean readAttribute(String attributeName, String prefix, String value) {
-    boolean isAttributeRead = (super.readAttribute(attributeName, prefix, value))
-        && (SpatialConstants.shortLabel == prefix);
+    boolean isAttributeRead = (super.readAttribute(attributeName, prefix, value));
     if (!isAttributeRead) {
       isAttributeRead = true;
       if (attributeName.equals(SpatialConstants.coord1)) {
         try {
-          setCoord1(StringTools.parseSBMLDouble(value));
+          setCoord1(StringTools.parseSBMLDoubleStrict(value));
         } catch (Exception e) {
+          AbstractReaderWriter.processInvalidAttribute(attributeName, null, value, prefix, this);
           logger.warn(MessageFormat.format(
             SpatialConstants.bundle.getString("COULD_NOT_READ_ATTRIBUTE"), value, SpatialConstants.coord1, getElementName()));
         }
       }
       else if (attributeName.equals(SpatialConstants.coord2)) {
         try {
-          setCoord2(StringTools.parseSBMLDouble(value));
+          setCoord2(StringTools.parseSBMLDoubleStrict(value));
         } catch (Exception e) {
+          AbstractReaderWriter.processInvalidAttribute(attributeName, null, value, prefix, this);
           logger.warn(MessageFormat.format(
             SpatialConstants.bundle.getString("COULD_NOT_READ_ATTRIBUTE"), value, SpatialConstants.coord2, getElementName()));
         }
       }
       else if (attributeName.equals(SpatialConstants.coord3)) {
         try {
-          setCoord3(StringTools.parseSBMLDouble(value));
+          setCoord3(StringTools.parseSBMLDoubleStrict(value));
         } catch (Exception e) {
+          AbstractReaderWriter.processInvalidAttribute(attributeName, null, value, prefix, this);
           logger.warn(MessageFormat.format(
             SpatialConstants.bundle.getString("COULD_NOT_READ_ATTRIBUTE"), value, SpatialConstants.coord3, getElementName()));
         }

--- a/extensions/spatial/src/org/sbml/jsbml/ext/spatial/SpatialReactionPlugin.java
+++ b/extensions/spatial/src/org/sbml/jsbml/ext/spatial/SpatialReactionPlugin.java
@@ -28,7 +28,6 @@ import org.apache.log4j.Logger;
 import org.sbml.jsbml.PropertyUndefinedError;
 import org.sbml.jsbml.Reaction;
 import org.sbml.jsbml.util.StringTools;
-import org.sbml.jsbml.xml.parsers.AbstractReaderWriter;
 
 /**
  * @author Alex Thomas
@@ -241,9 +240,8 @@ public class SpatialReactionPlugin extends AbstractSpatialSBasePlugin {
       isAttributeRead = true;
       if (attributeName.equals(SpatialConstants.isLocal)) {
         try {
-          setIsLocal(StringTools.parseSBMLBooleanStrict(value));
+          setIsLocal(StringTools.parseSBMLBoolean(value));
         } catch (Exception e) {
-          AbstractReaderWriter.processInvalidAttribute(attributeName, null, value, prefix, this);
           logger.warn(MessageFormat.format(
             SpatialConstants.bundle.getString("COULD_NOT_READ_ATTRIBUTE"), value, SpatialConstants.isLocal, getClass().getSimpleName()));
         }

--- a/extensions/spatial/src/org/sbml/jsbml/ext/spatial/SpatialReactionPlugin.java
+++ b/extensions/spatial/src/org/sbml/jsbml/ext/spatial/SpatialReactionPlugin.java
@@ -28,6 +28,7 @@ import org.apache.log4j.Logger;
 import org.sbml.jsbml.PropertyUndefinedError;
 import org.sbml.jsbml.Reaction;
 import org.sbml.jsbml.util.StringTools;
+import org.sbml.jsbml.xml.parsers.AbstractReaderWriter;
 
 /**
  * @author Alex Thomas
@@ -240,8 +241,9 @@ public class SpatialReactionPlugin extends AbstractSpatialSBasePlugin {
       isAttributeRead = true;
       if (attributeName.equals(SpatialConstants.isLocal)) {
         try {
-          setIsLocal(StringTools.parseSBMLBoolean(value));
+          setIsLocal(StringTools.parseSBMLBooleanStrict(value));
         } catch (Exception e) {
+          AbstractReaderWriter.processInvalidAttribute(attributeName, null, value, prefix, this);
           logger.warn(MessageFormat.format(
             SpatialConstants.bundle.getString("COULD_NOT_READ_ATTRIBUTE"), value, SpatialConstants.isLocal, getClass().getSimpleName()));
         }

--- a/extensions/spatial/src/org/sbml/jsbml/validator/offline/constraints/BoundaryConstraints.java
+++ b/extensions/spatial/src/org/sbml/jsbml/validator/offline/constraints/BoundaryConstraints.java
@@ -1,0 +1,138 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ * 
+ * Copyright (C) 2009-2018 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The University of California, San Diego, La Jolla, CA, USA
+ * 5. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.ext.spatial.Boundary;
+import org.sbml.jsbml.ext.spatial.SpatialConstants;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.InvalidAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the {@link Boundary} class.
+ * 
+ * @author Bhavye Jain
+ * @since 1.5
+ */
+public class BoundaryConstraints extends AbstractConstraintDeclaration {
+	
+	  /* (non-Javadoc)
+	   * @see org.sbml.jsbml.validator.offline.constraints.ConstraintDeclaration#addErrorCodesForAttribute(java.util.Set, int, int, java.lang.String)
+	   */
+	  @Override
+	  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+	    int version, String attributeName, ValidationContext context) 
+	  {
+	    // TODO 
+
+	  }
+	  
+	  /* (non-Javadoc)
+	   * @see org.sbml.jsbml.validator.offline.constraints.ConstraintDeclaration#addErrorCodesForCheck(java.util.Set, int, int, org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY)
+	   */
+	  @Override
+	  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+	    CHECK_CATEGORY category, ValidationContext context) {
+		  switch (category) {
+		    case GENERAL_CONSISTENCY:
+		    	if(level >= 3){		    		
+		    		addRangeToSet(set, SPATIAL_21001, SPATIAL_21004);
+		    	}
+		      break;
+		    case IDENTIFIER_CONSISTENCY:
+		      break;
+		    case MATHML_CONSISTENCY:
+		      break;
+		    case MODELING_PRACTICE:
+		      break;
+		    case OVERDETERMINED_MODEL:
+		      break;
+		    case SBO_CONSISTENCY:
+		      break;
+		    case UNITS_CONSISTENCY:
+		      break;
+		    }
+	  }
+	  
+	  @Override
+	  public ValidationFunction<?> getValidationFunction(int errorCode, ValidationContext context){
+		  ValidationFunction<Boundary> func = null;
+		  
+		  switch (errorCode) {
+		  	case SPATIAL_21001:
+		  	{
+		  		// A Boundary object may have the optional SBML Level 3 Core attributes metaid and sboTerm. 
+		  		// No other attributes from the SBML Level 3 Core namespaces are permitted on a Boundary.
+		  		
+		  		func = new UnknownCoreAttributeValidationFunction<Boundary>();
+		  		break;
+		  	}
+		  	
+		  	case SPATIAL_21002:
+		  	{
+		  		// A Boundary object may have the optional SBML Level 3 Core subobjects for notes and annotations.
+		  		// No other elements from the SBML Level 3 Core namespaces are permitted on a Boundary
+		  		
+		  		func = new UnknownCoreElementValidationFunction<Boundary>();
+		  		break;
+		  	}
+		  	
+		  	case SPATIAL_21003:
+		  	{
+		  		// A Boundary object must have the required attributes spatial:id and spatial:value. No 
+		  		// other attributes from the SBML Level 3 Spatial Processes namespaces are permitted on a 
+		  		// Boundary object.
+		  		
+		  		func = new UnknownPackageAttributeValidationFunction<Boundary>(SpatialConstants.shortLabel) {
+		  			
+		  			@Override
+		  			public boolean check(ValidationContext ctx, Boundary bound) {
+		  				
+		  				if(!bound.isSetId()) {
+		  					return false;
+		  				}
+		  				if(!bound.isSetValue()) {
+		  					return false;
+		  				}
+		  				return super.check(ctx, bound);
+		  			}
+		  		};
+		  		break;
+		  	}
+		  	
+		  	case SPATIAL_21004:
+		  	{
+		  		// The attribute spatial:value on a Boundary must have a value of data type double.
+		  		
+		  		func = new InvalidAttributeValidationFunction<Boundary>(SpatialConstants.value);
+		  		break;
+		  	}
+		  }
+		  
+		  return func;
+	  }
+	
+}

--- a/extensions/spatial/src/org/sbml/jsbml/validator/offline/constraints/DomainTypeConstraints.java
+++ b/extensions/spatial/src/org/sbml/jsbml/validator/offline/constraints/DomainTypeConstraints.java
@@ -1,0 +1,139 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ * 
+ * Copyright (C) 2009-2018 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The University of California, San Diego, La Jolla, CA, USA
+ * 5. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.ext.spatial.DomainType;
+import org.sbml.jsbml.ext.spatial.SpatialConstants;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.InvalidAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the {@link DomainType} class.
+ * 
+ * @author Bhavye Jain
+ * @since 1.5
+ */
+public class DomainTypeConstraints extends AbstractConstraintDeclaration {
+	
+	  /* (non-Javadoc)
+	   * @see org.sbml.jsbml.validator.offline.constraints.ConstraintDeclaration#addErrorCodesForAttribute(java.util.Set, int, int, java.lang.String)
+	   */
+	  @Override
+	  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+	    int version, String attributeName, ValidationContext context) 
+	  {
+	    // TODO 
+
+	  }
+	  
+	  /* (non-Javadoc)
+	   * @see org.sbml.jsbml.validator.offline.constraints.ConstraintDeclaration#addErrorCodesForCheck(java.util.Set, int, int, org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY)
+	   */
+	  @Override
+	  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+	    CHECK_CATEGORY category, ValidationContext context) {
+		  switch (category) {
+		    case GENERAL_CONSISTENCY:
+		    	if(level >= 3){		    		
+		    		addRangeToSet(set, SPATIAL_20701, SPATIAL_20704);
+		    	}
+		      break;
+		    case IDENTIFIER_CONSISTENCY:
+		      break;
+		    case MATHML_CONSISTENCY:
+		      break;
+		    case MODELING_PRACTICE:
+		      break;
+		    case OVERDETERMINED_MODEL:
+		      break;
+		    case SBO_CONSISTENCY:
+		      break;
+		    case UNITS_CONSISTENCY:
+		      break;
+		    }
+	  }
+	  
+	  @Override
+	  public ValidationFunction<?> getValidationFunction(int errorCode, ValidationContext context){
+		  ValidationFunction<DomainType> func = null;
+		  
+		  switch (errorCode) {
+		  	case SPATIAL_20701:
+		  	{
+		  		// A DomainType object may have the optional SBML Level 3 Core attributes metaid and sboTerm. 
+		  		// No other attributes from the SBML Level 3 Core namespaces are permitted on a DomainType.
+		  		
+		  		func = new UnknownCoreAttributeValidationFunction<DomainType>();
+		  		break;
+		  	}
+		  	
+		  	case SPATIAL_20702:
+		  	{
+		  		// A DomainType object may have the optional SBML Level 3 Core subobjects for notes and annotations.
+		  		// No other elements from the SBML Level 3 Core namespaces are permitted on a DomainType.
+		  		
+		  		func = new UnknownCoreElementValidationFunction<DomainType>();
+		  		break;
+		  	}
+		  	
+		  	case SPATIAL_20703:
+		  	{
+		  		// A DomainType object must have the required attributes spatial:id and spatial:spatialDimensions.
+		  		// No other attributes from the SBML Level 3 Spatial Processes namespaces are permitted on 
+		  		// a DomainType object.
+		  		
+		  		func = new UnknownPackageAttributeValidationFunction<DomainType>(SpatialConstants.shortLabel) {
+		  			
+		  			@Override
+		  			public boolean check(ValidationContext ctx, DomainType dt) {
+		  				
+		  				if(!dt.isSetId()) {
+		  					return false;
+		  				}
+		  				if(!dt.isSetSpatialDimensions()) {
+		  					return false;
+		  				}
+		  				return super.check(ctx, dt);
+		  			}
+		  		};
+		  		
+		  		break;
+		  	}
+		  	
+		  	case SPATIAL_20704:
+		  	{
+		  		// The attribute spatial:spatialDimensions on a DomainType must have a value of data type integer.
+		  		
+		  		func = new InvalidAttributeValidationFunction<DomainType>(SpatialConstants.spatialDimensions);
+		  		break;
+		  	}
+		  }		  
+		  
+		  return func;
+	  }
+	
+}

--- a/extensions/spatial/src/org/sbml/jsbml/validator/offline/constraints/GeometryDefinitionConstraints.java
+++ b/extensions/spatial/src/org/sbml/jsbml/validator/offline/constraints/GeometryDefinitionConstraints.java
@@ -1,0 +1,140 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ * 
+ * Copyright (C) 2009-2018 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The University of California, San Diego, La Jolla, CA, USA
+ * 5. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.ext.spatial.GeometryDefinition;
+import org.sbml.jsbml.ext.spatial.SpatialConstants;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.InvalidAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the {@link GeometryDefinition} class.
+ * 
+ * @author Bhavye Jain
+ * @since 1.5
+ */
+public class GeometryDefinitionConstraints extends AbstractConstraintDeclaration {
+	
+	  /* (non-Javadoc)
+	   * @see org.sbml.jsbml.validator.offline.constraints.ConstraintDeclaration#addErrorCodesForAttribute(java.util.Set, int, int, java.lang.String)
+	   */
+	  @Override
+	  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+	    int version, String attributeName, ValidationContext context) 
+	  {
+	    // TODO 
+
+	  }
+	  
+	  /* (non-Javadoc)
+	   * @see org.sbml.jsbml.validator.offline.constraints.ConstraintDeclaration#addErrorCodesForCheck(java.util.Set, int, int, org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY)
+	   */
+	  @Override
+	  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+	    CHECK_CATEGORY category, ValidationContext context) {
+		  switch (category) {
+		    case GENERAL_CONSISTENCY:
+		    	if(level >= 3){		    		
+		    		addRangeToSet(set, SPATIAL_21201, SPATIAL_21204);
+		    	}
+		      break;
+		    case IDENTIFIER_CONSISTENCY:
+		      break;
+		    case MATHML_CONSISTENCY:
+		      break;
+		    case MODELING_PRACTICE:
+		      break;
+		    case OVERDETERMINED_MODEL:
+		      break;
+		    case SBO_CONSISTENCY:
+		      break;
+		    case UNITS_CONSISTENCY:
+		      break;
+		    }
+	  }
+	  
+	  @Override
+	  public ValidationFunction<?> getValidationFunction(int errorCode, ValidationContext context){
+		  ValidationFunction<GeometryDefinition> func = null;
+		  
+		  switch (errorCode) {
+		  	
+		    case SPATIAL_21201:
+		  	{
+		  		// A GeometryDefinition object may have the optional SBML Level 3 Core attributes metaid and 
+		  		// sboTerm. No other attributes from the SBML Level 3 Core namespaces are permitted on a GeometryDefinition.
+		  		
+		  		func = new UnknownCoreAttributeValidationFunction<GeometryDefinition>();
+		  		break;
+		  	}
+		  	
+		  	case SPATIAL_21202:
+		  	{
+		  		// A GeometryDefinition object may have the optional SBML Level 3 Core subobjects for notes 
+		  		// and annotations. No other elements from the SBML Level 3 Core namespaces are permitted 
+		  		// on a GeometryDefinition. 
+		  		
+		  		func = new UnknownCoreElementValidationFunction<GeometryDefinition>();
+		  		break;
+		  	}
+		  	
+		  	case SPATIAL_21203:
+		  	{
+		  		// A GeometryDefinition object must have the required attributes spatial:id and spatial:
+		  		// isActive. No other attributes from the SBML Level 3 Spatial Processes namespaces are 
+		  		// permitted on a GeometryDefinition object.
+		  		
+		  		func = new UnknownPackageAttributeValidationFunction<GeometryDefinition>(SpatialConstants.shortLabel) {
+		  			
+		  			@Override
+		  			public boolean check(ValidationContext ctx, GeometryDefinition gdef) {
+		  				
+		  				if(!gdef.isSetId()) {
+		  					return false;
+		  				}
+		  				if(!gdef.isSetIsActive()) {
+		  					return false;
+		  				}
+		  				return super.check(ctx, gdef);
+		  			}
+		  		};
+		  		break;
+		  	}
+		  	
+		  	case SPATIAL_21204:
+		  	{
+		  		// The attribute spatial:isActive on a GeometryDefinition must have a value of data type boolean.
+		  		
+		  		func = new InvalidAttributeValidationFunction<GeometryDefinition>(SpatialConstants.isActive);
+		  		break;
+		  	}
+		  }
+		  
+		  return func;
+	  }
+	
+}

--- a/extensions/spatial/src/org/sbml/jsbml/validator/offline/constraints/InteriorPointConstraints.java
+++ b/extensions/spatial/src/org/sbml/jsbml/validator/offline/constraints/InteriorPointConstraints.java
@@ -1,0 +1,151 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ * 
+ * Copyright (C) 2009-2018 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The University of California, San Diego, La Jolla, CA, USA
+ * 5. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.ext.spatial.InteriorPoint;
+import org.sbml.jsbml.ext.spatial.SpatialConstants;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.InvalidAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the {@link InteriorPoint} class.
+ * 
+ * @author Bhavye Jain
+ * @since 1.5
+ */
+public class InteriorPointConstraints extends AbstractConstraintDeclaration {
+	
+	  /* (non-Javadoc)
+	   * @see org.sbml.jsbml.validator.offline.constraints.ConstraintDeclaration#addErrorCodesForAttribute(java.util.Set, int, int, java.lang.String)
+	   */
+	  @Override
+	  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+	    int version, String attributeName, ValidationContext context) 
+	  {
+	    // TODO 
+
+	  }
+	  
+	  /* (non-Javadoc)
+	   * @see org.sbml.jsbml.validator.offline.constraints.ConstraintDeclaration#addErrorCodesForCheck(java.util.Set, int, int, org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY)
+	   */
+	  @Override
+	  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+	    CHECK_CATEGORY category, ValidationContext context) {
+		  switch (category) {
+		    case GENERAL_CONSISTENCY:
+		    	if(level >= 3){		    		
+		    		addRangeToSet(set, SPATIAL_20901, SPATIAL_20906);
+		    	}
+		      break;
+		    case IDENTIFIER_CONSISTENCY:
+		      break;
+		    case MATHML_CONSISTENCY:
+		      break;
+		    case MODELING_PRACTICE:
+		      break;
+		    case OVERDETERMINED_MODEL:
+		      break;
+		    case SBO_CONSISTENCY:
+		      break;
+		    case UNITS_CONSISTENCY:
+		      break;
+		    }
+	  }
+	  
+	  @Override
+	  public ValidationFunction<?> getValidationFunction(int errorCode, ValidationContext context){
+		  ValidationFunction<InteriorPoint> func = null;
+		  
+		  switch (errorCode) {
+		  	case SPATIAL_20901:
+		  	{
+		  		// An InteriorPoint object may have the optional SBML Level 3 Core attributes metaid and sboTerm.
+		  		// No other attributes from the SBML Level 3 Core namespaces are permitted on an InteriorPoint.
+		  		
+		  		func = new UnknownCoreAttributeValidationFunction<InteriorPoint>();
+		  		break;
+		  	}
+		  	
+		  	case SPATIAL_20902:
+		  	{
+		  		// An InteriorPoint object may have the optional SBML Level 3 Core subobjects for notes and annotations.
+		  		// No other elements from the SBML Level 3 Core namespaces are permitted on an InteriorPoint.
+		  		
+		  		func = new UnknownCoreElementValidationFunction<InteriorPoint>();
+		  		break;
+		  	}
+		  	
+		  	case SPATIAL_20903:
+		  	{
+		  		// An InteriorPoint object must have the required attribute spatial:coordOne, and may have 
+		  		// the optional attributes spatial:coordTwo and spatial:coordThree. No other attributes 
+		  		// from the SBML Level 3 Spatial Processes namespaces are permitted on an InteriorPoint object.
+		  		
+		  		func = new UnknownPackageAttributeValidationFunction<InteriorPoint>(SpatialConstants.shortLabel){
+		  			
+		  			@Override
+		  			public boolean check(ValidationContext ctx, InteriorPoint ip) {
+		  				
+		  				if(!ip.isSetCoord1()) {
+		  					return false;
+		  				}
+		  				return super.check(ctx, ip);
+		  			}
+		  		};
+		  		break;
+		  	}
+		  	
+		  	case SPATIAL_20904:
+		  	{
+		  		// The attribute spatial:coordOne on an InteriorPoint must have a value of data type double.
+		  		
+		  		func = new InvalidAttributeValidationFunction<InteriorPoint>(SpatialConstants.coord1);
+		  		break;
+		  	}
+		  	
+		  	case SPATIAL_20905:
+		  	{
+		  		// The attribute spatial:coordTwo on an InteriorPoint must have a value of data type double.
+		  		
+		  		func = new InvalidAttributeValidationFunction<InteriorPoint>(SpatialConstants.coord2);
+		  		break;
+		  	}
+		  	
+		  	case SPATIAL_20906:
+		  	{
+		  		// The attribute spatial:coordThree on an InteriorPoint must have a value of data type double.
+		  		
+		  		func = new InvalidAttributeValidationFunction<InteriorPoint>(SpatialConstants.coord3);
+		  		break;
+		  	}
+		  }
+		  
+		  return func;
+	  }
+	
+}


### PR DESCRIPTION
A function has been added to StringTools.java to incorporate a strict double parser.

Constraints for the following classes have been successfully implemented and tested:
Boundary
InteriorPoint
DomainType
GeometryDefinition