### PR TITLE
Implement rules 221XX, 240XX and 238XX

### DIFF
--- a/extensions/spatial/src/org/sbml/jsbml/ext/spatial/MixedGeometry.java
+++ b/extensions/spatial/src/org/sbml/jsbml/ext/spatial/MixedGeometry.java
@@ -136,7 +136,7 @@ public class MixedGeometry extends GeometryDefinition {
    *         otherwise {@code false}
    */
   public boolean isSetListOfGeometryDefinitions() {
-    if ((listOfGeometryDefinitions == null) || listOfGeometryDefinitions.isEmpty()) {
+    if (listOfGeometryDefinitions == null) {
       return false;
     }
     return true;
@@ -344,7 +344,7 @@ public class MixedGeometry extends GeometryDefinition {
    *         otherwise {@code false}
    */
   public boolean isSetListOfOrdinalMappings() {
-    if ((listOfOrdinalMappings == null) || listOfOrdinalMappings.isEmpty()) {
+    if (listOfOrdinalMappings == null) {
       return false;
     }
     return true;

--- a/extensions/spatial/src/org/sbml/jsbml/ext/spatial/ParametricObject.java
+++ b/extensions/spatial/src/org/sbml/jsbml/ext/spatial/ParametricObject.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.apache.log4j.Logger;
 import org.sbml.jsbml.PropertyUndefinedError;
 import org.sbml.jsbml.util.StringTools;
+import org.sbml.jsbml.xml.parsers.AbstractReaderWriter;
 
 
 /**
@@ -577,8 +578,7 @@ public class ParametricObject extends AbstractSpatialNamedSBase {
 
   @Override
   public boolean readAttribute(String attributeName, String prefix, String value) {
-    boolean isAttributeRead = (super.readAttribute(attributeName, prefix, value))
-        && (SpatialConstants.shortLabel == prefix);
+    boolean isAttributeRead = super.readAttribute(attributeName, prefix, value);
     if (!isAttributeRead) {
       isAttributeRead = true;
       if (attributeName.equals(SpatialConstants.domainType)) {
@@ -593,6 +593,7 @@ public class ParametricObject extends AbstractSpatialNamedSBase {
         try {
           setPolygonType(value);
         } catch (Exception e) {
+          AbstractReaderWriter.processInvalidAttribute(attributeName, null, value, prefix, this);
           logger.warn(MessageFormat.format(
             SpatialConstants.bundle.getString("COULD_NOT_READ_ATTRIBUTE"), value, SpatialConstants.polygonType, getElementName()));
         }
@@ -601,6 +602,7 @@ public class ParametricObject extends AbstractSpatialNamedSBase {
         try {
           setCompression(value);
         } catch (Exception e) {
+          AbstractReaderWriter.processInvalidAttribute(attributeName, null, value, prefix, this);
           logger.warn(MessageFormat.format(
             SpatialConstants.bundle.getString("COULD_NOT_READ_ATTRIBUTE"), value, SpatialConstants.compression, getElementName()));
         }
@@ -609,6 +611,7 @@ public class ParametricObject extends AbstractSpatialNamedSBase {
         try {
           setPointIndexLength(StringTools.parseSBMLInt(value));
         } catch (Exception e) {
+          AbstractReaderWriter.processInvalidAttribute(attributeName, null, value, prefix, this);
           logger.warn(MessageFormat.format(
             SpatialConstants.bundle.getString("COULD_NOT_READ_ATTRIBUTE"), value, SpatialConstants.pointIndexLength, getElementName()));
         }
@@ -618,6 +621,7 @@ public class ParametricObject extends AbstractSpatialNamedSBase {
           // see DataKind.java
           setDataType(value.toUpperCase());
         } catch (Exception e) {
+          AbstractReaderWriter.processInvalidAttribute(attributeName, null, value, prefix, this);
           logger.warn(MessageFormat.format(
             SpatialConstants.bundle.getString("COULD_NOT_READ_ATTRIBUTE"), value, SpatialConstants.dataType, getElementName()));
         }

--- a/extensions/spatial/src/org/sbml/jsbml/ext/spatial/SpatialConstants.java
+++ b/extensions/spatial/src/org/sbml/jsbml/ext/spatial/SpatialConstants.java
@@ -351,6 +351,14 @@ public class SpatialConstants {
   /**
    * 
    */
+  public static final String listOfOrdinalMappings = "listOfOrdinalMappings";
+  /**
+   * 
+   */
+  public static final String ordinalMapping = "ordinalMapping";
+  /**
+   * 
+   */
   public static final String coordinateComponent = "coordinateComponent";
   /**
    * 

--- a/extensions/spatial/src/org/sbml/jsbml/ext/spatial/SpatialPoints.java
+++ b/extensions/spatial/src/org/sbml/jsbml/ext/spatial/SpatialPoints.java
@@ -26,6 +26,7 @@ import org.apache.log4j.Logger;
 import org.sbml.jsbml.AbstractSBase;
 import org.sbml.jsbml.PropertyUndefinedError;
 import org.sbml.jsbml.util.StringTools;
+import org.sbml.jsbml.xml.parsers.AbstractReaderWriter;
 
 
 /**
@@ -431,8 +432,7 @@ public class SpatialPoints extends AbstractSBase {
    */
   @Override
   public boolean readAttribute(String attributeName, String prefix, String value) {
-    boolean isAttributeRead = (super.readAttribute(attributeName, prefix, value))
-        && (SpatialConstants.shortLabel == prefix);
+    boolean isAttributeRead = super.readAttribute(attributeName, prefix, value);
     if(!isAttributeRead) {
       isAttributeRead = true;
 
@@ -441,6 +441,7 @@ public class SpatialPoints extends AbstractSBase {
           setCompression(value);
 
         } catch (Exception e) {
+          AbstractReaderWriter.processInvalidAttribute(attributeName, null, value, prefix, this);
           logger.warn(MessageFormat.format(
             SpatialConstants.bundle.getString("COULD_NOT_READ_ATTRIBUTE"), value, SpatialConstants.compression, getElementName()));
         }
@@ -450,6 +451,7 @@ public class SpatialPoints extends AbstractSBase {
           setArrayDataLength(StringTools.parseSBMLInt(value));
 
         } catch (Exception e) {
+          AbstractReaderWriter.processInvalidAttribute(attributeName, null, value, prefix, this);
           logger.warn(MessageFormat.format(
             SpatialConstants.bundle.getString("COULD_NOT_READ_ATTRIBUTE"), value, SpatialConstants.arrayDataLength, getElementName()));
         }
@@ -460,6 +462,7 @@ public class SpatialPoints extends AbstractSBase {
           setDataType(value.toUpperCase());
 
         } catch (Exception e) {
+          AbstractReaderWriter.processInvalidAttribute(attributeName, null, value, prefix, this);
           logger.warn(MessageFormat.format(
             SpatialConstants.bundle.getString("COULD_NOT_READ_ATTRIBUTE"), value, SpatialConstants.dataType, getElementName()));
         }

--- a/extensions/spatial/src/org/sbml/jsbml/validator/offline/constraints/MixedGeometryConstraints.java
+++ b/extensions/spatial/src/org/sbml/jsbml/validator/offline/constraints/MixedGeometryConstraints.java
@@ -1,0 +1,218 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ * 
+ * Copyright (C) 2009-2019 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.ListOf;
+import org.sbml.jsbml.ext.spatial.GeometryDefinition;
+import org.sbml.jsbml.ext.spatial.MixedGeometry;
+import org.sbml.jsbml.ext.spatial.OrdinalMapping;
+import org.sbml.jsbml.ext.spatial.SpatialConstants;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.DuplicatedElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageElementValidationFunction;
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the {@link MixedGeometry} class.
+ * 
+ * @author Bhavye Jain
+ * @since 1.5
+ */
+public class MixedGeometryConstraints extends AbstractConstraintDeclaration {
+
+  /* (non-Javadoc)
+   * @see org.sbml.jsbml.validator.offline.constraints.ConstraintDeclaration#addErrorCodesForAttribute(java.util.Set, int, int, java.lang.String)
+   */
+  @Override
+  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+    int version, String attributeName, ValidationContext context) 
+  {
+    // TODO 
+
+  }
+
+  /* (non-Javadoc)
+   * @see org.sbml.jsbml.validator.offline.constraints.ConstraintDeclaration#addErrorCodesForCheck(java.util.Set, int, int, org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY)
+   */
+  @Override
+  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+    CHECK_CATEGORY category, ValidationContext context) {
+    switch (category) {
+    case GENERAL_CONSISTENCY:
+      if(level >= 3){
+        addRangeToSet(set, SPATIAL_23801, SPATIAL_23807);
+      }
+      break;
+    case IDENTIFIER_CONSISTENCY:
+      break;
+    case MATHML_CONSISTENCY:
+      break;
+    case MODELING_PRACTICE:
+      break;
+    case OVERDETERMINED_MODEL:
+      break;
+    case SBO_CONSISTENCY:
+      break;
+    case UNITS_CONSISTENCY:
+      break;
+    }
+  }
+
+  @Override
+  public ValidationFunction<?> getValidationFunction(int errorCode, ValidationContext context){
+    ValidationFunction<MixedGeometry> func = null;
+
+    switch (errorCode) {
+    
+    case SPATIAL_23801:
+    {
+      // A MixedGeometry object may have the optional SBML Level 3 Core attributes metaid and 
+      // sboTerm. No other attributes from the SBML Level 3 Core namespaces are permitted on a 
+      // MixedGeometry.
+
+      func = new UnknownCoreAttributeValidationFunction<MixedGeometry>();
+      break;
+    }
+    
+    case SPATIAL_23802:
+    {
+      // A MixedGeometry object may have the optional SBML Level 3 Core subobjects for notes and 
+      // annotations. No other elements from the SBML Level 3 Core namespaces are permitted on a 
+      // MixedGeometry.
+
+      func = new UnknownCoreElementValidationFunction<MixedGeometry>();
+      break;
+    }
+    
+    case SPATIAL_23803:
+    {
+      // A MixedGeometry object may contain one and only one instance of each of the ListOfGeometryDefinitions
+      // and ListOfOrdinalMappings elements. No other elements from the SBML Level 3 Spatial Processes namespaces 
+      // are permitted on a MixedGeometry object.
+
+      func = new ValidationFunction<MixedGeometry>() {
+        
+        @Override
+        public boolean check(ValidationContext ctx, MixedGeometry mg) {
+          
+          return new DuplicatedElementValidationFunction<MixedGeometry>(SpatialConstants.listOfGeometryDefinitions).check(ctx, mg)
+              && new DuplicatedElementValidationFunction<MixedGeometry>(SpatialConstants.listOfOrdinalMappings).check(ctx, mg)
+              && new UnknownPackageElementValidationFunction<MixedGeometry>(SpatialConstants.shortLabel).check(ctx, mg);
+        }
+      };
+      
+      break;
+    }
+    
+    case SPATIAL_23804:
+    {
+      // Apart from the general notes and annotations subobjects permitted on all SBML objects, a 
+      // ListOfGeometryDefinitions container object may only contain GeometryDefinition objects.
+
+      func = new ValidationFunction<MixedGeometry>() {
+        
+        @Override
+        public boolean check(ValidationContext ctx, MixedGeometry mg) {
+          
+          if(mg.isSetListOfGeometryDefinitions()) {
+            return new UnknownElementValidationFunction<ListOf<GeometryDefinition>>().check(ctx, mg.getListOfGeometryDefinitions());
+          }          
+          return true;
+        }
+      };
+      
+      break;
+    }
+    
+    case SPATIAL_23805:
+    {
+      // Apart from the general notes and annotations subobjects permitted on all SBML objects, a 
+      // ListOfOrdinalMappings container object may only contain OrdinalMapping objects.
+
+      func = new ValidationFunction<MixedGeometry>() {
+        
+        @Override
+        public boolean check(ValidationContext ctx, MixedGeometry mg) {
+          
+          if(mg.isSetListOfGeometryDefinitions()) {
+            return new UnknownElementValidationFunction<ListOf<OrdinalMapping>>().check(ctx, mg.getListOfOrdinalMappings());
+          }          
+          return true;
+        }
+      };
+      
+      break;
+    }
+    
+    case SPATIAL_23806:
+    {
+      // A ListOfGeometryDefinitions object may have the optional SBML Level 3 Core attributes 
+      // metaid and sboTerm. No other attributes from the SBML Level 3 Core namespaces are permitted 
+      // on a ListOfGeometryDefinitions object.
+
+      func = new ValidationFunction<MixedGeometry>() {
+        
+        @Override
+        public boolean check(ValidationContext ctx, MixedGeometry mg) {
+          
+          if(mg.isSetListOfGeometryDefinitions()) {
+            return new UnknownAttributeValidationFunction<ListOf<GeometryDefinition>>().check(ctx, mg.getListOfGeometryDefinitions());
+          }          
+          return true;
+        }
+      };
+
+      break;
+    }
+    
+    case SPATIAL_23807:
+    {
+      // A ListOfOrdinalMappings object may have the optional SBML Level 3 Core attributes metaid 
+      // and sboTerm. No other attributes from the SBML Level 3 Core namespaces are permitted on a 
+      // ListOfOrdinalMappings object.
+
+      func = new ValidationFunction<MixedGeometry>() {
+        
+        @Override
+        public boolean check(ValidationContext ctx, MixedGeometry mg) {
+          
+          if(mg.isSetListOfGeometryDefinitions()) {
+            return new UnknownAttributeValidationFunction<ListOf<OrdinalMapping>>().check(ctx, mg.getListOfOrdinalMappings());
+          }          
+          return true;
+        }
+      };
+      
+      break;
+    }
+    
+    }    
+
+    return func;
+  }
+
+}
+

--- a/extensions/spatial/src/org/sbml/jsbml/validator/offline/constraints/ParametricObjectConstraints.java
+++ b/extensions/spatial/src/org/sbml/jsbml/validator/offline/constraints/ParametricObjectConstraints.java
@@ -1,0 +1,263 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ * 
+ * Copyright (C) 2009-2019 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+import java.util.StringTokenizer;
+
+import org.sbml.jsbml.ext.spatial.Geometry;
+import org.sbml.jsbml.ext.spatial.ParametricObject;
+import org.sbml.jsbml.ext.spatial.SpatialConstants;
+import org.sbml.jsbml.ext.spatial.SpatialModelPlugin;
+import org.sbml.jsbml.util.StringTools;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.InvalidAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the {@link ParametricObject} class.
+ * 
+ * @author Bhavye Jain
+ * @since 1.5
+ */
+public class ParametricObjectConstraints extends AbstractConstraintDeclaration {
+
+  /* (non-Javadoc)
+   * @see org.sbml.jsbml.validator.offline.constraints.ConstraintDeclaration#addErrorCodesForAttribute(java.util.Set, int, int, java.lang.String)
+   */
+  @Override
+  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+    int version, String attributeName, ValidationContext context) 
+  {
+    // TODO 
+
+  }
+
+  /* (non-Javadoc)
+   * @see org.sbml.jsbml.validator.offline.constraints.ConstraintDeclaration#addErrorCodesForCheck(java.util.Set, int, int, org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY)
+   */
+  @Override
+  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+    CHECK_CATEGORY category, ValidationContext context) {
+    switch (category) {
+    case GENERAL_CONSISTENCY:
+      if(level >= 3){
+        addRangeToSet(set, SPATIAL_22101, SPATIAL_22110);
+      }
+      break;
+    case IDENTIFIER_CONSISTENCY:
+      break;
+    case MATHML_CONSISTENCY:
+      break;
+    case MODELING_PRACTICE:
+      break;
+    case OVERDETERMINED_MODEL:
+      break;
+    case SBO_CONSISTENCY:
+      break;
+    case UNITS_CONSISTENCY:
+      break;
+    }
+  }
+
+  @Override
+  public ValidationFunction<?> getValidationFunction(int errorCode, ValidationContext context){
+    ValidationFunction<ParametricObject> func = null;
+
+    switch (errorCode) {
+    
+    case SPATIAL_22101:
+    {
+      // A ParametricObject object may have the optional SBML Level 3 Core attributes metaid and 
+      // sboTerm. No other attributes from the SBML Level 3 Core namespaces are permitted on a 
+      // ParametricObject.
+
+      func = new UnknownCoreAttributeValidationFunction<ParametricObject>();
+      break;
+    }
+    
+    case SPATIAL_22102:
+    {
+      // A ParametricObject object may have the optional SBML Level 3 Core subobjects for notes and 
+      // annotations. No other elements from the SBML Level 3 Core namespaces are permitted on a 
+      // ParametricObject.
+
+      func = new UnknownCoreElementValidationFunction<ParametricObject>();
+      break;
+    }
+    
+    case SPATIAL_22103:
+    {
+      // A ParametricObject object must have the required attributes spatial:id, spatial:polygonType, 
+      // spatial:domainType, spatial:pointIndex, spatial:pointIndexLength and spatial:compression, 
+      // and may have the optional attributes spatial:name and spatial:dataType. No other attributes 
+      // from the SBML Level 3 Spatial Processes namespaces are permitted on a ParametricObject object.
+
+      func = new UnknownPackageAttributeValidationFunction<ParametricObject>(SpatialConstants.shortLabel) {
+        
+        @Override
+        public boolean check(ValidationContext ctx, ParametricObject po) {
+          
+          if(!po.isSetId()) {
+            return false;
+          }
+          if(!po.isSetPolygonType()) {
+            return false;
+          }
+          if(!po.isSetDomainType()) {
+            return false;
+          }
+          if(!po.isSetPointIndex()) {
+            return false;
+          }
+          if(!po.isSetPointIndexLength()) {
+            return false;
+          }
+          if(!po.isSetCompression()){
+            return false;
+          }
+          
+          return super.check(ctx, po);
+        }
+      };
+      break;
+    }
+    
+    case SPATIAL_22104:
+    {
+      // The value of the attribute spatial:polygonType of a ParametricObject object must conform 
+      // to the syntax of SBML data type PolygonKind and may only take on the allowed values of 
+      // PolygonKind defined in SBML; that is, the value must be one of the following: “triangle” 
+      // or “quadrilateral”. 
+
+      func = new InvalidAttributeValidationFunction<ParametricObject>(SpatialConstants.polygonType);
+      break;
+    }
+    
+    case SPATIAL_22105:
+    {
+      // The value of the attribute spatial:domainType of a ParametricObject object must be the 
+      // identifier of an existing DomainType object defined in the enclosing Model object.
+
+      func = new ValidationFunction<ParametricObject>() {
+        
+        @Override
+        public boolean check(ValidationContext ctx, ParametricObject po) {
+          
+          if(po.isSetDomainType()) {
+            SpatialModelPlugin smp = (SpatialModelPlugin) po.getModel().getPlugin(SpatialConstants.shortLabel);
+            if(smp.isSetGeometry()) {
+              Geometry g = smp.getGeometry();
+              if(g.getDomainType(po.getDomainType()) != null) {
+                return true;
+              }
+              return false;
+            }
+          }
+          
+          return true;
+        }
+      };
+      break;
+    }
+    
+    case SPATIAL_22106:
+    {
+      // The value of the attribute spatial:pointIndex of a ParametricObject object must be an array 
+      // of values of type int.
+      func = new ValidationFunction<ParametricObject>() {
+        
+        @Override
+        public boolean check(ValidationContext ctx, ParametricObject po) {
+          
+          if(po.isSetPointIndex()) {
+            String pointIndex = po.getPointIndex().trim();
+            StringTokenizer test = new StringTokenizer(pointIndex, " ;");
+            while(test.hasMoreTokens()) {
+              try {
+                StringTools.parseSBMLInt(test.nextToken());
+              } catch (Exception e) {
+                return false;
+              }
+            }
+            return true;
+          }
+          
+          return true;
+        }
+      };
+      break;
+    }
+    
+    case SPATIAL_22107:
+    {
+      // The attribute spatial:pointIndexLength on a ParametricObject must have a value of data 
+      // type integer. 
+
+      func = new InvalidAttributeValidationFunction<ParametricObject>(SpatialConstants.pointIndexLength);
+      break;
+    }
+    
+    case SPATIAL_22108:
+    {
+      // The value of the attribute spatial:compression of a ParametricObject object must conform 
+      // to the syntax of SBML data type CompressionKind and may only take on the allowed values 
+      // of CompressionKind defined in SBML; that is, the value must be one of the following: 
+      // “uncompressed” or “deflated”.
+
+      func = new InvalidAttributeValidationFunction<ParametricObject>(SpatialConstants.compression);
+      break;
+    }
+    
+    case SPATIAL_22109:
+    {
+      // The attribute spatial:name on a ParametricObject must have a value of data type string.
+
+      func = new ValidationFunction<ParametricObject>() {
+        
+        @Override
+        public boolean check(ValidationContext ctx, ParametricObject po) {
+          
+          // nothing to check as Java can read any kiind of string
+          return true;
+        }
+      };
+      break;
+    }
+    
+    case SPATIAL_22110:
+    {
+      // The value of the attribute spatial:dataType of a ParametricObject object must conform to 
+      // the syntax of SBML data type DataKind and may only take on the allowed values of DataKind 
+      // defined in SBML; that is, the value must be one of the following: “double”, “float”, “uint8”, 
+      // “uint16” or “uint32”.
+
+      func = new InvalidAttributeValidationFunction<ParametricObject>(SpatialConstants.dataType);
+      break;
+    }
+    }    
+
+    return func;
+  }
+
+}

--- a/extensions/spatial/src/org/sbml/jsbml/validator/offline/constraints/SpatialPointsConstraints.java
+++ b/extensions/spatial/src/org/sbml/jsbml/validator/offline/constraints/SpatialPointsConstraints.java
@@ -1,0 +1,214 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ * 
+ * Copyright (C) 2009-2019 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+import java.util.StringTokenizer;
+
+import org.sbml.jsbml.ext.spatial.SpatialConstants;
+import org.sbml.jsbml.ext.spatial.SpatialPoints;
+import org.sbml.jsbml.util.StringTools;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.InvalidAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the {@link SpatialPoints} class.
+ * 
+ * @author Bhavye Jain
+ * @since 1.5
+ */
+public class SpatialPointsConstraints extends AbstractConstraintDeclaration {
+
+  /* (non-Javadoc)
+   * @see org.sbml.jsbml.validator.offline.constraints.ConstraintDeclaration#addErrorCodesForAttribute(java.util.Set, int, int, java.lang.String)
+   */
+  @Override
+  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+    int version, String attributeName, ValidationContext context) 
+  {
+    // TODO 
+
+  }
+
+  /* (non-Javadoc)
+   * @see org.sbml.jsbml.validator.offline.constraints.ConstraintDeclaration#addErrorCodesForCheck(java.util.Set, int, int, org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY)
+   */
+  @Override
+  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+    CHECK_CATEGORY category, ValidationContext context) {
+    switch (category) {
+    case GENERAL_CONSISTENCY:
+      if(level >= 3){
+        addRangeToSet(set, SPATIAL_24001, SPATIAL_24008);
+      }
+      break;
+    case IDENTIFIER_CONSISTENCY:
+      break;
+    case MATHML_CONSISTENCY:
+      break;
+    case MODELING_PRACTICE:
+      break;
+    case OVERDETERMINED_MODEL:
+      break;
+    case SBO_CONSISTENCY:
+      break;
+    case UNITS_CONSISTENCY:
+      break;
+    }
+  }
+
+  @Override
+  public ValidationFunction<?> getValidationFunction(int errorCode, ValidationContext context){
+    ValidationFunction<SpatialPoints> func = null;
+
+    switch (errorCode) {
+    
+    case SPATIAL_24001:
+    {
+      // A SpatialPoints object may have the optional SBML Level 3 Core attributes metaid and 
+      // sboTerm. No other attributes from the SBML Level 3 Core namespaces are permitted on 
+      // a SpatialPoints.
+
+      func = new UnknownCoreAttributeValidationFunction<SpatialPoints>();
+      break;
+    }
+    
+    case SPATIAL_24002:
+    {
+      // A SpatialPoints object may have the optional SBML Level 3 Core subobjects for notes and 
+      // annotations. No other elements from the SBML Level 3 Core namespaces are permitted on a 
+      // SpatialPoints.
+
+      func = new UnknownCoreElementValidationFunction<SpatialPoints>();
+      break;
+    }
+    
+    case SPATIAL_24003:
+    {
+      // A SpatialPoints object must have the required attributes spatial:compression, spatial:arrayData 
+      // and spatial:arrayDataLength, and may have the optional attributes spatial:id, spatial:name  
+      // and spatial:dataType. No other attributes from the SBML Level 3 Spatial Processes namespaces are 
+      // permitted on a SpatialPoints object.
+
+      func = new UnknownPackageAttributeValidationFunction<SpatialPoints>(SpatialConstants.shortLabel) {
+        
+        @Override
+        public boolean check(ValidationContext ctx, SpatialPoints sp) {
+          
+          if(!sp.isSetCompression()) {
+            return false;
+          }
+          if(!sp.isSetArrayData()) {
+            return false;
+          }
+          if(!sp.isSetArrayDataLength()) {
+            return false;
+          }
+          
+          return super.check(ctx, sp);
+        }
+      };
+      break;
+    }
+    
+    case SPATIAL_24004:
+    {
+      // The value of the attribute spatial:compression of a SpatialPoints object must conform 
+      // to the syntax of SBML data type CompressionKind and may only take on the allowed values 
+      // of CompressionKind defined in SBML; that is, the value must be one of the following: 
+      // “uncompressed” or “deflated”.
+
+      func = new InvalidAttributeValidationFunction<SpatialPoints>(SpatialConstants.compression);
+      break;
+    }
+    
+    case SPATIAL_24005:
+    {
+      // The value of the attribute spatial:arrayData of a SpatialPoints object must be an array of 
+      // values of type double.
+
+      func = new ValidationFunction<SpatialPoints>() {
+        
+        @Override
+        public boolean check(ValidationContext ctx, SpatialPoints sp) {
+          
+          if(sp.isSetArrayData()) {
+            String arrayData = sp.getArrayData().trim();
+            StringTokenizer test = new StringTokenizer(arrayData, " ;");
+            while(test.hasMoreTokens()) {
+              try {
+                StringTools.parseSBMLDoubleStrict(test.nextToken());
+              } catch (Exception e) {
+                return false;
+              }
+            }
+            return true;
+          }
+          
+          return true;
+        }
+      };
+      break;
+    }
+    
+    case SPATIAL_24006:
+    {
+      // The attribute spatial:arrayDataLength on a SpatialPoints must have a value of data type integer.
+
+      func = new InvalidAttributeValidationFunction<SpatialPoints>(SpatialConstants.arrayDataLength);
+      break;
+    }
+    
+    case SPATIAL_24007:
+    {
+      // The attribute spatial:name on a SpatialPoints must have a value of data type string.
+
+      func = new ValidationFunction<SpatialPoints>() {
+        
+        @Override
+        public boolean check(ValidationContext ctx, SpatialPoints sp) {
+          
+          // nothing to check as Java can read any kind of string 
+          return true;
+        }
+      };
+      break;
+    }
+    
+    case SPATIAL_24008:
+    {
+      // The value of the attribute spatial:dataType of a SpatialPoints object must conform to the 
+      // syntax of SBML data type DataKind and may only take on the allowed values of DataKind 
+      // defined in SBML; that is, the value must be one of the following: “double”, “float”, “uint8”, 
+      // “uint16” or “uint32”.
+
+      func = new InvalidAttributeValidationFunction<SpatialPoints>(SpatialConstants.dataType);
+      break;
+    }
+    }    
+
+    return func;
+  }
+
+}

--- a/extensions/spatial/src/org/sbml/jsbml/xml/parsers/SpatialParser.java
+++ b/extensions/spatial/src/org/sbml/jsbml/xml/parsers/SpatialParser.java
@@ -63,6 +63,7 @@ import org.sbml.jsbml.ext.spatial.Geometry;
 import org.sbml.jsbml.ext.spatial.GeometryDefinition;
 import org.sbml.jsbml.ext.spatial.InteriorPoint;
 import org.sbml.jsbml.ext.spatial.MixedGeometry;
+import org.sbml.jsbml.ext.spatial.OrdinalMapping;
 import org.sbml.jsbml.ext.spatial.ParametricGeometry;
 import org.sbml.jsbml.ext.spatial.ParametricObject;
 import org.sbml.jsbml.ext.spatial.SampledField;
@@ -535,6 +536,22 @@ public class SpatialParser extends AbstractReaderWriter implements PackageParser
       } else if (elementName.equals(SpatialConstants.listOfParametricObjects)){
         ListOf<ParametricObject> listOfParametricObjects = pg.getListOfParametricObjects();
         return listOfParametricObjects;
+      } else {
+        logger.warn(MessageFormat.format(bundle.getString("SBMLCoreParser.unknownElement"), elementName));
+        return AbstractReaderWriter.processUnknownElement(elementName, uri, prefix, contextObject);
+      }
+    } else if (contextObject instanceof MixedGeometry) {
+      MixedGeometry mg = (MixedGeometry) contextObject;
+      
+      // keep order of elements for later validation
+      AbstractReaderWriter.storeElementsOrder(elementName, contextObject);
+      
+      if (elementName.contentEquals(SpatialConstants.listOfOrdinalMappings)) {
+        ListOf<OrdinalMapping> listOfOrdinalMappings = mg.getListOfOrdinalMappings();
+        return listOfOrdinalMappings;
+      } else if (elementName.equals(SpatialConstants.listOfGeometryDefinitions)) {
+        ListOf<GeometryDefinition> listOfGeometryDefinitions = mg.getListOfGeometryDefinitions();
+        return listOfGeometryDefinitions;
       } else {
         logger.warn(MessageFormat.format(bundle.getString("SBMLCoreParser.unknownElement"), elementName));
         return AbstractReaderWriter.processUnknownElement(elementName, uri, prefix, contextObject);

--- a/extensions/spatial/src/org/sbml/jsbml/xml/parsers/SpatialParser.java
+++ b/extensions/spatial/src/org/sbml/jsbml/xml/parsers/SpatialParser.java
@@ -670,6 +670,11 @@ public class SpatialParser extends AbstractReaderWriter implements PackageParser
         ParametricObject elem = new ParametricObject();
         pg.addParametricObject(elem);
         return elem;
+      } else if (elementName.equals(SpatialConstants.ordinalMapping)) {
+        MixedGeometry mg = (MixedGeometry) listOf.getParentSBMLObject();
+        OrdinalMapping elem = new OrdinalMapping();
+        mg.addOrdinalMapping(elem);
+        return elem;
       } else {
         logger.warn(MessageFormat.format(bundle.getString("SBMLCoreParser.unknownElement"), elementName));
         return AbstractReaderWriter.processUnknownElement(elementName, uri, prefix, contextObject);


### PR DESCRIPTION
Implement constraints for:
ParametricObject
SpatialPoints
MixedGeometry

Modified test files uploaded.

New test files for SpatialPoints have been created considering 'id' and 'name' as valid attributes, as required by the rule in the specification.
This results in 2 files not being tested successfully. 
Once it is decided whether these 2 attributes are to be included or excluded, the test files can be changed without the need of changing the source code.