### PR TITLE
Correction of Classname Fcb to Fbc

### DIFF
--- a/extensions/fbc/src/org/sbml/jsbml/ext/fbc/converters/CobraToFbcV2Converter.java
+++ b/extensions/fbc/src/org/sbml/jsbml/ext/fbc/converters/CobraToFbcV2Converter.java
@@ -40,7 +40,7 @@ public class CobraToFbcV2Converter implements SBMLConverter {
     CobraToFbcV1Converter cobraToFbcV1Converter = new CobraToFbcV1Converter();
     sbmlDocument = cobraToFbcV1Converter.convert(sbmlDocument);
    // convert SBML FBCV1 file to SBML FBCV2
-    FcbV1ToFbcV2Converter fbcV1ToFbcV2Converter = new FcbV1ToFbcV2Converter();
+    FbcV1ToFbcV2Converter fbcV1ToFbcV2Converter = new FbcV1ToFbcV2Converter();
     sbmlDocument = fbcV1ToFbcV2Converter.convert(sbmlDocument);
 
     return sbmlDocument;

--- a/extensions/fbc/src/org/sbml/jsbml/ext/fbc/converters/FbcV1ToFbcV2Converter.java
+++ b/extensions/fbc/src/org/sbml/jsbml/ext/fbc/converters/FbcV1ToFbcV2Converter.java
@@ -52,7 +52,7 @@ import org.sbml.jsbml.util.filters.Filter;
  */
 
 @SuppressWarnings("deprecation")
-public class FcbV1ToFbcV2Converter implements SBMLConverter {
+public class FbcV1ToFbcV2Converter implements SBMLConverter {
   
   String userKey = null;
   


### PR DESCRIPTION
Spotted a spelling mistake for the FbcV1ToFbcV2Converter. It is only being used in this one location, so the change should have no sideeffects.