### PR TITLE
Pivotal 161592279 kinetic law

### DIFF
--- a/extensions/fbc/src/org/sbml/jsbml/ext/fbc/CobraConstants.java
+++ b/extensions/fbc/src/org/sbml/jsbml/ext/fbc/CobraConstants.java
@@ -1,0 +1,70 @@
+/*
+ * ---------------------------------------------------------------------------- 
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML> 
+ * for the latest version of JSBML and more information about SBML. 
+ * 
+ * Copyright (C) 2009-2020 jointly by the following organizations: 
+ * 1. The University of Tuebingen, Germany 
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK 
+ * 3. The California Institute of Technology, Pasadena, CA, USA 
+ * 4. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it 
+ * under the terms of the GNU Lesser General Public License as published by 
+ * the Free Software Foundation. A copy of the license agreement is provided 
+ * in the file named "LICENSE.txt" included with this software distribution 
+ * and also available online as <http://sbml.org/Software/JSBML/License>. 
+ * ---------------------------------------------------------------------------- 
+ */
+package org.sbml.jsbml.ext.fbc;
+
+
+/**
+ * @author Thorsten Tiede
+ * @since 1.5
+ * @date 12 Feb 2020
+ */
+public class CobraConstants {
+  
+  /**
+   * 
+   */
+  public final static String FLUX_VALUE = "FLUX_VALUE";
+  
+  /**
+   * 
+   */
+  public final static String UPPER_BOUND = "UPPER_BOUND";
+  
+  /**
+   * 
+   */
+  public final static String LOWER_BOUND = "LOWER_BOUND";
+  
+  /**
+   * 
+   */
+  public final static String mmol_per_gDW_per_hr = "mmol_per_gDW_per_hr";
+  
+  /**
+   * 
+   */
+  public final static String DEFAULT_LOWER_BOUND_NAME = "DEFAULT_LOWER_BOUND";
+  
+  /**
+   * 
+   */
+  public final static String DEFAULT_UPPER_BOUND_NAME = "DEFAULT_UPPER_BOUND";
+  
+  /**
+   * 
+   */
+  public final static String CHARGE = "CHARGE";
+ 
+  /**
+   * 
+   */
+  public final static String FORMULA = "FORMULA";
+ 
+  
+}

--- a/extensions/fbc/src/org/sbml/jsbml/ext/fbc/CobraConstants.java
+++ b/extensions/fbc/src/org/sbml/jsbml/ext/fbc/CobraConstants.java
@@ -42,6 +42,11 @@ public class CobraConstants {
   public final static String LOWER_BOUND = "LOWER_BOUND";
   
   /**
+  *
+  */
+ public final static String OBJECTIVE_COEFFICIENT = "OBJECTIVE_COEFFICIENT";
+ 
+  /**
    * 
    */
   public final static String mmol_per_gDW_per_hr = "mmol_per_gDW_per_hr";

--- a/extensions/fbc/src/org/sbml/jsbml/ext/fbc/CobraConstants.java
+++ b/extensions/fbc/src/org/sbml/jsbml/ext/fbc/CobraConstants.java
@@ -64,6 +64,11 @@ public class CobraConstants {
   /**
    * 
    */
+  public final static String DEFAULT_GENE_ASSOCIATION_SPELLING = "DEFAULT_GENE_ASSOCIATION_SPELLING";
+  
+  /**
+   * 
+   */
   public final static String CHARGE = "CHARGE";
  
   /**

--- a/extensions/fbc/src/org/sbml/jsbml/ext/fbc/FluxBound.java
+++ b/extensions/fbc/src/org/sbml/jsbml/ext/fbc/FluxBound.java
@@ -44,6 +44,7 @@ public class FluxBound extends AbstractNamedSBase implements UniqueNamedSBase {
    * Allowable operations for flux bounds.
    * 
    * @author Andreas Dr&auml;ger
+   * @author Thorsten Tiede
    * @since 1.0
    * @deprecated Only defined in FBC version 1.
    */
@@ -58,9 +59,17 @@ public class FluxBound extends AbstractNamedSBase implements UniqueNamedSBase {
      */
     GREATER_EQUAL("greaterEqual"),
     /**
+     * greater
+     */
+    GREATER("greater"),
+    /**
      * lessEqual
      */
-    LESS_EQUAL("lessEqual");
+    LESS_EQUAL("lessEqual"),
+    /**
+     * less
+     */
+    LESS("less");
 
     /**
      * @param value

--- a/extensions/fbc/src/org/sbml/jsbml/ext/fbc/converters/CobraToFbcV1Converter.java
+++ b/extensions/fbc/src/org/sbml/jsbml/ext/fbc/converters/CobraToFbcV1Converter.java
@@ -140,22 +140,23 @@ public class CobraToFbcV1Converter implements SBMLConverter {
         if (reaction.isSetFast() == false) {
           reaction.setFast(false);
         }
-        // get lower and upper flux bound from the kinetic law, set them in the list of flux bounds, and delete the kinetic law
-        if (reaction.getKineticLaw().getParameter("LOWER_BOUND").isSetValue()) {
-          FluxBound fluxBoundLo = new FluxBound();
-          fluxBoundLo.setReaction(reaction.getId());
-          fluxBoundLo.setOperation(FluxBound.Operation.GREATER_EQUAL);
-          fluxBoundLo.setValue(reaction.getKineticLaw().getParameter("LOWER_BOUND").getValue());
-          fbcModelPlugin.addFluxBound(fluxBoundLo);
-        }
-        if (reaction.getKineticLaw().getParameter("UPPER_BOUND").isSetValue()) {
-          FluxBound fluxBoundUp = new FluxBound();
-          fluxBoundUp.setReaction(reaction.getId());
-          fluxBoundUp.setOperation(FluxBound.Operation.LESS_EQUAL);
-          fluxBoundUp.setValue(reaction.getKineticLaw().getParameter("UPPER_BOUND").getValue());
-          fbcModelPlugin.addFluxBound(fluxBoundUp);
-        }
         if (reaction.isSetKineticLaw()) {
+          // get lower and upper flux bound from the kinetic law, set them in the list of flux bounds, and delete the kinetic law
+          if (reaction.getKineticLaw().getParameter("LOWER_BOUND") != null && reaction.getKineticLaw().getParameter("LOWER_BOUND").isSetValue()) {
+            FluxBound fluxBoundLo = new FluxBound();
+            fluxBoundLo.setReaction(reaction.getId());
+            fluxBoundLo.setOperation(FluxBound.Operation.GREATER_EQUAL);
+            fluxBoundLo.setValue(reaction.getKineticLaw().getParameter("LOWER_BOUND").getValue());
+            fbcModelPlugin.addFluxBound(fluxBoundLo);
+          }
+          if (reaction.getKineticLaw().getParameter("UPPER_BOUND") != null && reaction.getKineticLaw().getParameter("UPPER_BOUND").isSetValue()) {
+            FluxBound fluxBoundUp = new FluxBound();
+            fluxBoundUp.setReaction(reaction.getId());
+            fluxBoundUp.setOperation(FluxBound.Operation.LESS_EQUAL);
+            fluxBoundUp.setValue(reaction.getKineticLaw().getParameter("UPPER_BOUND").getValue());
+            fbcModelPlugin.addFluxBound(fluxBoundUp);
+          }
+          // then unset the KineticLaw of the reaction
           reaction.unsetKineticLaw();
         }
         // set attribute constant for products and reactants

--- a/extensions/fbc/src/org/sbml/jsbml/ext/fbc/converters/FbcV1ToCobraConverter.java
+++ b/extensions/fbc/src/org/sbml/jsbml/ext/fbc/converters/FbcV1ToCobraConverter.java
@@ -135,12 +135,12 @@ public class FbcV1ToCobraConverter implements SBMLConverter {
     LocalParameter lowerBoundParameter = kineticLaw.getLocalParameter(CobraConstants.LOWER_BOUND);
     LocalParameter upperBoundParameter = kineticLaw.getLocalParameter(CobraConstants.UPPER_BOUND);
     
-    if (operation.equals(FluxBound.Operation.LESS_EQUAL) || operation.equals(FluxBound.Operation.EQUAL)) 
+    if (operation.equals(FluxBound.Operation.LESS) || operation.equals(FluxBound.Operation.LESS_EQUAL) || operation.equals(FluxBound.Operation.EQUAL)) 
     {
       upperBoundParameter.setValue(bound.getValue());
     }
     
-    if (operation.equals(FluxBound.Operation.GREATER_EQUAL) || operation.equals(FluxBound.Operation.EQUAL)) 
+    if (operation.equals(FluxBound.Operation.GREATER) || operation.equals(FluxBound.Operation.GREATER_EQUAL) || operation.equals(FluxBound.Operation.EQUAL)) 
     {
       lowerBoundParameter.setValue(bound.getValue());
     }

--- a/extensions/fbc/src/org/sbml/jsbml/ext/fbc/converters/FbcV2ToCobraConverter.java
+++ b/extensions/fbc/src/org/sbml/jsbml/ext/fbc/converters/FbcV2ToCobraConverter.java
@@ -34,6 +34,9 @@ import org.sbml.jsbml.util.converters.SBMLConverter;
  */
 public class FbcV2ToCobraConverter implements SBMLConverter {
 
+  // Options for FbcV2ToFbcV1Converter
+  String defaultGeneAssociationSpelling = null;
+  
   // Options for FbcV1ToCobraConverter
   Double defaultLowerBound = null;
   Double defaultUpperBound = null;
@@ -45,6 +48,9 @@ public class FbcV2ToCobraConverter implements SBMLConverter {
   public SBMLDocument convert(SBMLDocument sbmlDocument) throws SBMLException {
    // convert SBML FBCV2 file to SBML FBCV1
     FbcV2ToFbcV1Converter fbcV2ToFbcV1Converter = new FbcV2ToFbcV1Converter();
+    if (this.defaultGeneAssociationSpelling != null) {
+      fbcV2ToFbcV1Converter.setOption(CobraConstants.DEFAULT_GENE_ASSOCIATION_SPELLING, defaultGeneAssociationSpelling);
+    }
     sbmlDocument = fbcV2ToFbcV1Converter.convert(sbmlDocument);
    // convert SBML FBCV1 file to old COBRA SBML
     FbcV1ToCobraConverter fbcV1ToCobraConverter = new FbcV1ToCobraConverter();
@@ -81,6 +87,8 @@ public class FbcV2ToCobraConverter implements SBMLConverter {
         this.defaultUpperBound = null;
       }
     }
-    
+    if (name.equals(CobraConstants.DEFAULT_GENE_ASSOCIATION_SPELLING)) {
+      this.defaultGeneAssociationSpelling = value;
+    }
   }
 }

--- a/extensions/fbc/src/org/sbml/jsbml/ext/fbc/converters/FbcV2ToCobraConverter.java
+++ b/extensions/fbc/src/org/sbml/jsbml/ext/fbc/converters/FbcV2ToCobraConverter.java
@@ -28,10 +28,15 @@ import org.sbml.jsbml.util.converters.SBMLConverter;
  * 
  * @author Thomas Hamm
  * @author Nicolas Rodriguez
+ * @author Thorsten Tiede
  * @since 1.3
  */
 public class FbcV2ToCobraConverter implements SBMLConverter {
 
+  // Options for FbcV1ToCobraConverter
+  Double defaultLowerFluxBound = null;
+  Double defaultUpperFluxBound = null;
+  
   /* (non-Javadoc)
    * @see org.sbml.jsbml.util.converters.SBMLConverter#convert(org.sbml.jsbml.SBMLDocument)
    */
@@ -42,6 +47,14 @@ public class FbcV2ToCobraConverter implements SBMLConverter {
     sbmlDocument = fbcV2ToFbcV1Converter.convert(sbmlDocument);
    // convert SBML FBCV1 file to old COBRA SBML
     FbcV1ToCobraConverter fbcV1ToCobraConverter = new FbcV1ToCobraConverter();
+    if (this.defaultLowerFluxBound != null)
+    {
+      fbcV1ToCobraConverter.setOption("defaultLowerFluxBound", this.defaultLowerFluxBound.toString());
+    }
+    if (this.defaultUpperFluxBound != null)
+    {
+      fbcV1ToCobraConverter.setOption("defaultUpperFluxBound", this.defaultUpperFluxBound.toString());
+    }
     sbmlDocument = fbcV1ToCobraConverter.convert(sbmlDocument);  
     
     return sbmlDocument;
@@ -52,7 +65,21 @@ public class FbcV2ToCobraConverter implements SBMLConverter {
    */
   @Override
   public void setOption(String name, String value) {
-    // TODO Auto-generated method stub
+    if (value == null) return;
+    if (name.equals("defaultLowerFluxBound")) {
+      try {
+        this.defaultLowerFluxBound = Double.valueOf(value);
+      } catch (NumberFormatException e) {
+        this.defaultLowerFluxBound = null;
+      }
+    }
+    if (name.equals("defaultUpperFluxBound")) {
+      try {
+        this.defaultUpperFluxBound = Double.valueOf(value);
+      } catch (NumberFormatException e) {
+        this.defaultUpperFluxBound = null;
+      }
+    }
     
   }
 }

--- a/extensions/fbc/src/org/sbml/jsbml/ext/fbc/converters/FbcV2ToCobraConverter.java
+++ b/extensions/fbc/src/org/sbml/jsbml/ext/fbc/converters/FbcV2ToCobraConverter.java
@@ -21,6 +21,7 @@ package org.sbml.jsbml.ext.fbc.converters;
 
 import org.sbml.jsbml.SBMLDocument;
 import org.sbml.jsbml.SBMLException;
+import org.sbml.jsbml.ext.fbc.CobraConstants;
 import org.sbml.jsbml.util.converters.SBMLConverter;
 
 /**
@@ -34,8 +35,8 @@ import org.sbml.jsbml.util.converters.SBMLConverter;
 public class FbcV2ToCobraConverter implements SBMLConverter {
 
   // Options for FbcV1ToCobraConverter
-  Double defaultLowerFluxBound = null;
-  Double defaultUpperFluxBound = null;
+  Double defaultLowerBound = null;
+  Double defaultUpperBound = null;
   
   /* (non-Javadoc)
    * @see org.sbml.jsbml.util.converters.SBMLConverter#convert(org.sbml.jsbml.SBMLDocument)
@@ -47,13 +48,13 @@ public class FbcV2ToCobraConverter implements SBMLConverter {
     sbmlDocument = fbcV2ToFbcV1Converter.convert(sbmlDocument);
    // convert SBML FBCV1 file to old COBRA SBML
     FbcV1ToCobraConverter fbcV1ToCobraConverter = new FbcV1ToCobraConverter();
-    if (this.defaultLowerFluxBound != null)
+    if (this.defaultLowerBound != null)
     {
-      fbcV1ToCobraConverter.setOption("defaultLowerFluxBound", this.defaultLowerFluxBound.toString());
+      fbcV1ToCobraConverter.setOption(CobraConstants.DEFAULT_LOWER_BOUND_NAME, this.defaultLowerBound.toString());
     }
-    if (this.defaultUpperFluxBound != null)
+    if (this.defaultUpperBound != null)
     {
-      fbcV1ToCobraConverter.setOption("defaultUpperFluxBound", this.defaultUpperFluxBound.toString());
+      fbcV1ToCobraConverter.setOption(CobraConstants.DEFAULT_UPPER_BOUND_NAME, this.defaultUpperBound.toString());
     }
     sbmlDocument = fbcV1ToCobraConverter.convert(sbmlDocument);  
     
@@ -66,18 +67,18 @@ public class FbcV2ToCobraConverter implements SBMLConverter {
   @Override
   public void setOption(String name, String value) {
     if (value == null) return;
-    if (name.equals("defaultLowerFluxBound")) {
+    if (name.equals(CobraConstants.DEFAULT_LOWER_BOUND_NAME)) {
       try {
-        this.defaultLowerFluxBound = Double.valueOf(value);
+        this.defaultLowerBound = Double.valueOf(value);
       } catch (NumberFormatException e) {
-        this.defaultLowerFluxBound = null;
+        this.defaultLowerBound = null;
       }
     }
-    if (name.equals("defaultUpperFluxBound")) {
+    if (name.equals(CobraConstants.DEFAULT_UPPER_BOUND_NAME)) {
       try {
-        this.defaultUpperFluxBound = Double.valueOf(value);
+        this.defaultUpperBound = Double.valueOf(value);
       } catch (NumberFormatException e) {
-        this.defaultUpperFluxBound = null;
+        this.defaultUpperBound = null;
       }
     }
     

--- a/extensions/fbc/src/org/sbml/jsbml/ext/fbc/converters/FbcV2ToFbcV1Converter.java
+++ b/extensions/fbc/src/org/sbml/jsbml/ext/fbc/converters/FbcV2ToFbcV1Converter.java
@@ -37,6 +37,7 @@ import org.sbml.jsbml.ext.AbstractSBasePlugin;
 import org.sbml.jsbml.ext.SBasePlugin;
 import org.sbml.jsbml.ext.fbc.And;
 import org.sbml.jsbml.ext.fbc.Association;
+import org.sbml.jsbml.ext.fbc.CobraConstants;
 import org.sbml.jsbml.ext.fbc.FBCConstants;
 import org.sbml.jsbml.ext.fbc.FBCModelPlugin;
 import org.sbml.jsbml.ext.fbc.FBCReactionPlugin;
@@ -61,7 +62,7 @@ import org.sbml.jsbml.util.filters.Filter;
 @SuppressWarnings("deprecation")
 public class FbcV2ToFbcV1Converter implements SBMLConverter {
 
-  String userKey = null;
+  String defaultGeneAssociationSpelling = null;
   
   /* (non-Javadoc)
    * @see org.sbml.jsbml.util.converters.SBMLConverter#convert(org.sbml.jsbml.SBMLDocument)
@@ -170,9 +171,9 @@ public class FbcV2ToFbcV1Converter implements SBMLConverter {
         // if there is an old gene association entry in the notes of this reaction it will be deleted
         Properties pElementsReactionNotes = new Properties();
         Pattern p;
-        if (userKey != null) {
-        // userKey is a way of writing “gene association” specified by the user    
-          p = Pattern.compile(userKey);
+        if (defaultGeneAssociationSpelling != null) {
+        // defaultGeneAssociationSpelling is a way of writing “gene association” specified by the user    
+          p = Pattern.compile(defaultGeneAssociationSpelling);
         } else {
         // regular expression to match the most common ways of writing “gene association”  
           p = Pattern.compile("(?i)gene[\\-_ ]*association");
@@ -210,7 +211,12 @@ public class FbcV2ToFbcV1Converter implements SBMLConverter {
    */
   @Override
   public void setOption(String name, String value) {
-    this.userKey = value;
+    if (name == null) {
+      return;
+    }
+    if (name.equals(CobraConstants.DEFAULT_GENE_ASSOCIATION_SPELLING)) {
+      this.defaultGeneAssociationSpelling = value;
+    }
   }
   
   private ASTNode processAssociation(Association association, FBCModelPlugin fbcModelPlugin) {

--- a/extensions/fbc/test/org/sbml/jsbml/ext/fbc/test/FbcJUnitTests.java
+++ b/extensions/fbc/test/org/sbml/jsbml/ext/fbc/test/FbcJUnitTests.java
@@ -1,0 +1,11 @@
+package org.sbml.jsbml.ext.fbc.test;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+@RunWith(value=Suite.class)
+@SuiteClasses(value={FbcV2ToCobraConverterTest.class})
+public class FbcJUnitTests {
+
+}

--- a/extensions/fbc/test/org/sbml/jsbml/ext/fbc/test/FbcJUnitTests.java
+++ b/extensions/fbc/test/org/sbml/jsbml/ext/fbc/test/FbcJUnitTests.java
@@ -1,9 +1,35 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ *
+ * Copyright (C) 2009-2020 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The University of California, San Diego, La Jolla, CA, USA
+ * 5. The Babraham Institute, Cambridge, UK
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
 package org.sbml.jsbml.ext.fbc.test;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+
+/**
+ * Suite of tests for the fbc package.
+ * 
+ * @author Thorsten Tiede
+ * @since 1.5
+ */
 @RunWith(value=Suite.class)
 @SuiteClasses(value={FbcV2ToCobraConverterTest.class})
 public class FbcJUnitTests {

--- a/extensions/fbc/test/org/sbml/jsbml/ext/fbc/test/FbcV2ToCobraConverterTest.java
+++ b/extensions/fbc/test/org/sbml/jsbml/ext/fbc/test/FbcV2ToCobraConverterTest.java
@@ -1,0 +1,448 @@
+/*
+ * ---------------------------------------------------------------------------- 
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML> 
+ * for the latest version of JSBML and more information about SBML. 
+ * 
+ * Copyright (C) 2009-2020 jointly by the following organizations: 
+ * 1. The University of Tuebingen, Germany 
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK 
+ * 3. The California Institute of Technology, Pasadena, CA, USA 
+ * 4. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it 
+ * under the terms of the GNU Lesser General Public License as published by 
+ * the Free Software Foundation. A copy of the license agreement is provided 
+ * in the file named "LICENSE.txt" included with this software distribution 
+ * and also available online as <http://sbml.org/Software/JSBML/License>. 
+ * ---------------------------------------------------------------------------- 
+ */
+package org.sbml.jsbml.ext.fbc.test;
+
+import static org.junit.Assert.*;
+import static org.sbml.jsbml.util.ModelBuilder.buildUnit;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.sbml.jsbml.ASTNode;
+import org.sbml.jsbml.Compartment;
+import org.sbml.jsbml.KineticLaw;
+import org.sbml.jsbml.LocalParameter;
+import org.sbml.jsbml.Model;
+import org.sbml.jsbml.Parameter;
+import org.sbml.jsbml.Reaction;
+import org.sbml.jsbml.SBMLDocument;
+import org.sbml.jsbml.SBMLException;
+import org.sbml.jsbml.Species;
+import org.sbml.jsbml.SpeciesReference;
+import org.sbml.jsbml.TidySBMLWriter;
+import org.sbml.jsbml.Unit;
+import org.sbml.jsbml.UnitDefinition;
+import org.sbml.jsbml.ext.fbc.CobraConstants;
+import org.sbml.jsbml.ext.fbc.FBCConstants;
+import org.sbml.jsbml.ext.fbc.FBCModelPlugin;
+import org.sbml.jsbml.ext.fbc.FBCReactionPlugin;
+import org.sbml.jsbml.ext.fbc.converters.FbcV1ToCobraConverter;
+import org.sbml.jsbml.ext.fbc.converters.FbcV2ToCobraConverter;
+import org.sbml.jsbml.ext.fbc.converters.FbcV2ToFbcV1Converter;
+import org.sbml.jsbml.util.ModelBuilder;
+
+
+/**
+ * @author Thorsten Tiede
+ * @since 1.5
+ * @date 12 Feb 2020
+ */
+public class FbcV2ToCobraConverterTest {
+
+  FbcV2ToFbcV1Converter fbcV2ToFbcV1Converter;
+  FbcV1ToCobraConverter fbcV1ToCobraConverter;
+  FbcV2ToCobraConverter fbcV2ToCobraConverter;
+  SBMLDocument doc;
+  
+  
+  
+  Double lowerFluxBound = 1d;
+  Double upperFluxBound = 100d;
+  String reactionId = "rnR00658";
+  Double fluxValueValue = 0d;
+  String defaultUpperBound = "9999";
+  String defaultLowerBound = "0.1";
+  
+  private SBMLDocument createDoc(boolean hasFbc, boolean hasUpper, boolean hasLower) {
+    int level = 3, version = 1;
+
+    ModelBuilder builder = new ModelBuilder(level, version);
+
+    Model model = builder.buildModel("fbcV1ToCobraConversion_test", "Simple test model for FBC version 2 conversion to L2 with Cobra Annotation");
+    FBCModelPlugin modelPlugin = (FBCModelPlugin) model.getPlugin(FBCConstants.shortLabel);
+    modelPlugin.setStrict(true);
+    
+    UnitDefinition ud = builder.buildUnitDefinition("volume", "Volume units");
+    buildUnit(ud, 1d, -3, Unit.Kind.LITRE, 1d);
+    model.setVolumeUnits(ud);
+
+    ud = builder.buildUnitDefinition("substance", "Substance units");
+    buildUnit(ud, 1d, -3, Unit.Kind.MOLE, 1d);
+    model.setSubstanceUnits(ud);
+    
+    ud = builder.buildUnitDefinition("mmol_per_gDW_per_hr", "mmol_per_gDW_per_hr");
+    buildUnit(ud, 1d, -3, Unit.Kind.MOLE, 1d);
+    buildUnit(ud, 1d, 0, Unit.Kind.GRAM, -1d);
+    buildUnit(ud, 3600, 0, Unit.Kind.SECOND, -1d);
+
+    Compartment compartment = builder.buildCompartment("default", true, "default compartment", 3d, 1d, model.getVolumeUnits());
+     
+    Species reactant = builder.buildSpecies("C3H7O7P", "C3H7O7P", compartment, true, false, false, 1d, model.getSubstanceUnits());
+    Species product1 = builder.buildSpecies("C3H5O6P", "C3H5O6P", compartment, true, false, false, 1d, model.getSubstanceUnits());
+    Species product2 = builder.buildSpecies("H2O", "H2O", compartment, true, false, false, 1d, model.getSubstanceUnits());
+    
+    Reaction reaction = builder.buildReaction(reactionId, "2-phospho-D-glycerate hydro-lyase (phosphoenolpyruvate-forming)", compartment, false, false);
+    reaction.addReactant(new SpeciesReference(reactant));
+    reaction.addProduct(new SpeciesReference(product1));
+    reaction.addProduct(new SpeciesReference(product2));
+    reaction.setReversible(true);
+    if(hasFbc) {
+      FBCReactionPlugin reactionPlugin = (FBCReactionPlugin) reaction.getPlugin(FBCConstants.shortLabel);
+      if (hasLower) {
+        Parameter lowerFluxBoundParameter = builder.buildParameter("lfb","lowerFluxBound", 1d, true, "mmol_per_gDW_per_hr");
+        reactionPlugin.setLowerFluxBound(lowerFluxBoundParameter);
+      }
+      if(hasUpper) {
+        Parameter upperFluxBoundParameter = builder.buildParameter("ufb","upperFluxBound", 100d, true, "mmol_per_gDW_per_hr");
+        reactionPlugin.setUpperFluxBound(upperFluxBoundParameter);
+      }
+    }
+    return builder.getSBMLDocument();
+  }
+  
+  
+  /**
+   * @throws java.lang.Exception
+   */
+  @Before
+  public void setUp() throws Exception {
+    doc = createDoc(true, true, true);
+    fbcV2ToFbcV1Converter = new FbcV2ToFbcV1Converter();
+    fbcV1ToCobraConverter = new FbcV1ToCobraConverter();
+    fbcV2ToCobraConverter = new FbcV2ToCobraConverter();
+  }
+
+
+  @Test
+  public void test() {
+    try {
+      
+      // reuse variables
+      KineticLaw kineticLaw;
+      ASTNode mathNode;
+      LocalParameter fluxValueParameter;
+      LocalParameter lowerBoundParameter;
+      LocalParameter upperBoundParameter;
+      // fullDoc
+      doc = fbcV2ToFbcV1Converter.convert(doc);
+      doc = fbcV1ToCobraConverter.convert(doc);
+      
+      assertNotNull(doc);
+      kineticLaw = doc.getModel().getListOfReactions().get(reactionId).getKineticLaw();
+      assertNotNull(kineticLaw);
+      mathNode = kineticLaw.getMath();
+      assertNotNull(mathNode);
+      assertEquals(mathNode.getName(), CobraConstants.FLUX_VALUE);
+      fluxValueParameter = kineticLaw.getLocalParameter(CobraConstants.FLUX_VALUE);
+      assertNotNull(fluxValueParameter);
+      assertEquals(fluxValueParameter.getUnits(), CobraConstants.mmol_per_gDW_per_hr);
+      assertEquals((Double)fluxValueParameter.getValue(), fluxValueValue);
+      lowerBoundParameter = kineticLaw.getLocalParameter(CobraConstants.LOWER_BOUND);
+      assertNotNull(lowerBoundParameter);
+      assertEquals((Double) lowerBoundParameter.getValue(), lowerFluxBound);
+      upperBoundParameter = kineticLaw.getLocalParameter(CobraConstants.UPPER_BOUND);
+      assertNotNull(upperBoundParameter);
+      assertEquals((Double) upperBoundParameter.getValue(), upperFluxBound);
+      
+      // complete doc, give default that should be ignored
+      fbcV2ToFbcV1Converter = new FbcV2ToFbcV1Converter();
+      fbcV1ToCobraConverter = new FbcV1ToCobraConverter();
+      doc = null;
+      assertNull(doc);
+      doc = createDoc(true, true, true);
+      assertNotNull(doc);
+      doc = fbcV2ToFbcV1Converter.convert(doc);
+      fbcV1ToCobraConverter.setOption(CobraConstants.DEFAULT_LOWER_BOUND_NAME, defaultLowerBound);
+      fbcV1ToCobraConverter.setOption(CobraConstants.DEFAULT_UPPER_BOUND_NAME, defaultUpperBound);
+      doc = fbcV1ToCobraConverter.convert(doc);
+      
+      assertNotNull(doc);
+      kineticLaw = doc.getModel().getListOfReactions().get(reactionId).getKineticLaw();
+      assertNotNull(kineticLaw);
+      mathNode = kineticLaw.getMath();
+      assertNotNull(mathNode);
+      assertEquals(mathNode.getName(), CobraConstants.FLUX_VALUE);
+      fluxValueParameter = kineticLaw.getLocalParameter(CobraConstants.FLUX_VALUE);
+      assertNotNull(fluxValueParameter);
+      assertEquals(fluxValueParameter.getUnits(), CobraConstants.mmol_per_gDW_per_hr);
+      assertEquals((Double)fluxValueParameter.getValue(), fluxValueValue);
+      lowerBoundParameter = kineticLaw.getLocalParameter(CobraConstants.LOWER_BOUND);
+      assertNotNull(lowerBoundParameter);
+      assertEquals((Double) lowerBoundParameter.getValue(), lowerFluxBound);
+      upperBoundParameter = kineticLaw.getLocalParameter(CobraConstants.UPPER_BOUND);
+      assertNotNull(upperBoundParameter);
+      assertEquals((Double) upperBoundParameter.getValue(), upperFluxBound);
+      
+      
+      // incomplete Doc no upper
+      fbcV2ToFbcV1Converter = new FbcV2ToFbcV1Converter();
+      fbcV1ToCobraConverter = new FbcV1ToCobraConverter();
+      doc = null;
+      assertNull(doc);
+      doc = createDoc(true, false, true);
+      assertNotNull(doc);
+      doc = fbcV2ToFbcV1Converter.convert(doc);
+      doc = fbcV1ToCobraConverter.convert(doc);
+      
+      assertNotNull(doc);
+      kineticLaw = doc.getModel().getListOfReactions().get(reactionId).getKineticLaw();
+      assertNotNull(kineticLaw);
+      mathNode = kineticLaw.getMath();
+      assertNotNull(mathNode);
+      assertEquals(mathNode.getName(), CobraConstants.FLUX_VALUE);
+      fluxValueParameter = kineticLaw.getLocalParameter(CobraConstants.FLUX_VALUE);
+      assertNotNull(fluxValueParameter);
+      assertEquals(fluxValueParameter.getUnits(), CobraConstants.mmol_per_gDW_per_hr);
+      assertEquals((Double)fluxValueParameter.getValue(), fluxValueValue);
+      lowerBoundParameter = kineticLaw.getLocalParameter(CobraConstants.LOWER_BOUND);
+      assertNotNull(lowerBoundParameter);
+      assertEquals((Double) lowerBoundParameter.getValue(), lowerFluxBound);
+      upperBoundParameter = kineticLaw.getLocalParameter(CobraConstants.UPPER_BOUND);
+      assertNotNull(upperBoundParameter);
+      assertEquals((Double) upperBoundParameter.getValue(), Double.valueOf(Double.POSITIVE_INFINITY));
+      
+      // incomplete Doc no upper but use give default value
+      fbcV2ToFbcV1Converter = new FbcV2ToFbcV1Converter();
+      fbcV1ToCobraConverter = new FbcV1ToCobraConverter();
+      doc = null;
+      assertNull(doc);
+      doc = createDoc(true, false, true);
+      assertNotNull(doc);
+      doc = fbcV2ToFbcV1Converter.convert(doc);
+      fbcV1ToCobraConverter.setOption(CobraConstants.DEFAULT_UPPER_BOUND_NAME, defaultUpperBound);
+      doc = fbcV1ToCobraConverter.convert(doc);
+      
+      assertNotNull(doc);
+      kineticLaw = doc.getModel().getListOfReactions().get(reactionId).getKineticLaw();
+      assertNotNull(kineticLaw);
+      mathNode = kineticLaw.getMath();
+      assertNotNull(mathNode);
+      assertEquals(mathNode.getName(), CobraConstants.FLUX_VALUE);
+      fluxValueParameter = kineticLaw.getLocalParameter(CobraConstants.FLUX_VALUE);
+      assertNotNull(fluxValueParameter);
+      assertEquals(fluxValueParameter.getUnits(), CobraConstants.mmol_per_gDW_per_hr);
+      assertEquals((Double)fluxValueParameter.getValue(), fluxValueValue);
+      lowerBoundParameter = kineticLaw.getLocalParameter(CobraConstants.LOWER_BOUND);
+      assertNotNull(lowerBoundParameter);
+      assertEquals((Double) lowerBoundParameter.getValue(), lowerFluxBound);
+      upperBoundParameter = kineticLaw.getLocalParameter(CobraConstants.UPPER_BOUND);
+      assertNotNull(upperBoundParameter);
+      assertEquals((Double) upperBoundParameter.getValue(), Double.valueOf(defaultUpperBound));
+      
+      // incomplete Doc no lower
+      fbcV2ToFbcV1Converter = new FbcV2ToFbcV1Converter();
+      fbcV1ToCobraConverter = new FbcV1ToCobraConverter();
+      doc = null;
+      assertNull(doc);
+      doc = createDoc(true, true, false);
+      assertNotNull(doc);
+      doc = fbcV2ToFbcV1Converter.convert(doc);
+      doc = fbcV1ToCobraConverter.convert(doc);
+      
+      assertNotNull(doc);
+      kineticLaw = doc.getModel().getListOfReactions().get(reactionId).getKineticLaw();
+      assertNotNull(kineticLaw);
+      mathNode = kineticLaw.getMath();
+      assertNotNull(mathNode);
+      assertEquals(mathNode.getName(), CobraConstants.FLUX_VALUE);
+      fluxValueParameter = kineticLaw.getLocalParameter(CobraConstants.FLUX_VALUE);
+      assertNotNull(fluxValueParameter);
+      assertEquals(fluxValueParameter.getUnits(), CobraConstants.mmol_per_gDW_per_hr);
+      assertEquals((Double)fluxValueParameter.getValue(), fluxValueValue);
+      lowerBoundParameter = kineticLaw.getLocalParameter(CobraConstants.LOWER_BOUND);
+      assertNotNull(lowerBoundParameter);
+      assertEquals((Double) lowerBoundParameter.getValue(), Double.valueOf(Double.NEGATIVE_INFINITY));
+      upperBoundParameter = kineticLaw.getLocalParameter(CobraConstants.UPPER_BOUND);
+      assertNotNull(upperBoundParameter);
+      assertEquals((Double) upperBoundParameter.getValue(), upperFluxBound);
+      
+      // incomplete Doc no lower but use give default value
+      fbcV2ToFbcV1Converter = new FbcV2ToFbcV1Converter();
+      fbcV1ToCobraConverter = new FbcV1ToCobraConverter();
+      doc = null;
+      assertNull(doc);
+      doc = createDoc(true, true, false);
+      assertNotNull(doc);
+      doc = fbcV2ToFbcV1Converter.convert(doc);
+      fbcV1ToCobraConverter.setOption(CobraConstants.DEFAULT_LOWER_BOUND_NAME, defaultLowerBound);
+      doc = fbcV1ToCobraConverter.convert(doc);
+      
+      assertNotNull(doc);
+      kineticLaw = doc.getModel().getListOfReactions().get(reactionId).getKineticLaw();
+      assertNotNull(kineticLaw);
+      mathNode = kineticLaw.getMath();
+      assertNotNull(mathNode);
+      assertEquals(mathNode.getName(), CobraConstants.FLUX_VALUE);
+      fluxValueParameter = kineticLaw.getLocalParameter(CobraConstants.FLUX_VALUE);
+      assertNotNull(fluxValueParameter);
+      assertEquals(fluxValueParameter.getUnits(), CobraConstants.mmol_per_gDW_per_hr);
+      assertEquals((Double)fluxValueParameter.getValue(), fluxValueValue);
+      lowerBoundParameter = kineticLaw.getLocalParameter(CobraConstants.LOWER_BOUND);
+      assertNotNull(lowerBoundParameter);
+      assertEquals((Double) lowerBoundParameter.getValue(), Double.valueOf(defaultLowerBound));
+      upperBoundParameter = kineticLaw.getLocalParameter(CobraConstants.UPPER_BOUND);
+      assertNotNull(upperBoundParameter);
+      assertEquals((Double) upperBoundParameter.getValue(), upperFluxBound);
+      
+      // incomplete Doc no lower and no upper
+      fbcV2ToFbcV1Converter = new FbcV2ToFbcV1Converter();
+      fbcV1ToCobraConverter = new FbcV1ToCobraConverter();
+      doc = null;
+      assertNull(doc);
+      doc = createDoc(true, false, false);
+      assertNotNull(doc);
+      doc = fbcV2ToFbcV1Converter.convert(doc);
+      doc = fbcV1ToCobraConverter.convert(doc);
+      
+      assertNotNull(doc);
+      kineticLaw = doc.getModel().getListOfReactions().get(reactionId).getKineticLaw();
+      assertNotNull(kineticLaw);
+      mathNode = kineticLaw.getMath();
+      assertNotNull(mathNode);
+      assertEquals(mathNode.getName(), CobraConstants.FLUX_VALUE);
+      fluxValueParameter = kineticLaw.getLocalParameter(CobraConstants.FLUX_VALUE);
+      assertNotNull(fluxValueParameter);
+      assertEquals(fluxValueParameter.getUnits(), CobraConstants.mmol_per_gDW_per_hr);
+      assertEquals((Double)fluxValueParameter.getValue(), fluxValueValue);
+      lowerBoundParameter = kineticLaw.getLocalParameter(CobraConstants.LOWER_BOUND);
+      assertNotNull(lowerBoundParameter);
+      assertEquals((Double) lowerBoundParameter.getValue(), Double.valueOf(Double.NEGATIVE_INFINITY));
+      upperBoundParameter = kineticLaw.getLocalParameter(CobraConstants.UPPER_BOUND);
+      assertNotNull(upperBoundParameter);
+      assertEquals((Double) upperBoundParameter.getValue(), Double.valueOf(Double.POSITIVE_INFINITY));
+      
+      // incomplete Doc no lower and no upper but use give default value
+      fbcV2ToFbcV1Converter = new FbcV2ToFbcV1Converter();
+      fbcV1ToCobraConverter = new FbcV1ToCobraConverter();
+      doc = null;
+      assertNull(doc);
+      doc = createDoc(true, false, false);
+      assertNotNull(doc);
+      doc = fbcV2ToFbcV1Converter.convert(doc);
+      fbcV1ToCobraConverter.setOption(CobraConstants.DEFAULT_LOWER_BOUND_NAME, defaultLowerBound);
+      fbcV1ToCobraConverter.setOption(CobraConstants.DEFAULT_UPPER_BOUND_NAME, defaultUpperBound);
+      doc = fbcV1ToCobraConverter.convert(doc);
+      
+      assertNotNull(doc);
+      kineticLaw = doc.getModel().getListOfReactions().get(reactionId).getKineticLaw();
+      assertNotNull(kineticLaw);
+      mathNode = kineticLaw.getMath();
+      assertNotNull(mathNode);
+      assertEquals(mathNode.getName(), CobraConstants.FLUX_VALUE);
+      fluxValueParameter = kineticLaw.getLocalParameter(CobraConstants.FLUX_VALUE);
+      assertNotNull(fluxValueParameter);
+      assertEquals(fluxValueParameter.getUnits(), CobraConstants.mmol_per_gDW_per_hr);
+      assertEquals((Double)fluxValueParameter.getValue(), fluxValueValue);
+      lowerBoundParameter = kineticLaw.getLocalParameter(CobraConstants.LOWER_BOUND);
+      assertNotNull(lowerBoundParameter);
+      assertEquals((Double) lowerBoundParameter.getValue(), Double.valueOf(defaultLowerBound));
+      upperBoundParameter = kineticLaw.getLocalParameter(CobraConstants.UPPER_BOUND);
+      assertNotNull(upperBoundParameter);
+      assertEquals((Double) upperBoundParameter.getValue(), Double.valueOf(defaultUpperBound));
+      
+      // incomplete Doc no kineticLaw 
+      fbcV2ToFbcV1Converter = new FbcV2ToFbcV1Converter();
+      fbcV1ToCobraConverter = new FbcV1ToCobraConverter();
+      doc = null;
+      assertNull(doc);
+      doc = createDoc(false, false, false);
+      assertNotNull(doc);
+      doc = fbcV2ToFbcV1Converter.convert(doc);
+      doc = fbcV1ToCobraConverter.convert(doc);
+       
+      assertNotNull(doc);
+      kineticLaw = doc.getModel().getListOfReactions().get(reactionId).getKineticLaw();
+      assertNotNull(kineticLaw);
+      mathNode = kineticLaw.getMath();
+      assertNotNull(mathNode);
+      assertEquals(mathNode.getName(), CobraConstants.FLUX_VALUE);
+      fluxValueParameter = kineticLaw.getLocalParameter(CobraConstants.FLUX_VALUE);
+      assertNotNull(fluxValueParameter);
+      assertEquals(fluxValueParameter.getUnits(), CobraConstants.mmol_per_gDW_per_hr);
+      assertEquals((Double)fluxValueParameter.getValue(), fluxValueValue);
+      lowerBoundParameter = kineticLaw.getLocalParameter(CobraConstants.LOWER_BOUND);
+      assertNotNull(lowerBoundParameter);
+      assertEquals((Double) lowerBoundParameter.getValue(), Double.valueOf(Double.NEGATIVE_INFINITY));
+      upperBoundParameter = kineticLaw.getLocalParameter(CobraConstants.UPPER_BOUND);
+      assertNotNull(upperBoundParameter);
+      assertEquals((Double) upperBoundParameter.getValue(), Double.valueOf(Double.POSITIVE_INFINITY));
+      
+      // incomplete Doc no kineticLaw but use give default value
+      fbcV2ToFbcV1Converter = new FbcV2ToFbcV1Converter();
+      fbcV1ToCobraConverter = new FbcV1ToCobraConverter();
+      doc = null;
+      assertNull(doc);
+      doc = createDoc(false, false, false);
+      assertNotNull(doc);
+      doc = fbcV2ToFbcV1Converter.convert(doc);
+      fbcV1ToCobraConverter.setOption(CobraConstants.DEFAULT_LOWER_BOUND_NAME, defaultLowerBound);
+      fbcV1ToCobraConverter.setOption(CobraConstants.DEFAULT_UPPER_BOUND_NAME, defaultUpperBound);
+      doc = fbcV1ToCobraConverter.convert(doc);
+      
+      assertNotNull(doc);
+      kineticLaw = doc.getModel().getListOfReactions().get(reactionId).getKineticLaw();
+      assertNotNull(kineticLaw);
+      mathNode = kineticLaw.getMath();
+      assertNotNull(mathNode);
+      assertEquals(mathNode.getName(), CobraConstants.FLUX_VALUE);
+      fluxValueParameter = kineticLaw.getLocalParameter(CobraConstants.FLUX_VALUE);
+      assertNotNull(fluxValueParameter);
+      assertEquals(fluxValueParameter.getUnits(), CobraConstants.mmol_per_gDW_per_hr);
+      assertEquals((Double)fluxValueParameter.getValue(), fluxValueValue);
+      lowerBoundParameter = kineticLaw.getLocalParameter(CobraConstants.LOWER_BOUND);
+      assertNotNull(lowerBoundParameter);
+      assertEquals((Double) lowerBoundParameter.getValue(), Double.valueOf(defaultLowerBound));
+      upperBoundParameter = kineticLaw.getLocalParameter(CobraConstants.UPPER_BOUND);
+      assertNotNull(upperBoundParameter);
+      assertEquals((Double) upperBoundParameter.getValue(), Double.valueOf(defaultUpperBound));
+      
+      // last but not least, also check the combined converter and the user parameter propagation:
+      doc = null;
+      assertNull(doc);
+      doc = createDoc(false, false, false);
+      assertNotNull(doc);
+      fbcV2ToCobraConverter.setOption(CobraConstants.DEFAULT_LOWER_BOUND_NAME, defaultLowerBound);
+      fbcV2ToCobraConverter.setOption(CobraConstants.DEFAULT_UPPER_BOUND_NAME, defaultUpperBound);
+      
+      doc = fbcV2ToCobraConverter.convert(doc);
+      
+      assertNotNull(doc);
+      kineticLaw = doc.getModel().getListOfReactions().get(reactionId).getKineticLaw();
+      assertNotNull(kineticLaw);
+      mathNode = kineticLaw.getMath();
+      assertNotNull(mathNode);
+      assertEquals(mathNode.getName(), CobraConstants.FLUX_VALUE);
+      fluxValueParameter = kineticLaw.getLocalParameter(CobraConstants.FLUX_VALUE);
+      assertNotNull(fluxValueParameter);
+      assertEquals(fluxValueParameter.getUnits(), CobraConstants.mmol_per_gDW_per_hr);
+      assertEquals((Double)fluxValueParameter.getValue(), fluxValueValue);
+      lowerBoundParameter = kineticLaw.getLocalParameter(CobraConstants.LOWER_BOUND);
+      assertNotNull(lowerBoundParameter);
+      assertEquals((Double) lowerBoundParameter.getValue(), Double.valueOf(defaultLowerBound));
+      upperBoundParameter = kineticLaw.getLocalParameter(CobraConstants.UPPER_BOUND);
+      assertNotNull(upperBoundParameter);
+      assertEquals((Double) upperBoundParameter.getValue(), Double.valueOf(defaultUpperBound));
+      
+    } catch (SBMLException e) {
+      fail(e.getLocalizedMessage());
+      
+    } catch (Exception e) {
+      fail(e.getLocalizedMessage());
+    }
+  }
+}

--- a/test/org/sbml/jsbml/test/AllTests.java
+++ b/test/org/sbml/jsbml/test/AllTests.java
@@ -27,6 +27,7 @@ import org.junit.runners.Suite.SuiteClasses;
 import org.sbml.jsbml.ext.arrays.test.ArraysJUnitTests;
 import org.sbml.jsbml.ext.comp.test.CompJUnitTests;
 import org.sbml.jsbml.ext.dyn.test.TestL3Dyn;
+import org.sbml.jsbml.ext.fbc.test.FbcJUnitTests;
 import org.sbml.jsbml.ext.groups.test.GroupsJUnitTests;
 import org.sbml.jsbml.ext.layout.test.LayoutJUnitTests;
 import org.sbml.jsbml.ext.render.test.RenderJUnitTests;
@@ -42,7 +43,7 @@ import org.sbml.jsbml.xml.test.Tests;
 @RunWith(value=Suite.class)
 @SuiteClasses(value={Tests.class, LibsbmlCompatibilityTests.class, LayoutJUnitTests.class, RenderJUnitTests.class,
   UnregisterPackageTests.class, ArraysJUnitTests.class, DisablePackageTests.class, TestL3Dyn.class,
-  PackageVersionTests.class, CompJUnitTests.class, UTF8Tests.class, GroupsJUnitTests.class})
+  PackageVersionTests.class, CompJUnitTests.class, UTF8Tests.class, GroupsJUnitTests.class, FbcJUnitTests.class})
 public class AllTests {
 
   /**


### PR DESCRIPTION
Implemented changes as discussed in Pivotal Tracker.
A kineticLaw with all LocalParameters for LOWER_BOUND, UPPER_BOUND and FLUX_VALUE is created for all reactions. Default values for these are used if missing. They can be overwritten via converter-options.
Included changes to a converter from Cobra to FbcV1 to prevent a NullPointerException upon missing kineticLaw elements as has been discussed in Pivotal Tracker.
Test Case for FbcV2 to Cobra now has multiple Tests for various document scenarios and is integrated in the AllTests - Suite.