### PR TITLE
Pending fixes in various classes.

### DIFF
--- a/extensions/spatial/src/org/sbml/jsbml/ext/spatial/SpatialPoints.java
+++ b/extensions/spatial/src/org/sbml/jsbml/ext/spatial/SpatialPoints.java
@@ -23,7 +23,6 @@ import java.text.MessageFormat;
 import java.util.Map;
 
 import org.apache.log4j.Logger;
-import org.sbml.jsbml.AbstractSBase;
 import org.sbml.jsbml.PropertyUndefinedError;
 import org.sbml.jsbml.util.StringTools;
 import org.sbml.jsbml.xml.parsers.AbstractReaderWriter;
@@ -33,7 +32,7 @@ import org.sbml.jsbml.xml.parsers.AbstractReaderWriter;
  * @author Piero Dalle Pezze
  * @since 1.0
  */
-public class SpatialPoints extends AbstractSBase {
+public class SpatialPoints extends AbstractSpatialNamedSBase {
 
   /**
    * A {@link Logger} for this class.
@@ -70,7 +69,6 @@ public class SpatialPoints extends AbstractSBase {
    */
   public SpatialPoints() {
     super();
-    initDefaults();
   }
 
   /**
@@ -81,6 +79,17 @@ public class SpatialPoints extends AbstractSBase {
    */
   public SpatialPoints(int level, int version) {
     super(level, version);
+  }
+  
+  /**
+   * Creates a SpatialPoints instance with a level and version.
+   * 
+   * @param id
+   * @param level SBML Level
+   * @param version SBML Version
+   */
+  public SpatialPoints(String id, int level, int version) {
+    super(id, level, version);
   }
 
 
@@ -136,14 +145,6 @@ public class SpatialPoints extends AbstractSBase {
       }
     }
     return equal;
-  }
-
-  /**
-   * Initializes the default values using the namespace.
-   */
-  public void initDefaults() {
-    packageName = SpatialConstants.shortLabel;
-    setPackageVersion(-1);
   }
 
   /**

--- a/extensions/spatial/src/org/sbml/jsbml/ext/spatial/SpatialReactionPlugin.java
+++ b/extensions/spatial/src/org/sbml/jsbml/ext/spatial/SpatialReactionPlugin.java
@@ -235,8 +235,7 @@ public class SpatialReactionPlugin extends AbstractSpatialSBasePlugin {
    */
   @Override
   public boolean readAttribute(String attributeName, String prefix, String value) {
-    boolean isAttributeRead = (super.readAttribute(attributeName, prefix, value))
-        && (SpatialConstants.shortLabel == prefix);
+    boolean isAttributeRead = (super.readAttribute(attributeName, prefix, value));
     if (!isAttributeRead) {
       isAttributeRead = true;
       if (attributeName.equals(SpatialConstants.isLocal)) {

--- a/extensions/spatial/src/org/sbml/jsbml/ext/spatial/SpatialSpeciesPlugin.java
+++ b/extensions/spatial/src/org/sbml/jsbml/ext/spatial/SpatialSpeciesPlugin.java
@@ -171,19 +171,23 @@ public class SpatialSpeciesPlugin extends AbstractSpatialSBasePlugin {
    */
   @Override
   public boolean readAttribute(String attributeName, String prefix, String value) {
-    boolean isAttributeRead = false;
-
-    if (attributeName.equals(SpatialConstants.isSpatial)) {
-      try {
-        setSpatial(StringTools.parseSBMLBooleanStrict(value));
-        isAttributeRead = true;
-      } catch (Exception e) {
-    	AbstractReaderWriter.processInvalidAttribute(attributeName, null, value, prefix, this);
-    	throw new SBMLException(MessageFormat.format(bundle.getString("COULD_NOT_READ"), value, SpatialConstants.isSpatial));
+    boolean isAttributeRead = (super.readAttribute(attributeName, prefix, value));
+    if (!isAttributeRead) {
+      isAttributeRead = true;
+      
+      if (attributeName.equals(SpatialConstants.isSpatial)) {
+        try {          
+          setSpatial(StringTools.parseSBMLBooleanStrict(value));
+        } catch (Exception e) {
+          AbstractReaderWriter.processInvalidAttribute(attributeName, null, value, prefix, this);
+          throw new SBMLException(MessageFormat.format(bundle.getString("COULD_NOT_READ"), value, SpatialConstants.isSpatial));
+        }
       }
-
+      else {
+        isAttributeRead = false;
+      }
+      
     }
-
     return isAttributeRead;
   }
 

--- a/extensions/spatial/src/org/sbml/jsbml/ext/spatial/SpatialSpeciesPlugin.java
+++ b/extensions/spatial/src/org/sbml/jsbml/ext/spatial/SpatialSpeciesPlugin.java
@@ -171,7 +171,9 @@ public class SpatialSpeciesPlugin extends AbstractSpatialSBasePlugin {
    */
   @Override
   public boolean readAttribute(String attributeName, String prefix, String value) {
-    boolean isAttributeRead = (super.readAttribute(attributeName, prefix, value));
+    
+    boolean isAttributeRead = super.readAttribute(attributeName, prefix, value);
+    
     if (!isAttributeRead) {
       isAttributeRead = true;
       


### PR DESCRIPTION
The SpatialPoints element now includes the `name` and `id` attributes. Changes have been made to extend the AbstractSpatialNamedSBase instead of AbstractSBase.
The `readAttribute()` method of `SpatialSpeciesPlugin` has been changed to make the code uniform with other classes and prevent wrong reporting of `true` or `false`.
The SpatialParser now adds a SpatialReactionPlugin at the end when no `isLocal` attribute is encountered.