### PR TITLE
Implement constraints 233XX, 234XX, 235XX and 236XX.

### DIFF
--- a/extensions/spatial/src/org/sbml/jsbml/ext/spatial/AdvectionCoefficient.java
+++ b/extensions/spatial/src/org/sbml/jsbml/ext/spatial/AdvectionCoefficient.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import org.apache.log4j.Logger;
 import org.sbml.jsbml.PropertyUndefinedError;
+import org.sbml.jsbml.xml.parsers.AbstractReaderWriter;
 
 
 /**
@@ -173,14 +174,14 @@ public class AdvectionCoefficient extends ParameterType {
 
   @Override
   public boolean readAttribute(String attributeName, String prefix, String value) {
-    boolean isAttributeRead = (super.readAttribute(attributeName, prefix, value))
-        && (SpatialConstants.shortLabel == prefix);
+    boolean isAttributeRead = super.readAttribute(attributeName, prefix, value);
     if (!isAttributeRead) {
       isAttributeRead = true;
       if (attributeName.equals(SpatialConstants.coordinate)) {
         try {
           setCoordinate(CoordinateKind.valueOf(value));
         } catch (Exception e) {
+          AbstractReaderWriter.processInvalidAttribute(attributeName, null, value, prefix, this);
           logger.warn(MessageFormat.format(
             SpatialConstants.bundle.getString("COULD_NOT_READ_ATTRIBUTE"), value, SpatialConstants.coordinate, getElementName()));
         }

--- a/extensions/spatial/src/org/sbml/jsbml/ext/spatial/BoundaryCondition.java
+++ b/extensions/spatial/src/org/sbml/jsbml/ext/spatial/BoundaryCondition.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import org.apache.log4j.Logger;
 import org.sbml.jsbml.PropertyUndefinedError;
+import org.sbml.jsbml.xml.parsers.AbstractReaderWriter;
 
 /**
  * @author Alex Thomas
@@ -323,14 +324,15 @@ public class BoundaryCondition extends ParameterType {
 
   @Override
   public boolean readAttribute(String attributeName, String prefix, String value) {
-    boolean isAttributeRead = (super.readAttribute(attributeName, prefix, value))
-        && (SpatialConstants.shortLabel == prefix);
+    boolean isAttributeRead = super.readAttribute(attributeName, prefix, value);
+    
     if (!isAttributeRead) {
       isAttributeRead = true;
       if (attributeName.equals(SpatialConstants.type)) {
         try {
           setType(value);
         } catch (Exception e) {
+          AbstractReaderWriter.processInvalidAttribute(attributeName, null, value, prefix, this);
           logger.warn(MessageFormat.format(
             SpatialConstants.bundle.getString("COULD_NOT_READ_ATTRIBUTE"), value, SpatialConstants.type, getElementName()));
         }

--- a/extensions/spatial/src/org/sbml/jsbml/ext/spatial/DiffusionCoefficient.java
+++ b/extensions/spatial/src/org/sbml/jsbml/ext/spatial/DiffusionCoefficient.java
@@ -74,8 +74,8 @@ public class DiffusionCoefficient extends ParameterType {
   public DiffusionCoefficient(DiffusionCoefficient diffCoeff) {
     super(diffCoeff);
 
-    if (diffCoeff.isSetDiffusionKind()) {
-      setDiffusionKind(diffCoeff.getDiffusionKind());
+    if (diffCoeff.isSetType()) {
+      setType(diffCoeff.getType());
     }
 
     if (diffCoeff.isSetCoordinateReference1()) {
@@ -120,9 +120,9 @@ public class DiffusionCoefficient extends ParameterType {
     if (equal) {
       DiffusionCoefficient diffCoeff = (DiffusionCoefficient) object;
 
-      equal &= diffCoeff.isSetDiffusionKind() == isSetDiffusionKind();
-      if (equal && isSetDiffusionKind()) {
-        equal &= diffCoeff.getDiffusionKind() == getDiffusionKind();
+      equal &= diffCoeff.isSetType() == isSetType();
+      if (equal && isSetType()) {
+        equal &= diffCoeff.getType() == getType();
       }
 
       equal &= diffCoeff.isSetCoordinateReference1() == isSetCoordinateReference1();
@@ -248,8 +248,8 @@ public class DiffusionCoefficient extends ParameterType {
    *
    * @return the value of diffusionKind
    */
-  public DiffusionKind getDiffusionKind() {
-    if (isSetDiffusionKind()) {
+  public DiffusionKind getType() {
+    if (isSetType()) {
       return diffusionKind;
     }
     // This is necessary if we cannot return null here.
@@ -262,7 +262,7 @@ public class DiffusionCoefficient extends ParameterType {
    *
    * @return whether diffusionKind is set
    */
-  public boolean isSetDiffusionKind() {
+  public boolean isSetType() {
     return diffusionKind != null;
   }
 
@@ -271,7 +271,7 @@ public class DiffusionCoefficient extends ParameterType {
    * Sets the value of diffusionKind
    * @param diffusionKind
    */
-  public void setDiffusionKind(DiffusionKind diffusionKind) {
+  public void setType(DiffusionKind diffusionKind) {
     DiffusionKind oldDiffusionKind = this.diffusionKind;
     this.diffusionKind = diffusionKind;
     firePropertyChange(SpatialConstants.diffusionKind, oldDiffusionKind, this.diffusionKind);
@@ -284,8 +284,8 @@ public class DiffusionCoefficient extends ParameterType {
    * @return {@code true}, if diffusionKind was set before,
    *         otherwise {@code false}
    */
-  public boolean unsetDiffusionKind() {
-    if (isSetDiffusionKind()) {
+  public boolean unsetType() {
+    if (isSetType()) {
       DiffusionKind oldDiffusionKind = diffusionKind;
       diffusionKind = null;
       firePropertyChange(SpatialConstants.diffusionKind, oldDiffusionKind, diffusionKind);
@@ -300,8 +300,8 @@ public class DiffusionCoefficient extends ParameterType {
     final int prime = 1531;
     int hashCode = super.hashCode();
 
-    if (isSetDiffusionKind()) {
-      hashCode += prime * getDiffusionKind().hashCode();
+    if (isSetType()) {
+      hashCode += prime * getType().hashCode();
     }
 
     if (isSetCoordinateReference1()) {
@@ -321,10 +321,10 @@ public class DiffusionCoefficient extends ParameterType {
   public Map<String, String> writeXMLAttributes() {
     Map<String, String> attributes = super.writeXMLAttributes();
 
-    if (isSetDiffusionKind()) {
+    if (isSetType()) {
       attributes.remove("type");
       attributes.put(SpatialConstants.shortLabel + ":type",
-        String.valueOf(getDiffusionKind()).toLowerCase());
+        String.valueOf(getType()).toLowerCase());
     } 
 
     if (isSetCoordinateReference1()) {
@@ -352,7 +352,7 @@ public class DiffusionCoefficient extends ParameterType {
       
       if (attributeName.equals(SpatialConstants.type)) {
         try {
-          setDiffusionKind(DiffusionKind.valueOf(value));
+          setType(DiffusionKind.valueOf(value));
         } catch (Exception e) {
           AbstractReaderWriter.processInvalidAttribute(attributeName, null, value, prefix, this);
           logger.warn(MessageFormat.format(

--- a/extensions/spatial/src/org/sbml/jsbml/ext/spatial/DiffusionCoefficient.java
+++ b/extensions/spatial/src/org/sbml/jsbml/ext/spatial/DiffusionCoefficient.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import org.apache.log4j.Logger;
 import org.sbml.jsbml.PropertyUndefinedError;
+import org.sbml.jsbml.xml.parsers.AbstractReaderWriter;
 
 
 /**
@@ -344,8 +345,8 @@ public class DiffusionCoefficient extends ParameterType {
 
   @Override
   public boolean readAttribute(String attributeName, String prefix, String value) {
-    boolean isAttributeRead = (super.readAttribute(attributeName, prefix, value))
-        && (SpatialConstants.shortLabel == prefix);
+    boolean isAttributeRead = super.readAttribute(attributeName, prefix, value);
+    
     if (!isAttributeRead) {
       isAttributeRead = true;
       
@@ -353,6 +354,7 @@ public class DiffusionCoefficient extends ParameterType {
         try {
           setDiffusionKind(DiffusionKind.valueOf(value));
         } catch (Exception e) {
+          AbstractReaderWriter.processInvalidAttribute(attributeName, null, value, prefix, this);
           logger.warn(MessageFormat.format(
             SpatialConstants.bundle.getString("COULD_NOT_READ_ATTRIBUTE"), value, SpatialConstants.type, getElementName()));
         }
@@ -362,6 +364,7 @@ public class DiffusionCoefficient extends ParameterType {
         try {
           setCoordinateReference1(CoordinateKind.valueOf(value));
         } catch (Exception e) {
+          AbstractReaderWriter.processInvalidAttribute(attributeName, null, value, prefix, this);
           logger.warn(MessageFormat.format(SpatialConstants.bundle.getString("COULD_NOT_READ_ATTRIBUTE"), value, SpatialConstants.coordinateReference1, getElementName()));
         }
       }
@@ -370,6 +373,7 @@ public class DiffusionCoefficient extends ParameterType {
         try {
           setCoordinateReference2(CoordinateKind.valueOf(value));
         } catch (Exception e) {
+          AbstractReaderWriter.processInvalidAttribute(attributeName, null, value, prefix, this);
           logger.warn(MessageFormat.format(SpatialConstants.bundle.getString("COULD_NOT_READ_ATTRIBUTE"), value, SpatialConstants.coordinateReference2, getElementName()));
         }
       }

--- a/extensions/spatial/src/org/sbml/jsbml/ext/spatial/ParameterType.java
+++ b/extensions/spatial/src/org/sbml/jsbml/ext/spatial/ParameterType.java
@@ -424,8 +424,8 @@ public class ParameterType extends AbstractSBase {
    */
   @Override
   public boolean readAttribute(String attributeName, String prefix, String value) {
-    boolean isAttributeRead = (super.readAttribute(attributeName, prefix, value))
-        && (SpatialConstants.shortLabel == prefix);
+    boolean isAttributeRead = super.readAttribute(attributeName, prefix, value);
+    
     if (!isAttributeRead) {
       isAttributeRead = true;
       if (attributeName.equals(SpatialConstants.spatialRef)) {

--- a/extensions/spatial/src/org/sbml/jsbml/validator/offline/constraints/AdvectionCoefficientConstraints.java
+++ b/extensions/spatial/src/org/sbml/jsbml/validator/offline/constraints/AdvectionCoefficientConstraints.java
@@ -1,0 +1,171 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ * 
+ * Copyright (C) 2009-2019 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.Model;
+import org.sbml.jsbml.ext.spatial.AdvectionCoefficient;
+import org.sbml.jsbml.ext.spatial.SpatialConstants;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.InvalidAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the {@link AdvectionCoefficient} class.
+ * 
+ * @author Bhavye Jain
+ * @since 1.5
+ */
+public class AdvectionCoefficientConstraints extends AbstractConstraintDeclaration {
+	
+	  /* (non-Javadoc)
+	   * @see org.sbml.jsbml.validator.offline.constraints.ConstraintDeclaration#addErrorCodesForAttribute(java.util.Set, int, int, java.lang.String)
+	   */
+	  @Override
+	  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+	    int version, String attributeName, ValidationContext context) 
+	  {
+	    // TODO 
+
+	  }
+	  
+	  /* (non-Javadoc)
+	   * @see org.sbml.jsbml.validator.offline.constraints.ConstraintDeclaration#addErrorCodesForCheck(java.util.Set, int, int, org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY)
+	   */
+	  @Override
+	  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+	    CHECK_CATEGORY category, ValidationContext context) {
+		  switch (category) {
+		    case GENERAL_CONSISTENCY:
+		    	if(level >= 3){		    		
+		    		addRangeToSet(set, SPATIAL_23501, SPATIAL_23505);
+		    	}
+		      break;
+		    case IDENTIFIER_CONSISTENCY:
+		      break;
+		    case MATHML_CONSISTENCY:
+		      break;
+		    case MODELING_PRACTICE:
+		      break;
+		    case OVERDETERMINED_MODEL:
+		      break;
+		    case SBO_CONSISTENCY:
+		      break;
+		    case UNITS_CONSISTENCY:
+		      break;
+		    }
+	  }
+	  
+	  @Override
+	  public ValidationFunction<?> getValidationFunction(int errorCode, ValidationContext context){
+		  ValidationFunction<AdvectionCoefficient> func = null;
+		  
+		  switch (errorCode) {
+		  	
+		  	case SPATIAL_23501:
+		  	{
+		  		// An AdvectionCoefficient object may have the optional SBML Level 3 Core attributes metaid 
+		  		// and sboTerm. No other attributes from the SBML Level 3 Core namespaces are permitted on 
+		  		// an AdvectionCoefficient.
+		  		
+		  		func = new UnknownCoreAttributeValidationFunction<AdvectionCoefficient>();
+		  		break;
+		  	}
+		  	
+		  	case SPATIAL_23502:
+		  	{
+		  		// An AdvectionCoefficient object may have the optional SBML Level 3 Core subobjects for notes 
+		  		// and annotations. No other elements from the SBML Level 3 Core namespaces are permitted on an 
+		  		// AdvectionCoefficient.
+		  		
+		  		func = new UnknownCoreElementValidationFunction<AdvectionCoefficient>();
+		  		break;
+		  	}
+		  	
+		  	case SPATIAL_23503:
+		  	{
+		  		// An AdvectionCoefficient object must have the required attributes spatial:variable and 
+		  		// spatial:coordinate. No other attributes from the SBML Level 3 Spatial Processes namespaces  
+		  		// are permitted on an AdvectionCoefficient object. 
+		  		
+		  		func = new UnknownPackageAttributeValidationFunction<AdvectionCoefficient>(SpatialConstants.shortLabel) {
+		  			
+		  			@Override
+		  			public boolean check(ValidationContext ctx, AdvectionCoefficient ac) {
+		  				
+		  				if(!ac.isSetVariable()) {
+		  					return false;
+		  				}
+		  				if(!ac.isSetCoordinate()) {
+		  					return false;
+		  				}
+		  				
+		  				return super.check(ctx, ac);
+		  			}
+		  		};
+		  		break;
+		  	}
+		  	
+		  	case SPATIAL_23504:
+		  	{
+		  		// The value of the attribute spatial:variable of an AdvectionCoefficient object must be the 
+		  		// identifier of an existing Species object defined in the enclosing Model object.
+		  		
+		  		func = new ValidationFunction<AdvectionCoefficient>() {
+		  			
+		  			@Override
+		  			public boolean check(ValidationContext ctx, AdvectionCoefficient ac) {
+		  				
+		  				if(ac.isSetVariable()) {
+		  					
+		  					Model m = ac.getModel();
+		  					if(m.getSpecies(ac.getVariable()) != null) {
+		  						return true;
+		  					}
+		  					
+		  					return false;
+		  				}
+		  				
+		  				return true;
+		  			}
+		  		};
+		  		break;
+		  	}
+		  	
+		  	case SPATIAL_23505:
+		  	{
+		  		// The value of the attribute spatial:coordinate of an AdvectionCoefficient object must conform 
+		  		// to the syntax of SBML data type CoordinateKind and may only take on the allowed values of 
+		  		// CoordinateKind defined in SBML; that is, the value must be one of the following: 
+		  		// “cartesianX”, “cartesianY” or “cartesianZ”.
+		  		
+		  		func = new InvalidAttributeValidationFunction<AdvectionCoefficient>(SpatialConstants.coordinate);
+		  		break;
+		  	}
+		  }
+		  
+		  return func;
+	  }
+	
+}

--- a/extensions/spatial/src/org/sbml/jsbml/validator/offline/constraints/BoundaryConditionConstraints.java
+++ b/extensions/spatial/src/org/sbml/jsbml/validator/offline/constraints/BoundaryConditionConstraints.java
@@ -1,0 +1,237 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ * 
+ * Copyright (C) 2009-2019 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.ListOf;
+import org.sbml.jsbml.Model;
+import org.sbml.jsbml.ext.spatial.Boundary;
+import org.sbml.jsbml.ext.spatial.BoundaryCondition;
+import org.sbml.jsbml.ext.spatial.CoordinateComponent;
+import org.sbml.jsbml.ext.spatial.Geometry;
+import org.sbml.jsbml.ext.spatial.SpatialConstants;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.InvalidAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the {@link BoundaryCondition} class.
+ * 
+ * @author Bhavye Jain
+ * @since 1.5
+ */
+public class BoundaryConditionConstraints extends AbstractConstraintDeclaration {
+	
+	  /* (non-Javadoc)
+	   * @see org.sbml.jsbml.validator.offline.constraints.ConstraintDeclaration#addErrorCodesForAttribute(java.util.Set, int, int, java.lang.String)
+	   */
+	  @Override
+	  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+	    int version, String attributeName, ValidationContext context) 
+	  {
+	    // TODO 
+
+	  }
+	  
+	  /* (non-Javadoc)
+	   * @see org.sbml.jsbml.validator.offline.constraints.ConstraintDeclaration#addErrorCodesForCheck(java.util.Set, int, int, org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY)
+	   */
+	  @Override
+	  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+	    CHECK_CATEGORY category, ValidationContext context) {
+		  switch (category) {
+		    case GENERAL_CONSISTENCY:
+		    	if(level >= 3){		    		
+		    		addRangeToSet(set, SPATIAL_23601, SPATIAL_23607);
+		    	}
+		      break;
+		    case IDENTIFIER_CONSISTENCY:
+		      break;
+		    case MATHML_CONSISTENCY:
+		      break;
+		    case MODELING_PRACTICE:
+		      break;
+		    case OVERDETERMINED_MODEL:
+		      break;
+		    case SBO_CONSISTENCY:
+		      break;
+		    case UNITS_CONSISTENCY:
+		      break;
+		    }
+	  }
+	  
+	  @Override
+	  public ValidationFunction<?> getValidationFunction(int errorCode, ValidationContext context){
+		  ValidationFunction<BoundaryCondition> func = null;
+		  
+		  switch (errorCode) {
+		  	
+		    case SPATIAL_23601:
+		  	{
+		  		// A BoundaryCondition object may have the optional SBML Level 3 Core attributes metaid and 
+		  		// sboTerm. No other attributes from the SBML Level 3 Core namespaces are permitted on a 
+		  		// BoundaryCondition.
+		  		
+		  		func = new UnknownCoreAttributeValidationFunction<BoundaryCondition>();
+		  		break;
+		  	}
+		  	
+		    case SPATIAL_23602:
+		  	{
+		  		// A BoundaryCondition object may have the optional SBML Level 3 Core subobjects for notes 
+		  		// and annotations. No other elements from the SBML Level 3 Core namespaces are permitted 
+		  		// on a BoundaryCondition. 
+		  		
+		  		func = new UnknownCoreElementValidationFunction<BoundaryCondition>();
+		  		break;
+		  	}
+		  	
+		    case SPATIAL_23603:
+		  	{
+		  		// A BoundaryCondition object must have the required attributes spatial:variable and spatial:type,
+		  		// and may have the optional attributes spatial:coordinateBoundary and spatial:boundaryDomainType.
+		  		// No other attributes from the SBML Level 3 Spatial Processes namespaces are permitted on a
+		  		// BoundaryCondition object.
+		  		
+		  		func = new UnknownPackageAttributeValidationFunction<BoundaryCondition>(SpatialConstants.shortLabel) {
+		  			
+		  			@Override
+		  			public boolean check(ValidationContext ctx, BoundaryCondition bc) {
+		  				
+		  				if(!bc.isSetVariable()) {
+		  					return false;
+		  				}
+		  				if(!bc.isSetType()) {
+		  					return false;
+		  				}
+		  				
+		  				return super.check(ctx, bc);
+		  			}
+		  		};
+		  		break;
+		  	}
+		  	
+		    case SPATIAL_23604:
+		  	{
+		  		// The value of the attribute spatial:variable of a BoundaryCondition object must be the 
+		  		// identifier of an existing Species object defined in the enclosing Model object.
+		  		
+		  		func = new ValidationFunction<BoundaryCondition>() {
+		  			
+		  			@Override
+		  			public boolean check(ValidationContext ctx, BoundaryCondition bc) {
+		  				
+		  				if(bc.isSetVariable()) {
+		  					
+		  					Model m = bc.getModel();
+		  					if(m.getSpecies(bc.getVariable()) != null) {
+		  						return true;
+		  					}
+		  					
+		  					return false;
+		  				}
+		  				
+		  				return true;
+		  			}
+		  		};
+		  		break;
+		  	}
+		  	
+		    case SPATIAL_23605:
+		  	{
+		  		// The value of the attribute spatial:type of a BoundaryCondition object must conform to 
+		  		// the syntax of SBML data type BoundaryKind and may only take on the allowed values of
+		  		// BoundaryKind defined in SBML; that is, the value must be one of the following: 
+		  		// “Robin_sum”, "Robin_valueCoefficient”, “Robin_inwardNormalGradientCoefficient”, 
+		  		// “Neumann” or “Dirichlet”.
+		  		 
+		  		func = new InvalidAttributeValidationFunction<BoundaryCondition>(SpatialConstants.type);
+		  		break;
+		  	}
+		  	
+		    case SPATIAL_23606:
+		  	{
+		  		// The value of the attribute spatial:coordinateBoundary of a BoundaryCondition object 
+		  		// must be the identifier of an existing Boundary object defined in the enclosing Model 
+		  		// object.
+		  		
+		  		func = new ValidationFunction<BoundaryCondition>() {
+		  			@Override
+		  			public boolean check(ValidationContext ctx, BoundaryCondition bc) {
+		  				
+		  				if(bc.isSetVariable()) {
+		  					
+		  					Geometry g = bc.getGeometryInstance();
+		  					ListOf<CoordinateComponent> locc = g.getListOfCoordinateComponents();
+		  					int n = locc.getNumChildren();
+		  					
+		  					for(int i = 0; i < n; i++) {
+		  						CoordinateComponent cc = (CoordinateComponent) locc.getChildAt(i);
+		  						Boundary b1 = (Boundary) cc.getChildAt(0);
+		  						Boundary b2 = (Boundary) cc.getChildAt(1);
+		  						if(b1.getId().compareTo(bc.getCoordinateBoundary()) == 0 || b2.getId().compareTo(bc.getCoordinateBoundary()) == 0) {
+		  							return true;
+		  						}
+		  					}
+
+		  					return false;
+		  				}
+		  				
+		  				return true;
+		  			}
+		  		};
+		  		break;
+		  	}
+		  	
+		    case SPATIAL_23607:
+		  	{
+		  		// The value of the attribute spatial:boundaryDomainType of a BoundaryCondition object 
+		  		// must be the identifier of an existing DomainType object defined in the enclosing Model 
+		  		// object.
+		  		
+		  		func = new ValidationFunction<BoundaryCondition>() {
+		  			@Override
+		  			public boolean check(ValidationContext ctx, BoundaryCondition bc) {
+		  				
+		  				if(bc.isSetVariable()) {
+		  					
+		  					Geometry g = bc.getGeometryInstance();
+		  					if(g.getDomainType(bc.getBoundaryDomainType()) != null) {
+		  						return true;
+		  					}
+		  					
+		  					return false;
+		  				}
+		  				
+		  				return true;
+		  			}
+		  		};
+		  		break;
+		  	}
+		  }
+		  
+		  return func;
+	  }
+	
+}

--- a/extensions/spatial/src/org/sbml/jsbml/validator/offline/constraints/DiffusionCoefficientConstraints.java
+++ b/extensions/spatial/src/org/sbml/jsbml/validator/offline/constraints/DiffusionCoefficientConstraints.java
@@ -1,0 +1,193 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ * 
+ * Copyright (C) 2009-2019 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.Model;
+import org.sbml.jsbml.ext.spatial.DiffusionCoefficient;
+import org.sbml.jsbml.ext.spatial.SpatialConstants;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.InvalidAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the {@link DiffusionCoefficient} class.
+ * 
+ * @author Bhavye Jain
+ * @since 1.5
+ */
+public class DiffusionCoefficientConstraints extends AbstractConstraintDeclaration {
+	
+	  /* (non-Javadoc)
+	   * @see org.sbml.jsbml.validator.offline.constraints.ConstraintDeclaration#addErrorCodesForAttribute(java.util.Set, int, int, java.lang.String)
+	   */
+	  @Override
+	  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+	    int version, String attributeName, ValidationContext context) 
+	  {
+	    // TODO 
+
+	  }
+	  
+	  /* (non-Javadoc)
+	   * @see org.sbml.jsbml.validator.offline.constraints.ConstraintDeclaration#addErrorCodesForCheck(java.util.Set, int, int, org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY)
+	   */
+	  @Override
+	  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+	    CHECK_CATEGORY category, ValidationContext context) {
+		  switch (category) {
+		    case GENERAL_CONSISTENCY:
+		    	if(level >= 3){		    		
+		    		addRangeToSet(set, SPATIAL_23401, SPATIAL_23407);
+		    	}
+		      break;
+		    case IDENTIFIER_CONSISTENCY:
+		      break;
+		    case MATHML_CONSISTENCY:
+		      break;
+		    case MODELING_PRACTICE:
+		      break;
+		    case OVERDETERMINED_MODEL:
+		      break;
+		    case SBO_CONSISTENCY:
+		      break;
+		    case UNITS_CONSISTENCY:
+		      break;
+		    }
+	  }
+	  
+	  @Override
+	  public ValidationFunction<?> getValidationFunction(int errorCode, ValidationContext context){
+		  ValidationFunction<DiffusionCoefficient> func = null;
+		  
+		  switch (errorCode) {
+		  	
+		    case SPATIAL_23401:
+		  	{
+		  		// A DiffusionCoefficient object may have the optional SBML Level 3 Core attributes metaid and 
+		  		// sboTerm. No other attributes from the SBML Level 3 Core namespaces are permitted on a 
+		  		// DiffusionCoefficient.
+		  		
+		  		func = new UnknownCoreAttributeValidationFunction<DiffusionCoefficient>();
+		  		break;
+		  	}
+		  	
+		    case SPATIAL_23402:
+		  	{
+		  		// A DiffusionCoefficient object may have the optional SBML Level 3 Core subobjects for notes 
+		  		// and annotations. No other elements from the SBML Level 3 Core namespaces are permitted on a
+		  		// DiffusionCoefficient.
+		  		
+		  		func = new UnknownCoreElementValidationFunction<DiffusionCoefficient>();
+		  		break;
+		  	}
+		  	
+		    case SPATIAL_23403:
+		  	{
+		  		// A DiffusionCoefficient object must have the required attributes spatial:variable and spatial:type,
+		  		// and may have the optional attributes spatial:coordinateReferenceOne and spatial:coordinateReferenceTwo.
+		  		// No other attributes from the SBML Level 3 Spatial Processes namespaces are permitted on a
+		  		// DiffusionCoefficient object.
+		  		
+		  		func = new UnknownPackageAttributeValidationFunction<DiffusionCoefficient>(SpatialConstants.shortLabel) {
+		  			
+		  			@Override
+		  			public boolean check(ValidationContext ctx, DiffusionCoefficient dc) {
+		  				
+		  				if(!dc.isSetVariable()) {
+		  					return false;
+		  				}
+		  				if(!dc.isSetDiffusionKind()) {
+		  					return false;
+		  				}
+		  				
+		  				return super.check(ctx, dc);
+		  			}
+		  		};
+		  		break;
+		  	}
+		  	
+		    case SPATIAL_23404:
+		  	{
+		  		// The value of the attribute spatial:variable of a DiffusionCoefficient object must be the 
+		  		// identifier of an existing Species object defined in the enclosing Model object.
+		  		
+		  		func = new ValidationFunction<DiffusionCoefficient>() {
+		  			
+		  			@Override
+		  			public boolean check(ValidationContext ctx, DiffusionCoefficient dc) {
+		  				
+		  				if(dc.isSetVariable()) {
+		  					
+		  					Model m = dc.getModel();		  					
+		  					if(m.getSpecies(dc.getVariable()) != null) {
+		  						return true;
+		  					}
+		  					return false;
+		  				}
+		  				
+		  				return true;
+		  			}
+		  		};
+		  		break;
+		  	}
+		  	
+		    case SPATIAL_23405:
+		  	{
+		  		// The value of the attribute spatial:type of a DiffusionCoefficient object must conform to 
+		  		// the syntax of SBML data type DiffusionKind and may only take on the allowed values of 
+		  		// DiffusionKind defined in SBML; that is, the value must be one of the following: “isotropic”, 
+		  		// “anisotropic” or “tensor”.
+		  		
+		  		func = new InvalidAttributeValidationFunction<DiffusionCoefficient>(SpatialConstants.type);
+		  		break;
+		  	}
+		  	
+		    case SPATIAL_23406:
+		  	{
+		  		// The value of the attribute spatial:coordinateReferenceOne of a DiffusionCoefficient object
+		  		// must conform to the syntax of SBML data type CoordinateKind and may only take onthe allowed 
+		  		// values of CoordinateKind defined in SBML; that is, the value must be one of the following:
+		  		// “cartesianX”, “cartesianY” or “cartesianZ”.
+		  		
+		  		func = new InvalidAttributeValidationFunction<DiffusionCoefficient>(SpatialConstants.coordinateReference1);
+		  		break;
+		  	}
+		  	
+		    case SPATIAL_23407:
+		  	{
+		  		// The value of the attribute spatial:coordinateReferenceTwo of a DiffusionCoefficient object
+		  		// must conform to the syntax of SBML data type CoordinateKind and may only take on the allowed
+		  		// values of CoordinateKind defined in SBML; that is, the value must be one of the following:
+		  		// “cartesianX”, “cartesianY” or “cartesianZ”.
+		  		
+		  		func = new InvalidAttributeValidationFunction<DiffusionCoefficient>(SpatialConstants.coordinateReference2);
+		  		break;
+		  	}
+		  }
+		  
+		  return func;
+	  }
+	
+}

--- a/extensions/spatial/src/org/sbml/jsbml/validator/offline/constraints/DiffusionCoefficientConstraints.java
+++ b/extensions/spatial/src/org/sbml/jsbml/validator/offline/constraints/DiffusionCoefficientConstraints.java
@@ -118,7 +118,7 @@ public class DiffusionCoefficientConstraints extends AbstractConstraintDeclarati
 		  				if(!dc.isSetVariable()) {
 		  					return false;
 		  				}
-		  				if(!dc.isSetDiffusionKind()) {
+		  				if(!dc.isSetType()) {
 		  					return false;
 		  				}
 		  				

--- a/extensions/spatial/src/org/sbml/jsbml/validator/offline/constraints/SpatialSymbolReferenceConstraints.java
+++ b/extensions/spatial/src/org/sbml/jsbml/validator/offline/constraints/SpatialSymbolReferenceConstraints.java
@@ -1,0 +1,154 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ * 
+ * Copyright (C) 2009-2019 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.ext.spatial.Geometry;
+import org.sbml.jsbml.ext.spatial.SpatialConstants;
+import org.sbml.jsbml.ext.spatial.SpatialModelPlugin;
+import org.sbml.jsbml.ext.spatial.SpatialSymbolReference;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the {@link SpatialSymbolReference} class.
+ * 
+ * @author Bhavye Jain
+ * @since 1.5
+ */
+public class SpatialSymbolReferenceConstraints extends AbstractConstraintDeclaration {
+	
+	  /* (non-Javadoc)
+	   * @see org.sbml.jsbml.validator.offline.constraints.ConstraintDeclaration#addErrorCodesForAttribute(java.util.Set, int, int, java.lang.String)
+	   */
+	  @Override
+	  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+	    int version, String attributeName, ValidationContext context) 
+	  {
+	    // TODO 
+
+	  }
+	  
+	  /* (non-Javadoc)
+	   * @see org.sbml.jsbml.validator.offline.constraints.ConstraintDeclaration#addErrorCodesForCheck(java.util.Set, int, int, org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY)
+	   */
+	  @Override
+	  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+	    CHECK_CATEGORY category, ValidationContext context) {
+		  switch (category) {
+		    case GENERAL_CONSISTENCY:
+		    	if(level >= 3){		   
+		    		addRangeToSet(set, SPATIAL_23301, SPATIAL_23304);
+		    	}
+		      break;
+		    case IDENTIFIER_CONSISTENCY:
+		      break;
+		    case MATHML_CONSISTENCY:
+		      break;
+		    case MODELING_PRACTICE:
+		      break;
+		    case OVERDETERMINED_MODEL:
+		      break;
+		    case SBO_CONSISTENCY:
+		      break;
+		    case UNITS_CONSISTENCY:
+		      break;
+		    }
+	  }
+	  
+	  @Override
+	  public ValidationFunction<?> getValidationFunction(int errorCode, ValidationContext context){
+		  ValidationFunction<SpatialSymbolReference> func = null;
+		  
+		  switch (errorCode) {
+		  	
+		  	case SPATIAL_23301:
+		  	{
+		  		// A SpatialSymbolReference object may have the optional SBML Level 3 Core attributes metaid 
+		  		// and sboTerm. No other attributes from the SBML Level 3 Core namespaces are permitted on a 
+		  		// SpatialSymbolReference.
+		  		
+		  		func = new UnknownCoreAttributeValidationFunction<SpatialSymbolReference>();
+		  		break;
+		  	}
+		  	
+		  	case SPATIAL_23302:
+		  	{
+		  		// A SpatialSymbolReference object may have the optional SBML Level 3 Core subobjects for 
+		  		// notes and annotations. No other elements from the SBML Level 3 Core namespaces are permitted
+		  		// on a SpatialSymbolReference.
+		  		
+		  		func = new UnknownCoreElementValidationFunction<SpatialSymbolReference>();
+		  		break;
+		  	}
+		  	
+		  	case SPATIAL_23303:
+		  	{
+		  		// A SpatialSymbolReference object must have the required attribute spatial:spatialRef. No 
+		  		// other attributes from the SBML Level 3 Spatial Processes namespaces are permitted on a 
+		  		// SpatialSymbolReference object.
+		  		
+		  		func = new UnknownPackageAttributeValidationFunction<SpatialSymbolReference>(SpatialConstants.shortLabel) {
+		  			
+		  			@Override
+		  			public boolean check(ValidationContext ctx, SpatialSymbolReference ssr) {
+		  			
+		  				if(!ssr.isSetSpatialRef()) {
+		  					return false;
+		  				}
+		  				return super.check(ctx, ssr);
+		  			}
+		  		};
+		  		break;
+		  	}
+		  	
+		  	case SPATIAL_23304:
+		  	{
+		  		// The value of the attribute spatial:spatialRef of a SpatialSymbolReference object must be 
+		  		// the identifier of an existing Geometry object defined in the enclosing Model object.
+
+		  		func = new ValidationFunction<SpatialSymbolReference>() {
+		  			
+		  			@Override
+		  			public boolean check(ValidationContext ctx, SpatialSymbolReference ssr) {
+		  				if(ssr.isSetSpatialRef()) {
+		  					SpatialModelPlugin smp = (SpatialModelPlugin) ssr.getModel().getPlugin(SpatialConstants.shortLabel);
+		  					Geometry g = smp.getGeometry();	
+		  					if(ssr.getSpatialRef().compareTo(g.getId()) == 0) {
+		  						return true;
+		  					}
+		  					return false;
+		  				}
+		  				
+		  				return true;
+		  			}
+		  		};
+		  		break;
+		  	}
+		  }
+		  
+		  return func;
+	  }
+	
+}


### PR DESCRIPTION
Implemented constraints for:
SpatialSymbolReference
DiffusionCoefficient
AdvectionCoefficient
BoundaryCondition

Renamed getters/setters for the attribute `spatial:type` in `DiffusionCoefficient.java` 

Link for modified test files:
https://drive.google.com/open?id=1b58WwK6v8SanO3q_bvzVZR1RrR778UTP