### PR TITLE
Render validation

### DIFF
--- a/core/src/org/sbml/jsbml/validator/offline/factory/SBMLErrorCodes.java
+++ b/core/src/org/sbml/jsbml/validator/offline/factory/SBMLErrorCodes.java
@@ -7275,12 +7275,12 @@ public interface SBMLErrorCodes {
  	 public static final int RENDER_20903 = 1320903; 
 
 	 /**
-	  * Error code 1320904:
-	  * A &lt;gradientBase&gt; object may contain one and only one instance of the 
-	  * &lt;listOfGradientStops&gt; element. No other elements from the SBML Level 3 Render 
-	  * namespaces are permitted on a &lt;gradientBase&gt; object. Reference: L3V1 Render V1 
-	  * Section 
-	  */
+   * Error code 1320904:
+   * A GradientBase object must contain at least one instance of the
+   * GradientStop element. No other elements from the SBML Level 3 Render
+   * namespaces are permitted on a GradientBase object.
+   * Reference: L3V1 Render V1 Section 3.7.2
+   */
  	 public static final int RENDER_20904 = 1320904; 
 
 	 /**

--- a/core/src/org/sbml/jsbml/validator/offline/factory/SBMLErrorCodes.java
+++ b/core/src/org/sbml/jsbml/validator/offline/factory/SBMLErrorCodes.java
@@ -7332,13 +7332,13 @@ public interface SBMLErrorCodes {
  	 public static final int RENDER_21004 = 1321004; 
 
 	 /**
-	  * Error code 1321005:
-	  * The value of the attribute 'render:offset' of a &lt;gradientStop&gt; object must 
-	  * conform to the syntax of SBML data type &lt;relAbsVector,&gt; i.e., a string encoding 
-	  * optionally an absolute number followed by an optional relative number followed 
-	  * by a &lt;% sign&gt;. Adding spaces between the coordinates is encouraged, but not 
-	  * required. Reference: L3V1 Render V1 Section 
-	  */
+   * Error code 1321005:
+   * The value of the attribute render:offset of a GradientStop object must
+   * conform to the syntax of SBML data type RelAbsVector but in this case <b>can
+   * only encode a relative value</b> i.e. a string encoding a number followed by a
+   * % sign.
+   * Reference: L3V1 Render V1 Section 3.7.3
+   */
  	 public static final int RENDER_21005 = 1321005; 
 
 	 /**

--- a/core/src/org/sbml/jsbml/validator/offline/factory/SBMLErrorCodes.java
+++ b/core/src/org/sbml/jsbml/validator/offline/factory/SBMLErrorCodes.java
@@ -8609,11 +8609,8 @@ public interface SBMLErrorCodes {
 	  * Error code 1322910:
 	  * The &lt;listOfColorDefinitions,&gt; &lt;listOfGradientBases&gt; and &lt;listOfLineEndings&gt; 
 	  * subobjects on a &lt;renderInformationBase&gt; object are optional, but if present, 
-	  * these container objects must not be empty.The &lt;listOfColorDefinitions&gt; must 
-	  * contain at least zero instances of the &lt;colorDefinition&gt; object.The 
-	  * &lt;listOfGradientBases&gt; must contain at least one instances of the &lt;gradientBase&gt; 
-	  * object.The &lt;listOfLineEndings&gt; must contain at least one instances of the 
-	  * &lt;lineEnding&gt; object. Reference: L3V1 Render V1 Section 
+	  * these container objects must not be empty.
+	  * Reference: L3V1 Render V1 Section 
 	  */
  	 public static final int RENDER_22910 = 1322910; 
 

--- a/core/src/org/sbml/jsbml/validator/offline/factory/SBMLErrorCodes.java
+++ b/core/src/org/sbml/jsbml/validator/offline/factory/SBMLErrorCodes.java
@@ -7760,18 +7760,27 @@ public interface SBMLErrorCodes {
 	 /**
 	  * Error code 1321703:
 	  * A &lt;polygon&gt; object may contain one and only one instance of the 
-	  * &lt;listOfRenderPoints&gt; element. No other elements from the SBML Level 3 Render 
+	  * &lt;listOfElements&gt; element. No other elements from the SBML Level 3 Render 
 	  * namespaces are permitted on a &lt;polygon&gt; object. Reference: L3V1 Render V1 
 	  * Section 
 	  */
  	 public static final int RENDER_21703 = 1321703; 
 
-	 /**
+	 /*
 	  * Error code 1321704:
 	  * The &lt;listOfRenderPoints&gt; subobject on a &lt;polygon&gt; object is optional, but if 
 	  * present, this container object must not be empty. Reference: L3V1 Render V1 
 	  * Section 
 	  */
+   // TODO 2020/03: there is a mismatch between the specification and the
+   // implemented constraints here!
+ 	 /**
+   * Error code 1321704:
+   * A &lt;polygon&gt; object may contain one and only one instance of the
+   * &lt;listOfCurveSegments&gt; element from the Layout package. No other
+   * elements from the SBML Level 3 Layout namespaces are permitted on a
+   * &lt;polygon&gt; object. Reference: L3V1 Render V1 Section 3.10.1
+   */
  	 public static final int RENDER_21704 = 1321704; 
 
 	 /**

--- a/core/src/org/sbml/jsbml/validator/offline/factory/SBMLErrorCodes.java
+++ b/core/src/org/sbml/jsbml/validator/offline/factory/SBMLErrorCodes.java
@@ -13761,13 +13761,45 @@ public interface SBMLErrorCodes {
  	 
  	 public static final int SPATIAL_21652 = 1221652;
  	 
-   /**
+  /**
    * Error code 1321209:
-   * 
-   * Reference: L3V1 Render V1 Section
    * The attribute render:href on an Image must point to a local file of type
-   * "jpeg" or "png". 
+   * "jpeg" or "png".
    * Reference: L3V1 Render V1 Section 3.10.5
    */
-   public static final int RENDER_21209 = 1321209; 
+  public static final int RENDER_21209  = 1321209; 
+  
+  /**
+   * Error code 1323040:
+   * The ListOfElements subobject on a RenderCurve or a Polygon object is
+   * optional, but if present, this container object must not be empty.
+   * Reference: L3V1 Render V1 Section 3.9.3
+   */
+  public static final int RENDER_23040  = 1323040;
+  
+  /**
+   * Error code 1323041:
+   * Apart from the general notes and annotations subobjects permitted on all
+   * SBML objects, a ListOfElements container object may only contain
+   * RenderPoint or the derived RenderCubicBezier objects.
+   * Reference: L3V1 Render V1 Section 3.9.3
+   */
+  public static final int RENDER_23041  = 1323041;
+   
+  /**
+   * Error code 1323042:
+   * A ListOfElements object may have the optional SBML Level 3 Core attributes
+   * metaid and sboTerm. No other attributes from the SBML Level 3 Core
+   * namespaces are permitted on a ListOfElements object.
+   * Reference: L3V1 Render V1 Section 3.9.3
+   */
+  public static final int RENDER_23042  = 1323042;
+  
+  /**
+   * Error code 1323043:
+   * The first element within a ListOfElements container object must be of type
+   * RenderPoint (but not of the derived RenderCubicBezier)
+   * Reference: L3V1 Render V1 Section 3.9.3
+   */
+  public static final int RENDER_23043  = 1323043;
 }

--- a/core/src/org/sbml/jsbml/validator/offline/factory/SBMLErrorCodes.java
+++ b/core/src/org/sbml/jsbml/validator/offline/factory/SBMLErrorCodes.java
@@ -7519,6 +7519,8 @@ public interface SBMLErrorCodes {
 	  */
  	 public static final int RENDER_21208 = 1321208; 
 
+ 	 // render-21209 see end of file
+ 	 
 	 /**
 	  * Error code 1321210:
 	  * The value of the attribute 'render:z' of an &lt;image&gt; object must conform to the 
@@ -13752,4 +13754,14 @@ public interface SBMLErrorCodes {
  	 public static final int SPATIAL_21651 = 1221651;
  	 
  	 public static final int SPATIAL_21652 = 1221652;
+ 	 
+   /**
+   * Error code 1321209:
+   * 
+   * Reference: L3V1 Render V1 Section
+   * The attribute render:href on an Image must point to a local file of type
+   * "jpeg" or "png". 
+   * Reference: L3V1 Render V1 Section 3.10.5
+   */
+   public static final int RENDER_21209 = 1321209; 
 }

--- a/example_implementations/org/sbml/jsbml/examples/render/RenderUncertainProcessNode.java
+++ b/example_implementations/org/sbml/jsbml/examples/render/RenderUncertainProcessNode.java
@@ -74,7 +74,7 @@ public class RenderUncertainProcessNode extends RenderSBGNProcessNode
     Text questionmark = group.createText();
     double breadth = 13; // based on font-size, found manually
     double fontHeight = 20; // based on font-size, found manually 
-    questionmark.setFontSize((short) 10);
+    questionmark.setFontSize(new RelAbsVector(10));
     questionmark.setFontFamily("monospace");
     questionmark.setTextAnchor(HTextAnchor.START);
     questionmark.setVTextAnchor(VTextAnchor.TOP);

--- a/extensions/layout/src/org/sbml/jsbml/validator/offline/constraints/LayoutModelPluginConstraints.java
+++ b/extensions/layout/src/org/sbml/jsbml/validator/offline/constraints/LayoutModelPluginConstraints.java
@@ -146,7 +146,8 @@ public class LayoutModelPluginConstraints extends AbstractConstraintDeclaration 
 
         @Override
         public boolean check(ValidationContext ctx, LayoutModelPlugin layoutMP) {
-          
+          // TODO 2020/03: this will return true (i.e. 'constraint not broken'),
+          // if the list is set and empty
           return layoutMP.isSetListOfLayouts() && layoutMP.getListOfLayouts().size() == 0; 
         }
       };

--- a/extensions/layout/src/org/sbml/jsbml/validator/offline/constraints/LayoutModelPluginConstraints.java
+++ b/extensions/layout/src/org/sbml/jsbml/validator/offline/constraints/LayoutModelPluginConstraints.java
@@ -146,9 +146,7 @@ public class LayoutModelPluginConstraints extends AbstractConstraintDeclaration 
 
         @Override
         public boolean check(ValidationContext ctx, LayoutModelPlugin layoutMP) {
-          // TODO 2020/03: this will return true (i.e. 'constraint not broken'),
-          // if the list is set and empty
-          return layoutMP.isSetListOfLayouts() && layoutMP.getListOfLayouts().size() == 0; 
+          return !(layoutMP.isSetListOfLayouts() && layoutMP.getListOfLayouts().size() == 0); 
         }
       };
       break;

--- a/extensions/render/src/org/sbml/jsbml/ext/render/Ellipse.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/Ellipse.java
@@ -23,7 +23,6 @@ package org.sbml.jsbml.ext.render;
 import java.util.Locale;
 import java.util.Map;
 
-import org.sbml.jsbml.JSBML;
 import org.sbml.jsbml.PropertyUndefinedError;
 import org.sbml.jsbml.util.StringTools;
 
@@ -517,7 +516,7 @@ public class Ellipse extends GraphicalPrimitive2D {
         try {
           setRatio(Double.parseDouble(value));
         } catch(NumberFormatException e){
-          putUserObject(JSBML.INVALID_XML, value);
+          XMLTools.addToInvalidXMLUserObject(this, attributeName, value);
         }
       }
       else {

--- a/extensions/render/src/org/sbml/jsbml/ext/render/Ellipse.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/Ellipse.java
@@ -23,6 +23,7 @@ package org.sbml.jsbml.ext.render;
 import java.util.Locale;
 import java.util.Map;
 
+import org.sbml.jsbml.JSBML;
 import org.sbml.jsbml.PropertyUndefinedError;
 import org.sbml.jsbml.util.StringTools;
 
@@ -513,7 +514,11 @@ public class Ellipse extends GraphicalPrimitive2D {
         setRy(new RelAbsVector(value));
       }
       else if(attributeName.equals(RenderConstants.ratio)) {
-        setRatio(Double.parseDouble(value));
+        try {
+          setRatio(Double.parseDouble(value));
+        } catch(NumberFormatException e){
+          putUserObject(JSBML.INVALID_XML, value);
+        }
       }
       else {
         isAttributeRead = false;

--- a/extensions/render/src/org/sbml/jsbml/ext/render/FontRenderStyle.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/FontRenderStyle.java
@@ -62,7 +62,7 @@ public interface FontRenderStyle { // TODO - FontWeight (bold, normal) and FontS
   /**
    * @return the value of fontSize
    */
-  public abstract short getFontSize();
+  public abstract RelAbsVector getFontSize();
 
   /**
    * @return whether fontSize is set
@@ -73,7 +73,7 @@ public interface FontRenderStyle { // TODO - FontWeight (bold, normal) and FontS
    * Set the value of fontSize
    * @param fontSize
    */
-  public abstract void setFontSize(short fontSize);
+  public abstract void setFontSize(RelAbsVector fontSize);
 
   /**
    * Unsets the variable fontSize

--- a/extensions/render/src/org/sbml/jsbml/ext/render/GlobalRenderInformation.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/GlobalRenderInformation.java
@@ -177,6 +177,15 @@ public class GlobalRenderInformation extends RenderInformationBase {
     }
     return true;
   }
+  
+  
+  /**
+   * @return {@code true} iff listOfStyles is not {@code null}, but empty
+   *         (relevant for validation)
+   */
+  public boolean isListOfStylesEmpty() {
+    return listOfStyles != null && listOfStyles.isEmpty();
+  }
 
 
   /**

--- a/extensions/render/src/org/sbml/jsbml/ext/render/GradientBase.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/GradientBase.java
@@ -428,6 +428,7 @@ public class GradientBase extends AbstractNamedSBase implements UniqueNamedSBase
         try {
           setSpreadMethod(Spread.valueOf(value.toUpperCase()));
         } catch (Exception e) {
+          XMLTools.addToInvalidXMLUserObject(this, attributeName, value);
           throw new SBMLException("Could not recognized the value '" + value
               + "' for the attribute " + RenderConstants.spreadMethod
               + " on the 'gradient' element.");

--- a/extensions/render/src/org/sbml/jsbml/ext/render/GradientBase.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/GradientBase.java
@@ -292,6 +292,15 @@ public class GradientBase extends AbstractNamedSBase implements UniqueNamedSBase
     }
     return true;
   }
+  
+  /**
+   * @return {@code true} iff listOfGradientStops is not {@code null}, but empty
+   *         (relevant for validation)
+   */
+  public boolean isListOfGradientStopsEmpty() {
+    return listOfGradientStops != null && listOfGradientStops.isEmpty();
+  }
+  
 
   /**
    * @return the listOfGradientStops

--- a/extensions/render/src/org/sbml/jsbml/ext/render/GraphicalPrimitive1D.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/GraphicalPrimitive1D.java
@@ -333,6 +333,10 @@ public class GraphicalPrimitive1D extends Transformation2D {
       attributes.put(RenderConstants.shortLabel + ':' + RenderConstants.strokeWidth,
         getStrokeWidth().toString().toLowerCase());
     }
+    if(isSetId()) {
+      attributes.put(RenderConstants.shortLabel + ':' + RenderConstants.id,
+        getId());
+    }
     return attributes;
   }
 
@@ -354,6 +358,9 @@ public class GraphicalPrimitive1D extends Transformation2D {
       }
       else if (attributeName.equals(RenderConstants.strokeWidth)) {
         setStrokeWidth(StringTools.parseSBMLDouble(value));
+      } 
+      else if (attributeName.equals(RenderConstants.id)) {
+        setId(value);
       }
       else {
         isAttributeRead = false;

--- a/extensions/render/src/org/sbml/jsbml/ext/render/GraphicalPrimitive1D.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/GraphicalPrimitive1D.java
@@ -346,7 +346,7 @@ public class GraphicalPrimitive1D extends Transformation2D {
   @Override
   public boolean readAttribute(String attributeName, String prefix, String value) {
     boolean isAttributeRead = super.readAttribute(attributeName, prefix, value);
-
+    
     if (!isAttributeRead) {
       isAttributeRead = true;
 
@@ -354,10 +354,19 @@ public class GraphicalPrimitive1D extends Transformation2D {
         setStroke(value);
       }
       else if (attributeName.equals(RenderConstants.strokeDashArray)) {
-        setStrokeDashArray(XMLTools.decodeStringToArrayShort(value));
+        if(XMLTools.canDecodeStringToArrayUnsignedInt(value)) {
+          setStrokeDashArray(XMLTools.decodeStringToArrayShort(value));
+        } else {
+          XMLTools.addToInvalidXMLUserObject(this, attributeName, value);
+        }
       }
       else if (attributeName.equals(RenderConstants.strokeWidth)) {
-        setStrokeWidth(StringTools.parseSBMLDouble(value));
+        try {
+          Double.parseDouble(value);
+          setStrokeWidth(StringTools.parseSBMLDouble(value));
+        } catch (NumberFormatException e) {
+          XMLTools.addToInvalidXMLUserObject(this, attributeName, value);
+        }
       } 
       else if (attributeName.equals(RenderConstants.id)) {
         setId(value);

--- a/extensions/render/src/org/sbml/jsbml/ext/render/GraphicalPrimitive2D.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/GraphicalPrimitive2D.java
@@ -286,6 +286,7 @@ public class GraphicalPrimitive2D extends GraphicalPrimitive1D {
         try {
           setFillRule(FillRule.valueOf(value.toUpperCase()));
         } catch (Exception e) {
+          XMLTools.addToInvalidXMLUserObject(this, attributeName, value);
           throw new SBMLException("Could not recognized the value '" + value
               + "' for the attribute " + RenderConstants.fillRule
               + " on the '" + getElementName() + "' element.");

--- a/extensions/render/src/org/sbml/jsbml/ext/render/LineEnding.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/LineEnding.java
@@ -24,7 +24,6 @@ import java.util.Map;
 
 import javax.swing.tree.TreeNode;
 
-import org.sbml.jsbml.JSBML;
 import org.sbml.jsbml.PropertyUndefinedError;
 import org.sbml.jsbml.ext.layout.BoundingBox;
 import org.sbml.jsbml.ext.layout.IBoundingBox;
@@ -369,7 +368,7 @@ public class LineEnding extends GraphicalPrimitive2D implements IBoundingBox {
           || value.trim().equals("1") || value.trim().equals("0")) {
           setEnableRotationMapping(StringTools.parseSBMLBoolean(value));
         } else {
-          putUserObject(JSBML.INVALID_XML, value);
+          XMLTools.addToInvalidXMLUserObject(this, attributeName, value);
         }
       }
       else {

--- a/extensions/render/src/org/sbml/jsbml/ext/render/LineEnding.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/LineEnding.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import javax.swing.tree.TreeNode;
 
+import org.sbml.jsbml.JSBML;
 import org.sbml.jsbml.PropertyUndefinedError;
 import org.sbml.jsbml.ext.layout.BoundingBox;
 import org.sbml.jsbml.ext.layout.IBoundingBox;
@@ -363,7 +364,13 @@ public class LineEnding extends GraphicalPrimitive2D implements IBoundingBox {
         setId(value);
       }
       else if (attributeName.equals(RenderConstants.enableRotationMapping)) {
-        setEnableRotationMapping(StringTools.parseSBMLBoolean(value));
+        if (value.trim().toLowerCase().equals("true")
+          || value.trim().toLowerCase().equals("false")
+          || value.trim().equals("1") || value.trim().equals("0")) {
+          setEnableRotationMapping(StringTools.parseSBMLBoolean(value));
+        } else {
+          putUserObject(JSBML.INVALID_XML, value);
+        }
       }
       else {
         isAttributeRead = false;

--- a/extensions/render/src/org/sbml/jsbml/ext/render/LinearGradient.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/LinearGradient.java
@@ -485,6 +485,7 @@ public class LinearGradient extends GradientBase {
     boolean isAttributeRead = super.readAttribute(attributeName, prefix, value);
     if (!isAttributeRead) {
       isAttributeRead = true;
+      // TODO 2020/03: issue: spec says ,linearGradient_x1/x2/etc'
       if (attributeName.equals(RenderConstants.x1)) {
         setX1(new RelAbsVector(value));
       }

--- a/extensions/render/src/org/sbml/jsbml/ext/render/ListOfRenderInformation.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/ListOfRenderInformation.java
@@ -384,10 +384,20 @@ public abstract class ListOfRenderInformation<T extends RenderInformationBase> e
       isAttributeRead = true;
 
       if (attributeName.equals(RenderConstants.versionMajor)) {
-        setVersionMajor(StringTools.parseSBMLShort(value));
+        try {
+          Short.parseShort(value);
+          setVersionMajor(StringTools.parseSBMLShort(value));  
+        } catch (NumberFormatException e) {
+          XMLTools.addToInvalidXMLUserObject(this, attributeName, value);
+        }
       }
       else if (attributeName.equals(RenderConstants.versionMinor)) {
-        setVersionMinor(StringTools.parseSBMLShort(value));
+        try {
+          Short.parseShort(value);
+          setVersionMinor(StringTools.parseSBMLShort(value));
+        } catch (NumberFormatException e) {
+          XMLTools.addToInvalidXMLUserObject(this, attributeName, value);
+        }
       }
       else {
         isAttributeRead = false;

--- a/extensions/render/src/org/sbml/jsbml/ext/render/LocalRenderInformation.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/LocalRenderInformation.java
@@ -180,6 +180,16 @@ public class LocalRenderInformation extends RenderInformationBase {
     }
     return true;
   }
+  
+  /**
+   * @return {@code true} iff listOfLocalStyles is not {@code null}, but empty
+   *         (relevant for validation)
+   */
+  public boolean isListOfLocalStylesEmpty() {
+    return listOfLocalStyles != null && listOfLocalStyles.isEmpty();
+  }
+  
+  
 
   /* (non-Javadoc)
    * @see org.sbml.jsbml.AbstractSBase#getElementName()

--- a/extensions/render/src/org/sbml/jsbml/ext/render/Polygon.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/Polygon.java
@@ -105,6 +105,7 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
    */
   @Override
   public SBase getChildAt(int childIndex) {
+    // TODO 2020/03: what about notes and annotation?
     if (childIndex < 0) {
       throw new IndexOutOfBoundsException(MessageFormat.format(resourceBundle.getString("IndexSurpassesBoundsException"), childIndex, 0));
     }

--- a/extensions/render/src/org/sbml/jsbml/ext/render/Polygon.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/Polygon.java
@@ -22,7 +22,6 @@ import java.text.MessageFormat;
 import javax.swing.tree.TreeNode;
 
 import org.sbml.jsbml.ListOf;
-import org.sbml.jsbml.SBase;
 import org.sbml.jsbml.ext.layout.CubicBezier;
 import org.sbml.jsbml.ext.layout.CurveSegment;
 import org.sbml.jsbml.ext.layout.ICurve;
@@ -113,7 +112,6 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
    */
   @Override
   public TreeNode getChildAt(int childIndex) {
-    // TODO 2020/03: what about notes and annotation?
     if (childIndex < 0) {
       throw new IndexOutOfBoundsException(MessageFormat.format(
         resourceBundle.getString("IndexSurpassesBoundsException"), childIndex,
@@ -132,12 +130,8 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
       }
       pos++;
     }
-    
+    // Super will throw exception, if necessary
     return super.getChildAt(childIndex - pos);
-    /*
-    throw new IndexOutOfBoundsException(MessageFormat.format(
-      resourceBundle.getString("IndexExceedsBoundsException"), childIndex,
-      Math.min(pos, 0))); */
   }
 
 

--- a/extensions/render/src/org/sbml/jsbml/ext/render/Polygon.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/Polygon.java
@@ -173,12 +173,25 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
     packageName = RenderConstants.shortLabel;
   }
 
+  
   /**
-   * @return whether listOfElements is set
+   * To check, whether {@link #listOfElements} is non-{@code null}, but empty,
+   * use {@link #isListOfElementsEmpty()}
+   * 
+   * @return whether listOfElements is set (to a non-empty and non-null list)
    */
   public boolean isSetListOfElements() {
-    return listOfElements != null;
+    return listOfElements != null && !listOfElements.isEmpty();
   }
+  
+  /**
+   * @return {@code true} iff listOfElements is not {@code null}, but empty
+   *         (relevant for validation)
+   */
+  public boolean isListOfElementsEmpty() {
+    return listOfElements != null && listOfElements.isEmpty();
+  }
+  
 
   /**
    * Set the value of listOfElements
@@ -265,10 +278,15 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
    *         one element, otherwise {@code false}.
    */
   public boolean isSetListOfCurveSegments() {
-    if (listOfCurveSegments == null) {
-      return false;
-    }
-    return true;
+    return listOfCurveSegments != null && !listOfCurveSegments.isEmpty();
+  }
+  
+  /**
+   * @return {@code true} iff listOfCurveSegments is not {@code null}, but empty
+   *         (relevant for validation)
+   */
+  public boolean isListOfCurveSegmentsEmpty() {
+    return listOfCurveSegments != null && listOfCurveSegments.isEmpty();
   }
 
   /**

--- a/extensions/render/src/org/sbml/jsbml/ext/render/Polygon.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/Polygon.java
@@ -2,14 +2,12 @@
  * ----------------------------------------------------------------------------
  * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
  * for the latest version of JSBML and more information about SBML.
- *
  * Copyright (C) 2009-2018 jointly by the following organizations:
  * 1. The University of Tuebingen, Germany
  * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
  * 3. The California Institute of Technology, Pasadena, CA, USA
  * 4. The University of California, San Diego, La Jolla, CA, USA
  * 5. The Babraham Institute, Cambridge, UK
- * 
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation. A copy of the license agreement is provided
@@ -20,6 +18,8 @@
 package org.sbml.jsbml.ext.render;
 
 import java.text.MessageFormat;
+
+import javax.swing.tree.TreeNode;
 
 import org.sbml.jsbml.ListOf;
 import org.sbml.jsbml.SBase;
@@ -37,21 +37,20 @@ import org.sbml.jsbml.ext.layout.LineSegment;
  * @since 1.0
  */
 public class Polygon extends GraphicalPrimitive2D implements ICurve {
+
   /**
    * Generated serial version identifier
    */
-  private static final long serialVersionUID = 9207043017589271103L;
-
+  private static final long    serialVersionUID = 9207043017589271103L;
   /**
    * 
    */
-  private ListOf<RenderPoint> listOfElements;
-
+  private ListOf<RenderPoint>  listOfElements;
   /**
    * 
    */
   private ListOf<CurveSegment> listOfCurveSegments;
-  
+
   /**
    * Creates an Polygon instance
    */
@@ -60,14 +59,15 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
     initDefaults();
   }
 
+
   /**
    * Clone constructor
    * 
-   * @param obj the {@link Polygon} instance to clone
+   * @param obj
+   *        the {@link Polygon} instance to clone
    */
   public Polygon(Polygon obj) {
     super(obj);
-    
     if (obj.isSetListOfElements()) {
       setListOfElements(obj.getListOfElements().clone());
     }
@@ -75,6 +75,7 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
       setListOfCurveSegments(obj.getListOfCurveSegments().clone());
     }
   }
+
 
   /**
    * @param element
@@ -84,7 +85,9 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
     return getListOfElements().add(element);
   }
 
-  /* (non-Javadoc)
+
+  /*
+   * (non-Javadoc)
    * @see org.sbml.jsbml.ext.render.GraphicalPrimitive2D#clone()
    */
   @Override
@@ -92,7 +95,9 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
     return new Polygon(this);
   }
 
-  /* (non-Javadoc)
+
+  /*
+   * (non-Javadoc)
    * @see org.sbml.jsbml.ext.render.GraphicalPrimitive1D#getAllowsChildren()
    */
   @Override
@@ -100,14 +105,19 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
     return true;
   }
 
-  /* (non-Javadoc)
-   * @see org.sbml.jsbml.ext.render.GraphicalPrimitive1D#getChildAt(int)
+
+  /**
+   * The listOfElements and listOfCurveSegments will take the indices 0 and 1,
+   * or 0 (if only one is set). ChildElements like Annotation will be shifted
+   * accordingly
    */
   @Override
-  public SBase getChildAt(int childIndex) {
+  public TreeNode getChildAt(int childIndex) {
     // TODO 2020/03: what about notes and annotation?
     if (childIndex < 0) {
-      throw new IndexOutOfBoundsException(MessageFormat.format(resourceBundle.getString("IndexSurpassesBoundsException"), childIndex, 0));
+      throw new IndexOutOfBoundsException(MessageFormat.format(
+        resourceBundle.getString("IndexSurpassesBoundsException"), childIndex,
+        0));
     }
     int pos = 0;
     if (isSetListOfElements()) {
@@ -123,27 +133,30 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
       pos++;
     }
     
+    return super.getChildAt(childIndex - pos);
+    /*
     throw new IndexOutOfBoundsException(MessageFormat.format(
       resourceBundle.getString("IndexExceedsBoundsException"), childIndex,
-      Math.min(pos, 0)));
+      Math.min(pos, 0))); */
   }
 
-  /* (non-Javadoc)
+
+  /*
+   * (non-Javadoc)
    * @see org.sbml.jsbml.ext.render.GraphicalPrimitive1D#getChildCount()
    */
   @Override
   public int getChildCount() {
     int count = super.getChildCount();
-    
     if (isSetListOfElements()) {
       count++;
     }
     if (isSetListOfCurveSegments()) {
       count++;
     }
-    
     return count;
   }
+
 
   /**
    * @return the value of listOfElements
@@ -157,14 +170,14 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
       listOfElements.setPackageName(RenderConstants.shortLabel);
       listOfElements.setSBaseListType(ListOf.Type.other);
       listOfElements.setOtherListName(RenderConstants.listOfElements);
-      
       registerChild(listOfElements);
     }
-    
     return listOfElements;
   }
 
-  /* (non-Javadoc)
+
+  /*
+   * (non-Javadoc)
    * @see org.sbml.jsbml.ext.render.GraphicalPrimitive2D#initDefaults()
    */
   @Override
@@ -173,7 +186,7 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
     packageName = RenderConstants.shortLabel;
   }
 
-  
+
   /**
    * To check, whether {@link #listOfElements} is non-{@code null}, but empty,
    * use {@link #isListOfElementsEmpty()}
@@ -183,7 +196,8 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
   public boolean isSetListOfElements() {
     return listOfElements != null && !listOfElements.isEmpty();
   }
-  
+
+
   /**
    * @return {@code true} iff listOfElements is not {@code null}, but empty
    *         (relevant for validation)
@@ -191,41 +205,45 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
   public boolean isListOfElementsEmpty() {
     return listOfElements != null && listOfElements.isEmpty();
   }
-  
+
 
   /**
    * Set the value of listOfElements
+   * 
    * @param listOfElements
    */
   public void setListOfElements(ListOf<RenderPoint> listOfElements) {
     unsetListOfElements();
     this.listOfElements = listOfElements;
-
     if (listOfElements != null) {
       listOfElements.setPackageVersion(-1);
       // changing the ListOf package name from 'core' to 'render'
       listOfElements.setPackageName(null);
       listOfElements.setPackageName(RenderConstants.shortLabel);
       listOfElements.setSBaseListType(ListOf.Type.other);
-
       registerChild(this.listOfElements);
     }
   }
 
+
   /**
    * Unsets the variable listOfElements
+   * 
    * @return {@code true}, if listOfElements was set before,
    *         otherwise {@code false}
    */
   public boolean unsetListOfElements() {
     if (isSetListOfElements()) {
       ListOf<RenderPoint> oldListOfElements = listOfElements;
+      unregisterChild(listOfElements);
       listOfElements = null;
-      firePropertyChange(RenderConstants.listOfElements, oldListOfElements, listOfElements);
+      firePropertyChange(RenderConstants.listOfElements, oldListOfElements,
+        listOfElements);
       return true;
     }
     return false;
   }
+
 
   /**
    * @param element
@@ -238,6 +256,7 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
     return false;
   }
 
+
   /**
    * @param i
    */
@@ -248,8 +267,10 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
     getListOfElements().remove(i);
   }
 
+
   /**
-   * Creates a new {@link RenderCubicBezier} instance and adds it to the ListOfElements list
+   * Creates a new {@link RenderCubicBezier} instance and adds it to the
+   * ListOfElements list
    * 
    * @return a new {@link RenderCubicBezier} instance
    */
@@ -259,8 +280,10 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
     return element;
   }
 
+
   /**
-   * Creates a new {@link RenderPoint} instance and adds it to the ListOfElements list
+   * Creates a new {@link RenderPoint} instance and adds it to the
+   * ListOfElements list
    * 
    * @return a new {@link RenderPoint} instance
    */
@@ -269,7 +292,8 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
     addElement(element);
     return element;
   }
-  
+
+
   /**
    * Returns {@code true} if {@link #listOfCurveSegments} contains at least
    * one element.
@@ -280,7 +304,8 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
   public boolean isSetListOfCurveSegments() {
     return listOfCurveSegments != null && !listOfCurveSegments.isEmpty();
   }
-  
+
+
   /**
    * @return {@code true} iff listOfCurveSegments is not {@code null}, but empty
    *         (relevant for validation)
@@ -288,6 +313,7 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
   public boolean isListOfCurveSegmentsEmpty() {
     return listOfCurveSegments != null && listOfCurveSegments.isEmpty();
   }
+
 
   /**
    * Returns the {@link #listOfCurveSegments}.
@@ -304,23 +330,23 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
       listOfCurveSegments.setPackageName(LayoutConstants.shortLabel);
       listOfCurveSegments.setSBaseListType(ListOf.Type.other);
       listOfCurveSegments.setOtherListName(LayoutConstants.listOfCurveSegments);
-      
       registerChild(listOfCurveSegments);
     }
     return listOfCurveSegments;
   }
+
 
   /**
    * Sets the given {@code ListOf<CurveSegment>}.
    * If {@link #listOfCurveSegments} was defined before and contains some
    * elements, they are all unset.
    *
-   * @param listOfCurveSegments the list of {@link CurveSegment}s
+   * @param listOfCurveSegments
+   *        the list of {@link CurveSegment}s
    */
   public void setListOfCurveSegments(ListOf<CurveSegment> listOfCurveSegments) {
     unsetListOfCurveSegments();
     this.listOfCurveSegments = listOfCurveSegments;
-
     if (listOfCurveSegments != null) {
       listOfCurveSegments.setPackageVersion(-1);
       // changing the ListOf package name from 'core' to 'layout'
@@ -328,11 +354,10 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
       listOfCurveSegments.setPackageName(LayoutConstants.shortLabel);
       listOfCurveSegments.setSBaseListType(ListOf.Type.other);
       listOfCurveSegments.setOtherListName(LayoutConstants.listOfCurveSegments);
-
       registerChild(listOfCurveSegments);
     }
-
   }
+
 
   /**
    * Returns {@code true} if {@link #listOfCurveSegments} contains at least
@@ -351,28 +376,33 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
     return false;
   }
 
+
   /**
    * Adds a new {@link CurveSegment} to the {@link #listOfCurveSegments}.
-   * <p>The listOfCurveSegments is initialized if necessary.
+   * <p>
+   * The listOfCurveSegments is initialized if necessary.
    *
-   * @param curveSegment the element to add to the list
+   * @param curveSegment
+   *        the element to add to the list
    * @return {@code true} (as specified by {@link java.util.Collection#add})
    * @see java.util.Collection#add(Object)
    */
   public boolean addCurveSegment(CurveSegment curveSegment) {
     return getListOfCurveSegments().add(curveSegment);
   }
-  
+
+
   @Override
   public void addCurveSegment(int index, CurveSegment element) {
     getListOfCurveSegments().add(index, element);
   }
-  
+
 
   /**
    * Removes an element from the {@link #listOfCurveSegments}.
    *
-   * @param curveSegment the element to be removed from the list.
+   * @param curveSegment
+   *        the element to be removed from the list.
    * @return {@code true} if the list contained the specified element and it was
    *         removed.
    * @see java.util.List#remove(Object)
@@ -384,12 +414,16 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
     return false;
   }
 
+
   /**
-   * Removes an element from the {@link #listOfCurveSegments} at the given index.
+   * Removes an element from the {@link #listOfCurveSegments} at the given
+   * index.
    *
-   * @param i the index where to remove the {@link CurveSegment}.
+   * @param i
+   *        the index where to remove the {@link CurveSegment}.
    * @return the specified element if it was successfully found and removed.
-   * @throws IndexOutOfBoundsException if the listOf is not set or if the index is
+   * @throws IndexOutOfBoundsException
+   *         if the listOf is not set or if the index is
    *         out of bound ({@code (i < 0) || (i > listOfCurveSegments)}).
    */
   public CurveSegment removeCurveSegment(int i) {
@@ -398,6 +432,7 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
     }
     return getListOfCurveSegments().remove(i);
   }
+
 
   /**
    * Creates a new {@link LineSegment} instance and adds it to the
@@ -412,6 +447,7 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
     return curveSegment;
   }
 
+
   /**
    * Creates a new {@link CubicBezier} instance and adds it to the
    * {@link #listOfCurveSegments} list.
@@ -425,13 +461,16 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
     return curveSegment;
   }
 
+
   /**
    * Gets an element from the {@link #listOfCurveSegments} at the given index.
    *
-   * @param i the index of the {@link CurveSegment} element to get.
+   * @param i
+   *        the index of the {@link CurveSegment} element to get.
    * @return an element from the listOfCurveSegments at the given index.
-   * @throws IndexOutOfBoundsException if the listOf is not set or
-   * if the index is out of bound (index < 0 || index > list.size).
+   * @throws IndexOutOfBoundsException
+   *         if the listOf is not set or
+   *         if the index is out of bound (index < 0 || index > list.size).
    */
   public CurveSegment getCurveSegment(int i) {
     if (!isSetListOfCurveSegments()) {
@@ -439,6 +478,7 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
     }
     return getListOfCurveSegments().get(i);
   }
+
 
   /**
    * Returns the number of {@link CurveSegment}s in this
@@ -450,6 +490,7 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
   public int getCurveSegmentCount() {
     return isSetListOfCurveSegments() ? getListOfCurveSegments().size() : 0;
   }
+
 
   /**
    * Returns the number of {@link CurveSegment}s in this
@@ -463,8 +504,9 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
     return getCurveSegmentCount();
   }
 
-  
-  /* (non-Javadoc)
+
+  /*
+   * (non-Javadoc)
    * @see java.lang.Object#hashCode()
    */
   @Override
@@ -472,13 +514,15 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
     final int prime = 3167;
     int result = super.hashCode();
     result = prime * result
-        + ((listOfCurveSegments == null) ? 0 : listOfCurveSegments.hashCode());
+      + ((listOfCurveSegments == null) ? 0 : listOfCurveSegments.hashCode());
     result = prime * result
-        + ((listOfElements == null) ? 0 : listOfElements.hashCode());
+      + ((listOfElements == null) ? 0 : listOfElements.hashCode());
     return result;
   }
 
-  /* (non-Javadoc)
+
+  /*
+   * (non-Javadoc)
    * @see java.lang.Object#equals(java.lang.Object)
    */
   @Override
@@ -509,6 +553,4 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
     }
     return true;
   }
-
-  
 }

--- a/extensions/render/src/org/sbml/jsbml/ext/render/Rectangle.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/Rectangle.java
@@ -22,6 +22,7 @@ package org.sbml.jsbml.ext.render;
 import java.text.MessageFormat;
 import java.util.Map;
 
+import org.sbml.jsbml.JSBML;
 import org.sbml.jsbml.PropertyUndefinedError;
 import org.sbml.jsbml.SBase;
 
@@ -564,7 +565,14 @@ public class Rectangle extends GraphicalPrimitive2D implements Point3D {
         setRy(new RelAbsVector(value));
       }
       else if (attributeName.equals(RenderConstants.ratio)) {
-        setRatio(XMLTools.parsePosition(value));
+        try {
+          // Note: this is done for validation; XMLTools would take care of
+          // invalid doubles
+          Double.parseDouble(value.trim());
+          setRatio(XMLTools.parsePosition(value)); 
+        } catch (NumberFormatException e) {
+          putUserObject(JSBML.INVALID_XML, value);
+        }
       }
       else {
         isAttributeRead = false;

--- a/extensions/render/src/org/sbml/jsbml/ext/render/Rectangle.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/Rectangle.java
@@ -22,7 +22,6 @@ package org.sbml.jsbml.ext.render;
 import java.text.MessageFormat;
 import java.util.Map;
 
-import org.sbml.jsbml.JSBML;
 import org.sbml.jsbml.PropertyUndefinedError;
 import org.sbml.jsbml.SBase;
 
@@ -571,7 +570,7 @@ public class Rectangle extends GraphicalPrimitive2D implements Point3D {
           Double.parseDouble(value.trim());
           setRatio(XMLTools.parsePosition(value)); 
         } catch (NumberFormatException e) {
-          putUserObject(JSBML.INVALID_XML, value);
+          XMLTools.addToInvalidXMLUserObject(this, attributeName, value);
         }
       }
       else {

--- a/extensions/render/src/org/sbml/jsbml/ext/render/RelAbsVector.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/RelAbsVector.java
@@ -40,7 +40,7 @@ public class RelAbsVector extends AbstractTreeNode {
   private Double absolute;
   private Double relative;
   
-  private static final String ABSOLUTE_PATTERN = "-?((.\\d+)|(\\d+(\\.\\d*)?))";
+  private static final String ABSOLUTE_PATTERN = "-?((\\.\\d+)|(\\d+(\\.\\d*)?))";
   private static final String RELATIVE_PATTERN = ABSOLUTE_PATTERN + "\\%";
   
   public RelAbsVector() {
@@ -250,7 +250,6 @@ public class RelAbsVector extends AbstractTreeNode {
         // Allowed variant 2: Absolute followed by relative
         } else if (entries.length == 2 && entries[0].matches(ABSOLUTE_PATTERN)
           && entries[1].matches(RELATIVE_PATTERN)) {
-          
           setAbsoluteValue(Double.parseDouble(entries[0]));
           setRelativeValue(Double.parseDouble(
             entries[1].substring(0, entries[1].length() - 1)));

--- a/extensions/render/src/org/sbml/jsbml/ext/render/RelAbsVector.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/RelAbsVector.java
@@ -178,6 +178,7 @@ public class RelAbsVector extends AbstractTreeNode {
    * @return whether the absolute value is set to a number
    */
   public boolean isSetAbsoluteValue() {
+    // Note: second check is relied upon by Validator (e.g. EllipseConstraint)!
     return absolute != null && !absolute.isNaN();
   }
   
@@ -185,6 +186,7 @@ public class RelAbsVector extends AbstractTreeNode {
    * @return whether the relative value is set to a number
    */
   public boolean isSetRelativeValue() {
+    // Note: second check is relied upon by Validator (e.g. EllipseConstraint)!
     return relative != null && !relative.isNaN();
   }
   

--- a/extensions/render/src/org/sbml/jsbml/ext/render/RenderConstants.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/RenderConstants.java
@@ -173,7 +173,7 @@ public class RenderConstants {
    */
   public static final String z1 = "z1";
   /**
-   * 
+   *
    */
   public static final String x2 = "x2";
   /**
@@ -184,6 +184,7 @@ public class RenderConstants {
    * 
    */
   public static final String z2 = "z2";
+
   
   // COPASI and the render-specification (January 2020) use camel-case basePoint 
   /**
@@ -547,6 +548,35 @@ public class RenderConstants {
   
   /** Refers to the relative part of a RelAbsVector */
   public static final String relativeValue = "relativeValue";
+
+  /** For DefaultValues */
+  public static final String linearGradient_x1 = "linearGradient_x1";
+  /** For DefaultValues */
+  public static final String linearGradient_y1 = "linearGradient_y1";
+  /** For DefaultValues */
+  public static final String linearGradient_z1 = "linearGradient_z1";
+  /** For DefaultValues */
+  public static final String linearGradient_x2 = "linearGradient_x2";
+  /** For DefaultValues */
+  public static final String linearGradient_y2 = "linearGradient_y2";
+  /** For DefaultValues */
+  public static final String linearGradient_z2 = "linearGradient_z2";
+  /** For DefaultValues */
+  public static final String radialGradient_cx = "radialGradient_cx";
+  /** For DefaultValues */
+  public static final String radialGradient_cy = "radialGradient_cy";
+  /** For DefaultValues */
+  public static final String radialGradient_cz = "radialGradient_cz";
+  /** For DefaultValues */
+  public static final String radialGradient_r = "radialGradient_r";
+  /** For DefaultValues */
+  public static final String radialGradient_fx = "radialGradient_fx";
+  /** For DefaultValues */
+  public static final String radialGradient_fy = "radialGradient_fy";
+  /** For DefaultValues */
+  public static final String radialGradient_fz = "radialGradient_fz";
+  /** For DefaultValues */
+  public static final String default_z = "default_z";
   
   /**
    * Returns the namespace URI corresponding to the given level and version.

--- a/extensions/render/src/org/sbml/jsbml/ext/render/RenderConstants.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/RenderConstants.java
@@ -344,9 +344,9 @@ public class RenderConstants {
    */
   public static final String href = "href";
   /**
-   * 
+   * This previously (before 2020/03) held the outdated value "enable-rotation-mapping" 
    */
-  public static final String enableRotationMapping = "enable-rotation-mapping";
+  public static final String enableRotationMapping = "enableRotationalMapping"; 
   /**
    * 
    */

--- a/extensions/render/src/org/sbml/jsbml/ext/render/RenderCubicBezier.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/RenderCubicBezier.java
@@ -262,7 +262,7 @@ public class RenderCubicBezier extends RenderPoint {
     if (isSetX1()) {
       RelAbsVector oldX1 = x1;
       x1 = null;
-      firePropertyChange(RenderConstants.x1, oldX1, x1);
+      firePropertyChange(RenderConstants.basepoint1_x, oldX1, x1);
       return true;
     }
     return false;

--- a/extensions/render/src/org/sbml/jsbml/ext/render/RenderCurve.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/RenderCurve.java
@@ -314,6 +314,14 @@ public class RenderCurve extends GraphicalPrimitive1D implements ICurve {
     }
     return true;
   }
+  
+  /**
+   * @return {@code true} iff listOfElements is not {@code null}, but empty
+   *         (relevant for validation)
+   */
+  public boolean isListOfElementsEmpty() {
+    return listOfElements != null && listOfElements.isEmpty();
+  }
 
   /**
    * @return the listOfElements
@@ -439,6 +447,14 @@ public class RenderCurve extends GraphicalPrimitive1D implements ICurve {
       return false;
     }
     return true;
+  }
+  
+  /**
+   * @return {@code true} iff listOfCurveSegments is not {@code null}, but empty
+   *         (relevant for validation)
+   */
+  public boolean isListOfCurveSegmentsEmpty() {
+    return listOfCurveSegments != null && listOfCurveSegments.isEmpty();
   }
 
   /**

--- a/extensions/render/src/org/sbml/jsbml/ext/render/RenderCurve.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/RenderCurve.java
@@ -699,7 +699,7 @@ public class RenderCurve extends GraphicalPrimitive1D implements ICurve {
       }
       pos++;
     }
-    
+    // TODO 2020/03: cf Polygon: Can cause problems, bc super can also have children (notes, annotation)
     throw new IndexOutOfBoundsException(MessageFormat.format(
       resourceBundle.getString("IndexExceedsBoundsException"), childIndex,
       Math.min(pos, 0)));

--- a/extensions/render/src/org/sbml/jsbml/ext/render/RenderCurveSegment.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/RenderCurveSegment.java
@@ -253,6 +253,7 @@ public abstract class RenderCurveSegment extends AbstractSBase implements Point3
         }
         catch (Exception e)
         {
+          XMLTools.addToInvalidXMLUserObject(this, attributeName, value);
           throw new SBMLException("Could not recognized the value '" + value
             + "' for the attribute " + RenderConstants.type
             + " on a 'RenderPoint' or 'RenderCubicBezier' element.");

--- a/extensions/render/src/org/sbml/jsbml/ext/render/RenderGroup.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/RenderGroup.java
@@ -1088,10 +1088,24 @@ public class RenderGroup extends GraphicalPrimitive2D implements UniqueNamedSBas
         setFontSize(Short.valueOf(value));
       }
       else if (attributeName.equals(RenderConstants.fontWeightBold)) {
-        setFontWeightBold(XMLTools.parseFontWeightBold(value));
+        if (value.toLowerCase().equals(RenderConstants.fontWeightBoldFalse)
+          || value.toLowerCase().equals(RenderConstants.fontWeightBoldTrue)) {
+          setFontWeightBold(XMLTools.parseFontWeightBold(value));
+        } else {
+          throw new SBMLException(
+            "Could not recognized the value '" + value + "' for the attribute "
+              + RenderConstants.fontWeightBold + " on the 'g' element.");
+        }
       }
       else if (attributeName.equals(RenderConstants.fontStyleItalic)) {
-        setFontStyleItalic(XMLTools.parseFontStyleItalic(value));
+        if (value.toLowerCase().equals(RenderConstants.fontStyleItalicFalse)
+          || value.toLowerCase().equals(RenderConstants.fontStyleItalicTrue)) {
+          setFontStyleItalic(XMLTools.parseFontStyleItalic(value));
+        } else {
+          throw new SBMLException(
+            "Could not recognized the value '" + value + "' for the attribute "
+              + RenderConstants.fontStyleItalic + " on the 'g' element.");
+        }
       }
       else if (attributeName.equals(RenderConstants.textAnchor)) {
         try {

--- a/extensions/render/src/org/sbml/jsbml/ext/render/RenderGroup.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/RenderGroup.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import javax.swing.tree.TreeNode;
 
+import org.sbml.jsbml.JSBML;
 import org.sbml.jsbml.ListOf;
 import org.sbml.jsbml.PropertyUndefinedError;
 import org.sbml.jsbml.SBMLException;
@@ -1079,6 +1080,7 @@ public class RenderGroup extends GraphicalPrimitive2D implements UniqueNamedSBas
         try {
           setFontFamily(value);
         } catch (Exception e) {
+          putUserObject(JSBML.INVALID_XML, value);
           throw new SBMLException("Could not recognized the value '" + value
               + "' for the attribute " + RenderConstants.fontFamily
               + " on the 'g' element.");
@@ -1092,6 +1094,7 @@ public class RenderGroup extends GraphicalPrimitive2D implements UniqueNamedSBas
           || value.toLowerCase().equals(RenderConstants.fontWeightBoldTrue)) {
           setFontWeightBold(XMLTools.parseFontWeightBold(value));
         } else {
+          putUserObject(JSBML.INVALID_XML, value);
           throw new SBMLException(
             "Could not recognized the value '" + value + "' for the attribute "
               + RenderConstants.fontWeightBold + " on the 'g' element.");
@@ -1102,6 +1105,7 @@ public class RenderGroup extends GraphicalPrimitive2D implements UniqueNamedSBas
           || value.toLowerCase().equals(RenderConstants.fontStyleItalicTrue)) {
           setFontStyleItalic(XMLTools.parseFontStyleItalic(value));
         } else {
+          putUserObject(JSBML.INVALID_XML, value);
           throw new SBMLException(
             "Could not recognized the value '" + value + "' for the attribute "
               + RenderConstants.fontStyleItalic + " on the 'g' element.");
@@ -1111,6 +1115,7 @@ public class RenderGroup extends GraphicalPrimitive2D implements UniqueNamedSBas
         try {
           setTextAnchor(HTextAnchor.valueOf(value.toUpperCase()));
         } catch (Exception e) {
+          putUserObject(JSBML.INVALID_XML, value);
           throw new SBMLException("Could not recognized the value '" + value
               + "' for the attribute " + RenderConstants.textAnchor
               + " on the 'g' element.");
@@ -1120,6 +1125,7 @@ public class RenderGroup extends GraphicalPrimitive2D implements UniqueNamedSBas
         try {
           setVTextAnchor(VTextAnchor.valueOf(value.toUpperCase()));
         } catch (Exception e) {
+          putUserObject(JSBML.INVALID_XML, value);
           throw new SBMLException("Could not recognized the value '" + value
               + "' for the attribute " + RenderConstants.vTextAnchor
               + " on the 'g' element.");

--- a/extensions/render/src/org/sbml/jsbml/ext/render/RenderGroup.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/RenderGroup.java
@@ -1080,7 +1080,7 @@ public class RenderGroup extends GraphicalPrimitive2D implements UniqueNamedSBas
         try {
           setFontFamily(value);
         } catch (Exception e) {
-          putUserObject(JSBML.INVALID_XML, value);
+          XMLTools.addToInvalidXMLUserObject(this, attributeName, value);
           throw new SBMLException("Could not recognized the value '" + value
               + "' for the attribute " + RenderConstants.fontFamily
               + " on the 'g' element.");
@@ -1094,7 +1094,7 @@ public class RenderGroup extends GraphicalPrimitive2D implements UniqueNamedSBas
           || value.toLowerCase().equals(RenderConstants.fontWeightBoldTrue)) {
           setFontWeightBold(XMLTools.parseFontWeightBold(value));
         } else {
-          putUserObject(JSBML.INVALID_XML, value);
+          XMLTools.addToInvalidXMLUserObject(this, attributeName, value);
           throw new SBMLException(
             "Could not recognized the value '" + value + "' for the attribute "
               + RenderConstants.fontWeightBold + " on the 'g' element.");
@@ -1105,7 +1105,7 @@ public class RenderGroup extends GraphicalPrimitive2D implements UniqueNamedSBas
           || value.toLowerCase().equals(RenderConstants.fontStyleItalicTrue)) {
           setFontStyleItalic(XMLTools.parseFontStyleItalic(value));
         } else {
-          putUserObject(JSBML.INVALID_XML, value);
+          XMLTools.addToInvalidXMLUserObject(this, attributeName, value);
           throw new SBMLException(
             "Could not recognized the value '" + value + "' for the attribute "
               + RenderConstants.fontStyleItalic + " on the 'g' element.");
@@ -1115,7 +1115,7 @@ public class RenderGroup extends GraphicalPrimitive2D implements UniqueNamedSBas
         try {
           setTextAnchor(HTextAnchor.valueOf(value.toUpperCase()));
         } catch (Exception e) {
-          putUserObject(JSBML.INVALID_XML, value);
+          XMLTools.addToInvalidXMLUserObject(this, attributeName, value);
           throw new SBMLException("Could not recognized the value '" + value
               + "' for the attribute " + RenderConstants.textAnchor
               + " on the 'g' element.");
@@ -1125,7 +1125,7 @@ public class RenderGroup extends GraphicalPrimitive2D implements UniqueNamedSBas
         try {
           setVTextAnchor(VTextAnchor.valueOf(value.toUpperCase()));
         } catch (Exception e) {
-          putUserObject(JSBML.INVALID_XML, value);
+          XMLTools.addToInvalidXMLUserObject(this, attributeName, value);
           throw new SBMLException("Could not recognized the value '" + value
               + "' for the attribute " + RenderConstants.vTextAnchor
               + " on the 'g' element.");

--- a/extensions/render/src/org/sbml/jsbml/ext/render/RenderGroup.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/RenderGroup.java
@@ -26,7 +26,6 @@ import java.util.Map;
 
 import javax.swing.tree.TreeNode;
 
-import org.sbml.jsbml.JSBML;
 import org.sbml.jsbml.ListOf;
 import org.sbml.jsbml.PropertyUndefinedError;
 import org.sbml.jsbml.SBMLException;
@@ -756,6 +755,14 @@ public class RenderGroup extends GraphicalPrimitive2D implements UniqueNamedSBas
       return false;
     }
     return true;
+  }
+  
+  /**
+   * @return {@code true} iff listOfCurveSegments is not {@code null}, but empty
+   *         (relevant for validation)
+   */
+  public boolean isListOfElementsEmpty() {
+    return listOfElements != null && listOfElements.isEmpty();
   }
 
 

--- a/extensions/render/src/org/sbml/jsbml/ext/render/RenderInformationBase.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/RenderInformationBase.java
@@ -459,6 +459,14 @@ public class RenderInformationBase extends AbstractNamedSBase implements UniqueN
     }
     return true;
   }
+  
+  /**
+   * @return {@code true} iff listOfColorDefinitions is not {@code null}, but empty
+   *         (relevant for validation)
+   */
+  public boolean isListOfColorDefinitionsEmpty() {
+    return listOfColorDefinitions != null && listOfColorDefinitions.isEmpty();
+  }
 
   /**
    * @return the listOfColorDefinitions
@@ -558,6 +566,14 @@ public class RenderInformationBase extends AbstractNamedSBase implements UniqueN
       return false;
     }
     return true;
+  }
+  
+  /**
+   * @return {@code true} iff listOfGradientDefinitions is not {@code null}, but empty
+   *         (relevant for validation)
+   */
+  public boolean isListOfGradientDefinitionsEmpty() {
+    return listOfGradientDefinitions != null && listOfGradientDefinitions.isEmpty();
   }
 
   /**
@@ -711,6 +727,14 @@ public class RenderInformationBase extends AbstractNamedSBase implements UniqueN
       return false;
     }
     return true;
+  }
+  
+  /**
+   * @return {@code true} iff listOfLineEndings is not {@code null}, but empty
+   *         (relevant for validation)
+   */
+  public boolean isListOfLineEndingsEmpty() {
+    return listOfLineEndings != null && listOfLineEndings.isEmpty();
   }
 
 

--- a/extensions/render/src/org/sbml/jsbml/ext/render/RenderLayoutPlugin.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/RenderLayoutPlugin.java
@@ -123,10 +123,15 @@ public class RenderLayoutPlugin extends AbstractRenderPlugin {
    *         otherwise {@code false}
    */
   public boolean isSetListOfLocalRenderInformation() {
-    if ((listOfLocalRenderInformation == null) || listOfLocalRenderInformation.isEmpty()) {
-      return false;
-    }
-    return true;
+    return listOfLocalRenderInformation != null && !listOfLocalRenderInformation.isEmpty();
+  }
+  
+  /**
+   * @return {@code true} iff listOfLocalRenderInformation is not {@code null}, but empty
+   *         (relevant for validation)
+   */
+  public boolean isListOfLocalRenderInformationEmpty() {
+    return listOfLocalRenderInformation != null && listOfLocalRenderInformation.isEmpty();
   }
 
   /**

--- a/extensions/render/src/org/sbml/jsbml/ext/render/RenderListOfLayoutsPlugin.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/RenderListOfLayoutsPlugin.java
@@ -170,12 +170,17 @@ public class RenderListOfLayoutsPlugin extends AbstractRenderPlugin {
    *         otherwise {@code false}
    */
   public boolean isSetListOfGlobalRenderInformation() {
-    if (listOfGlobalRenderInformation == null) {
-      return false;
-    }
-    return true;
+    return listOfGlobalRenderInformation != null && !listOfGlobalRenderInformation.isEmpty();
   }
 
+  /**
+   * @return {@code true} iff listOfGlobalRenderInformation is not {@code null}, but empty
+   *         (relevant for validation)
+   */
+  public boolean isListOfGlobalRenderInformationEmpty() {
+    return listOfGlobalRenderInformation != null && listOfGlobalRenderInformation.isEmpty();
+  }
+  
   /**
    * @param field
    * @return

--- a/extensions/render/src/org/sbml/jsbml/ext/render/Text.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/Text.java
@@ -21,6 +21,7 @@ package org.sbml.jsbml.ext.render;
 
 import java.util.Map;
 
+import org.sbml.jsbml.JSBML;
 import org.sbml.jsbml.PropertyUndefinedError;
 import org.sbml.jsbml.SBMLException;
 
@@ -45,7 +46,7 @@ public class Text extends GraphicalPrimitive1D implements FontRenderStyle, Point
   /**
    * 
    */
-  private Short fontSize;
+  private RelAbsVector fontSize;
   /**
    * 
    */
@@ -130,7 +131,7 @@ public class Text extends GraphicalPrimitive1D implements FontRenderStyle, Point
    * @see org.sbml.jsbml.ext.render.FontRenderStyle#getFontSize()
    */
   @Override
-  public short getFontSize() {
+  public RelAbsVector getFontSize() {
     if (isSetFontSize()) {
       return fontSize;
     }
@@ -337,8 +338,8 @@ public class Text extends GraphicalPrimitive1D implements FontRenderStyle, Point
    * @see org.sbml.jsbml.ext.render.FontRenderStyle#setFontSize(short)
    */
   @Override
-  public void setFontSize(short fontSize) {
-    Short oldFontSize = this.fontSize;
+  public void setFontSize(RelAbsVector fontSize) {
+    RelAbsVector oldFontSize = this.fontSize;
     this.fontSize = fontSize;
     firePropertyChange(RenderConstants.fontSize, oldFontSize, this.fontSize);
   }
@@ -443,7 +444,7 @@ public class Text extends GraphicalPrimitive1D implements FontRenderStyle, Point
   @Override
   public boolean unsetFontSize() {
     if (isSetFontSize()) {
-      Short oldFontSize = fontSize;
+      RelAbsVector oldFontSize = fontSize;
       fontSize = null;
       firePropertyChange(RenderConstants.fontSize, oldFontSize, fontSize);
       return true;
@@ -586,7 +587,7 @@ public class Text extends GraphicalPrimitive1D implements FontRenderStyle, Point
     }
     if (isSetFontSize()) {
       attributes.put(RenderConstants.shortLabel + ':' + RenderConstants.fontSize,
-        Short.toString(getFontSize()));
+        getFontSize().getCoordinate());
     }
     if (isSetX()) {
       attributes.put(RenderConstants.shortLabel + ':' + RenderConstants.x,
@@ -626,7 +627,8 @@ public class Text extends GraphicalPrimitive1D implements FontRenderStyle, Point
         try {
           setFontFamily(value);
         } catch (Exception e) {
-          throw new SBMLException("Could not recognized the value '" + value
+          putUserObject(JSBML.INVALID_XML, value);
+          throw new SBMLException("Could not recognize the value '" + value
               + "' for the attribute " + RenderConstants.fontFamily
               + " on the 'text' element.");
         }
@@ -635,7 +637,8 @@ public class Text extends GraphicalPrimitive1D implements FontRenderStyle, Point
         try {
           setTextAnchor(HTextAnchor.valueOf(value.toUpperCase()));
         } catch (Exception e) {
-          throw new SBMLException("Could not recognized the value '" + value
+          putUserObject(JSBML.INVALID_XML, value);
+          throw new SBMLException("Could not recognize the value '" + value
               + "' for the attribute " + RenderConstants.textAnchor
               + " on the 'text' element.");
         }
@@ -644,13 +647,14 @@ public class Text extends GraphicalPrimitive1D implements FontRenderStyle, Point
         try {
           setVTextAnchor(VTextAnchor.valueOf(value.toUpperCase()));
         } catch (Exception e) {
-          throw new SBMLException("Could not recognized the value '" + value
+          putUserObject(JSBML.INVALID_XML, value);
+          throw new SBMLException("Could not recognize the value '" + value
               + "' for the attribute " + RenderConstants.vTextAnchor
               + " on the 'text' element.");
         }
       }
       else if (attributeName.equals(RenderConstants.fontSize)) {
-        setFontSize(Short.valueOf(value));
+        setFontSize(new RelAbsVector(value));
       }
       else if (attributeName.equals(RenderConstants.x)) {
         setX(new RelAbsVector(value));
@@ -662,10 +666,26 @@ public class Text extends GraphicalPrimitive1D implements FontRenderStyle, Point
         setZ(new RelAbsVector(value));
       }
       else if (attributeName.equals(RenderConstants.fontStyleItalic)) {
-        setFontStyleItalic(XMLTools.parseFontStyleItalic(value));
+        if (value.toLowerCase().equals(RenderConstants.fontStyleItalicFalse)
+            || value.toLowerCase().equals(RenderConstants.fontStyleItalicTrue)) {
+            setFontStyleItalic(XMLTools.parseFontStyleItalic(value));
+          } else {
+            putUserObject(JSBML.INVALID_XML, value);
+            throw new SBMLException(
+              "Could not recognize the value '" + value + "' for the attribute "
+                + RenderConstants.fontStyleItalic + " on the 'text' element.");
+          }
       }
       else if (attributeName.equals(RenderConstants.fontWeightBold)) {
-        setFontWeightBold(XMLTools.parseFontWeightBold(value));
+        if (value.toLowerCase().equals(RenderConstants.fontWeightBoldFalse)
+            || value.toLowerCase().equals(RenderConstants.fontWeightBoldTrue)) {
+            setFontWeightBold(XMLTools.parseFontWeightBold(value));
+          } else {
+            putUserObject(JSBML.INVALID_XML, value);
+            throw new SBMLException(
+              "Could not recognize the value '" + value + "' for the attribute "
+                + RenderConstants.fontWeightBold + " on the 'text' element.");
+          }
       }
       else {
         isAttributeRead = false;

--- a/extensions/render/src/org/sbml/jsbml/ext/render/Text.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/Text.java
@@ -627,7 +627,7 @@ public class Text extends GraphicalPrimitive1D implements FontRenderStyle, Point
         try {
           setFontFamily(value);
         } catch (Exception e) {
-          putUserObject(JSBML.INVALID_XML, value);
+          XMLTools.addToInvalidXMLUserObject(this, attributeName, value);
           throw new SBMLException("Could not recognize the value '" + value
               + "' for the attribute " + RenderConstants.fontFamily
               + " on the 'text' element.");
@@ -637,7 +637,7 @@ public class Text extends GraphicalPrimitive1D implements FontRenderStyle, Point
         try {
           setTextAnchor(HTextAnchor.valueOf(value.toUpperCase()));
         } catch (Exception e) {
-          putUserObject(JSBML.INVALID_XML, value);
+          XMLTools.addToInvalidXMLUserObject(this, attributeName, value);
           throw new SBMLException("Could not recognize the value '" + value
               + "' for the attribute " + RenderConstants.textAnchor
               + " on the 'text' element.");
@@ -647,7 +647,7 @@ public class Text extends GraphicalPrimitive1D implements FontRenderStyle, Point
         try {
           setVTextAnchor(VTextAnchor.valueOf(value.toUpperCase()));
         } catch (Exception e) {
-          putUserObject(JSBML.INVALID_XML, value);
+          XMLTools.addToInvalidXMLUserObject(this, attributeName, value);
           throw new SBMLException("Could not recognize the value '" + value
               + "' for the attribute " + RenderConstants.vTextAnchor
               + " on the 'text' element.");
@@ -670,7 +670,7 @@ public class Text extends GraphicalPrimitive1D implements FontRenderStyle, Point
             || value.toLowerCase().equals(RenderConstants.fontStyleItalicTrue)) {
             setFontStyleItalic(XMLTools.parseFontStyleItalic(value));
           } else {
-            putUserObject(JSBML.INVALID_XML, value);
+            XMLTools.addToInvalidXMLUserObject(this, attributeName, value);
             throw new SBMLException(
               "Could not recognize the value '" + value + "' for the attribute "
                 + RenderConstants.fontStyleItalic + " on the 'text' element.");
@@ -681,7 +681,7 @@ public class Text extends GraphicalPrimitive1D implements FontRenderStyle, Point
             || value.toLowerCase().equals(RenderConstants.fontWeightBoldTrue)) {
             setFontWeightBold(XMLTools.parseFontWeightBold(value));
           } else {
-            putUserObject(JSBML.INVALID_XML, value);
+            XMLTools.addToInvalidXMLUserObject(this, attributeName, value);
             throw new SBMLException(
               "Could not recognize the value '" + value + "' for the attribute "
                 + RenderConstants.fontWeightBold + " on the 'text' element.");

--- a/extensions/render/src/org/sbml/jsbml/ext/render/Text.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/Text.java
@@ -21,7 +21,6 @@ package org.sbml.jsbml.ext.render;
 
 import java.util.Map;
 
-import org.sbml.jsbml.JSBML;
 import org.sbml.jsbml.PropertyUndefinedError;
 import org.sbml.jsbml.SBMLException;
 

--- a/extensions/render/src/org/sbml/jsbml/ext/render/Transformation.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/Transformation.java
@@ -22,7 +22,6 @@ package org.sbml.jsbml.ext.render;
 import java.util.Map;
 
 import org.sbml.jsbml.AbstractSBase;
-import org.sbml.jsbml.JSBML;
 
 /**
  * @author Eugen Netz

--- a/extensions/render/src/org/sbml/jsbml/ext/render/Transformation.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/Transformation.java
@@ -22,6 +22,7 @@ package org.sbml.jsbml.ext.render;
 import java.util.Map;
 
 import org.sbml.jsbml.AbstractSBase;
+import org.sbml.jsbml.JSBML;
 
 /**
  * @author Eugen Netz
@@ -159,9 +160,12 @@ public class Transformation extends AbstractSBase {
 
     if (!isAttributeRead) {
       isAttributeRead = true;
-      // TODO: catch Exception if Enum.valueOf fails, generate logger output
       if (attributeName.equals(RenderConstants.transform)) {
-        setTransform(XMLTools.decodeStringToArrayDouble(value));
+        if(XMLTools.canDecodeStringToArrayDouble(value)) {
+          setTransform(XMLTools.decodeStringToArrayDouble(value));
+        } else {
+          XMLTools.addToInvalidXMLUserObject(this, attributeName, value);
+        }
       }
       else {
         isAttributeRead = false;

--- a/extensions/render/src/org/sbml/jsbml/ext/render/XMLTools.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/XMLTools.java
@@ -23,7 +23,13 @@ package org.sbml.jsbml.ext.render;
 import java.awt.Color;
 import java.util.Locale;
 
+import org.sbml.jsbml.JSBML;
 import org.sbml.jsbml.util.StringTools;
+import org.sbml.jsbml.util.TreeNodeWithChangeSupport;
+import org.sbml.jsbml.xml.XMLAttributes;
+import org.sbml.jsbml.xml.XMLNamespaces;
+import org.sbml.jsbml.xml.XMLNode;
+import org.sbml.jsbml.xml.XMLTriple;
 
 /**
  * Utility class to help write the XML
@@ -193,6 +199,22 @@ public class XMLTools {
     }
     return temp;
   }
+  
+  
+  /**
+   * Checks whether given value is a valid doubleArray (i.e. a
+   * comma-and-space-separated list of doubles)
+   * 
+   * @param value
+   * @return
+   */
+  public static boolean canDecodeStringToArrayDouble(String value) {
+    String[] array = value.split(", ");
+    for(String s : array) {
+      try { Double.parseDouble(s); } catch (NumberFormatException e) { return false; }
+    }
+    return true;
+  }
 
   /**
    * 
@@ -223,6 +245,33 @@ public class XMLTools {
       temp[i] = StringTools.parseSBMLShort(array[i]);
     }
     return temp;
+  }
+  
+  public static boolean canDecodeStringToArrayUnsignedInt(String value) {
+    String[] array = value.split(", ");
+    for (String s : array) {
+      try { Integer.parseUnsignedInt(s); } catch(NumberFormatException e) { return false; };
+    }
+    return true;
+  }
+  
+
+  /**
+   * (not quite object-oriented style)
+   * Helper to add an entry to the {@link JSBML.INVALID_XML}-{@link XMLNode} on given TreeNode
+   * @param t to which to add the UserObject/where to modify the userObject
+   * @param attributeName
+   * @param invalidValue
+   */
+  public static void addToInvalidXMLUserObject(TreeNodeWithChangeSupport t, String attributeName, String invalidValue) {
+    if(!t.isSetUserObjects() || !t.containsUserObjectKey(JSBML.INVALID_XML)) {
+      // TODO 2020/03: this is somewhat abusive code
+      t.putUserObject(JSBML.INVALID_XML,
+        new XMLNode(new XMLTriple(JSBML.INVALID_XML, "", ""),
+          (XMLAttributes) null, (XMLNamespaces) null, 0l, 0l));
+    }
+    XMLNode invalidNode = (XMLNode) t.getUserObject(JSBML.INVALID_XML);
+    invalidNode.addAttr(attributeName, invalidValue);
   }
 
 }

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/ColorDefinitionConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/ColorDefinitionConstraints.java
@@ -30,7 +30,8 @@ import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementVal
 import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
 
 /**
- * Defines validation rules (as {@link ValidationFunction} instances) for the {@link ColorDefinition} class.
+ * Defines validation rules (as {@link ValidationFunction} instances) for the
+ * {@link ColorDefinition} class.
  * 
  * @author David Emanuel Vetter
  */

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/ColorDefinitionConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/ColorDefinitionConstraints.java
@@ -82,22 +82,12 @@ public class ColorDefinitionConstraints extends AbstractConstraintDeclaration {
       };
       break;
     case RENDER_20504:
-      func = new ValidationFunction<ColorDefinition>() {
-
-        @Override
-        public boolean check(ValidationContext ctx, ColorDefinition t) {
-          // Check that render:value is of type String
-          // TODO 2020/03: on p. 79, only String is required, but value is
-          // actually supposed to be a colorString
-          return true;
-        }
-      };
-      break;
     case RENDER_20505:
       func = new ValidationFunction<ColorDefinition>() {
         @Override
         public boolean check(ValidationContext ctx, ColorDefinition t) {
-          // cf. ReferenceGlyphConstraints->LAYOUT_21112
+          // TODO 2020/03: For render:value, on p. 79, only String is required, but value is
+          // actually supposed to be a colorString
           return true;
         }
       };

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/ColorDefinitionConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/ColorDefinitionConstraints.java
@@ -63,7 +63,7 @@ public class ColorDefinitionConstraints extends AbstractConstraintDeclaration {
   @Override
   public ValidationFunction<?> getValidationFunction(int errorCode,
     ValidationContext context) {
-    ValidationFunction<ColorDefinition> func = null;
+    ValidationFunction<ColorDefinition> func;
     switch(errorCode) {
     case RENDER_20501:
       func = new UnknownCoreAttributeValidationFunction<ColorDefinition>();
@@ -91,6 +91,10 @@ public class ColorDefinitionConstraints extends AbstractConstraintDeclaration {
           return true;
         }
       };
+      break;
+      
+    default:
+      func = null;
       break;
     }
     return func;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/ColorDefinitionConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/ColorDefinitionConstraints.java
@@ -1,0 +1,107 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ *
+ * Copyright (C) 2009-2018 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The University of California, San Diego, La Jolla, CA, USA
+ * 5. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.ext.render.ColorDefinition;
+import org.sbml.jsbml.ext.render.RenderConstants;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the {@link ColorDefinition} class.
+ * 
+ * @author David Emanuel Vetter
+ */
+public class ColorDefinitionConstraints extends AbstractConstraintDeclaration {
+  
+  
+  @Override
+  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+    CHECK_CATEGORY category, ValidationContext context) {
+    switch(category) {
+    case GENERAL_CONSISTENCY:
+      addRangeToSet(set, RENDER_20501, RENDER_20505);
+      break;
+    default:
+      break;
+    }
+  }
+
+  /* (non-Javadoc)
+   * @see org.sbml.jsbml.validator.offline.constraints.ConstraintDeclaration#addErrorCodesForAttribute(java.util.Set, int, int, java.lang.String)
+   */
+  @Override
+  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+    int version, String attributeName, ValidationContext context) {
+    // TODO Auto-generated method stub
+  }
+
+
+  @Override
+  public ValidationFunction<?> getValidationFunction(int errorCode,
+    ValidationContext context) {
+    ValidationFunction<ColorDefinition> func = null;
+    switch(errorCode) {
+    case RENDER_20501:
+      func = new UnknownCoreAttributeValidationFunction<ColorDefinition>();
+      break;
+    case RENDER_20502:
+      func = new UnknownCoreElementValidationFunction<ColorDefinition>();
+      break;
+    case RENDER_20503:
+      func = new ValidationFunction<ColorDefinition>() {
+        @Override
+        public boolean check(ValidationContext ctx, ColorDefinition t) {
+          return t.isSetId() && t.isSetValue()
+            && new UnknownPackageAttributeValidationFunction<ColorDefinition>(
+              RenderConstants.shortLabel).check(ctx, t);
+        }
+      };
+      break;
+    case RENDER_20504:
+      func = new ValidationFunction<ColorDefinition>() {
+
+        @Override
+        public boolean check(ValidationContext ctx, ColorDefinition t) {
+          // Check that render:value is of type String
+          // TODO 2020/03: on p. 79, only String is required, but value is
+          // actually supposed to be a colorString
+          return true;
+        }
+      };
+      break;
+    case RENDER_20505:
+      func = new ValidationFunction<ColorDefinition>() {
+        @Override
+        public boolean check(ValidationContext ctx, ColorDefinition t) {
+          // cf. ReferenceGlyphConstraints->LAYOUT_21112
+          return true;
+        }
+      };
+      break;
+    }
+    return func;
+  }
+}

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/DefaultValuesConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/DefaultValuesConstraints.java
@@ -1,0 +1,413 @@
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.SBase;
+import org.sbml.jsbml.ext.render.DefaultValues;
+import org.sbml.jsbml.ext.render.HTextAnchor;
+import org.sbml.jsbml.ext.render.LineEnding;
+import org.sbml.jsbml.ext.render.RelAbsVector;
+import org.sbml.jsbml.ext.render.RenderConstants;
+import org.sbml.jsbml.ext.render.VTextAnchor;
+import org.sbml.jsbml.ext.render.GradientBase.Spread;
+import org.sbml.jsbml.ext.render.GraphicalPrimitive2D.FillRule;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
+
+
+public class DefaultValuesConstraints extends AbstractConstraintDeclaration {
+
+  @Override
+  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+    CHECK_CATEGORY category, ValidationContext context) {
+    switch(category) {
+    case GENERAL_CONSISTENCY:
+      addRangeToSet(set, RENDER_23001, RENDER_23032);
+      break;
+    default:
+      break;
+    }
+  }
+
+
+  @Override
+  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+    int version, String attributeName, ValidationContext context) {
+    // TODO Auto-generated method stub
+  }
+
+
+  @Override
+  public ValidationFunction<?> getValidationFunction(int errorCode,
+    ValidationContext context) {
+    ValidationFunction<DefaultValues> func = null;
+    switch(errorCode) {
+    case RENDER_23001:
+      func = new UnknownCoreAttributeValidationFunction<DefaultValues>();
+      break;
+    case RENDER_23002:
+      func = new UnknownCoreElementValidationFunction<DefaultValues>();
+      break;
+    case RENDER_23003:
+      func = new UnknownPackageAttributeValidationFunction<DefaultValues>(RenderConstants.shortLabel);
+      break;
+      
+    case RENDER_23004:
+    case RENDER_23006:
+    case RENDER_23008:
+    case RENDER_23010:
+      func = new ValidationFunction<DefaultValues>() {
+        @Override // Any string
+        public boolean check(ValidationContext ctx, DefaultValues t) { return true; }
+      };
+      break;
+      
+    case RENDER_23005:
+      func = new ValidationFunction<DefaultValues>() {
+        @Override
+        public boolean check(ValidationContext ctx, DefaultValues t) {
+          String value = t.getDefaultValue(RenderConstants.spreadMethod);
+          if(value != null) {
+            try {
+              Spread.valueOf(value.toUpperCase());
+            } catch (Exception e) {
+              return false;
+            }
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_23007:
+      func = new ValidationFunction<DefaultValues>() {
+        @Override
+        public boolean check(ValidationContext ctx, DefaultValues t) {
+          String value = t.getDefaultValue(RenderConstants.fillRule);
+          if(value != null) {
+            try {
+              FillRule.valueOf(value.toUpperCase());
+            } catch (Exception e) {
+              return false;
+            }
+          }
+          return true;
+        }
+        
+      };
+      break;
+    case RENDER_23009:
+      func = new ValidationFunction<DefaultValues>() {
+        @Override
+        public boolean check(ValidationContext ctx, DefaultValues t) {
+          String value = t.getDefaultValue(RenderConstants.strokeWidth);
+          if(value != null) {
+            try {
+              Double.parseDouble(value.trim());
+            } catch (Exception e) {
+              return false;
+            }
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_23011:
+      func = new ValidationFunction<DefaultValues>() {
+        @Override
+        public boolean check(ValidationContext ctx, DefaultValues t) {
+          String value = t.getDefaultValue(RenderConstants.fontWeightBold);
+          if(value != null) {
+            value = value.toLowerCase();
+            return value.equals(RenderConstants.fontWeightBoldFalse)
+              || value.equals(RenderConstants.fontWeightBoldTrue);
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_23012:
+      func = new ValidationFunction<DefaultValues>() {
+        @Override
+        public boolean check(ValidationContext ctx, DefaultValues t) {
+          String value = t.getDefaultValue(RenderConstants.fontStyleItalic);
+          if(value != null) {
+            value = value.toLowerCase();
+            return value.equals(RenderConstants.fontStyleItalicFalse)
+              || value.equals(RenderConstants.fontStyleItalicTrue);
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_23013:
+      func = new ValidationFunction<DefaultValues>() {
+        @Override
+        public boolean check(ValidationContext ctx, DefaultValues t) {
+          String value = t.getDefaultValue(RenderConstants.textAnchor);
+          if(value != null) {
+            try {
+              HTextAnchor.valueOf(value.toUpperCase());
+            } catch (Exception e) {
+              return false;
+            }
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_23014:
+      func = new ValidationFunction<DefaultValues>() {
+        @Override
+        public boolean check(ValidationContext ctx, DefaultValues t) {
+          String value = t.getDefaultValue(RenderConstants.vTextAnchor);
+          if(value != null) {
+            try {
+              VTextAnchor.valueOf(value.toUpperCase());
+            } catch (Exception e) {
+              return false;
+            }
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_23015:
+      func = new ValidationFunction<DefaultValues>() {
+        @Override
+        public boolean check(ValidationContext ctx, DefaultValues t) {
+          String value = t.getDefaultValue(RenderConstants.startHead);
+          if(value != null) {
+            SBase referenced = t.getModel().getSBaseById(value);
+            return referenced != null && referenced instanceof LineEnding;
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_23016:
+      func = new ValidationFunction<DefaultValues>() {
+        @Override
+        public boolean check(ValidationContext ctx, DefaultValues t) {
+          String value = t.getDefaultValue(RenderConstants.endHead);
+          if(value != null) {
+            SBase referenced = t.getModel().getSBaseById(value);
+            return referenced != null && referenced instanceof LineEnding;
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_23017:
+      func = new ValidationFunction<DefaultValues>() {
+        @Override
+        public boolean check(ValidationContext ctx, DefaultValues t) {
+          String value = t.getDefaultValue(RenderConstants.enableRotationMapping);
+          if(value != null) {
+            try { Boolean.parseBoolean(value); } catch (Exception e) { return false; }
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_23018:
+      func = new ValidationFunction<DefaultValues>() {
+        @Override
+        public boolean check(ValidationContext ctx, DefaultValues t) {
+          String value = t.getDefaultValue(RenderConstants.linearGradient_x1);
+          if(value != null) {
+            RelAbsVector vec = new RelAbsVector(value);
+            return vec.isSetAbsoluteValue() || vec.isSetRelativeValue();
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_23019:
+      func = new ValidationFunction<DefaultValues>() {
+        @Override
+        public boolean check(ValidationContext ctx, DefaultValues t) {
+          String value = t.getDefaultValue(RenderConstants.linearGradient_y1);
+          if(value != null) {
+            RelAbsVector vec = new RelAbsVector(value);
+            return vec.isSetAbsoluteValue() || vec.isSetRelativeValue();
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_23020:
+      func = new ValidationFunction<DefaultValues>() {
+        @Override
+        public boolean check(ValidationContext ctx, DefaultValues t) {
+          String value = t.getDefaultValue(RenderConstants.linearGradient_z1);
+          if(value != null) {
+            RelAbsVector vec = new RelAbsVector(value);
+            return vec.isSetAbsoluteValue() || vec.isSetRelativeValue();
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_23021:
+      func = new ValidationFunction<DefaultValues>() {
+        @Override
+        public boolean check(ValidationContext ctx, DefaultValues t) {
+          String value = t.getDefaultValue(RenderConstants.linearGradient_x2);
+          if(value != null) {
+            RelAbsVector vec = new RelAbsVector(value);
+            return vec.isSetAbsoluteValue() || vec.isSetRelativeValue();
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_23022:
+      func = new ValidationFunction<DefaultValues>() {
+        @Override
+        public boolean check(ValidationContext ctx, DefaultValues t) {
+          String value = t.getDefaultValue(RenderConstants.linearGradient_y2);
+          if(value != null) {
+            RelAbsVector vec = new RelAbsVector(value);
+            return vec.isSetAbsoluteValue() || vec.isSetRelativeValue();
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_23023:
+      func = new ValidationFunction<DefaultValues>() {
+        @Override
+        public boolean check(ValidationContext ctx, DefaultValues t) {
+          String value = t.getDefaultValue(RenderConstants.linearGradient_z2);
+          if(value != null) {
+            RelAbsVector vec = new RelAbsVector(value);
+            return vec.isSetAbsoluteValue() || vec.isSetRelativeValue();
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_23024:
+      func = new ValidationFunction<DefaultValues>() {
+        @Override
+        public boolean check(ValidationContext ctx, DefaultValues t) {
+          String value = t.getDefaultValue(RenderConstants.radialGradient_cx);
+          if(value != null) {
+            RelAbsVector vec = new RelAbsVector(value);
+            return vec.isSetAbsoluteValue() || vec.isSetRelativeValue();
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_23025:
+      func = new ValidationFunction<DefaultValues>() {
+        @Override
+        public boolean check(ValidationContext ctx, DefaultValues t) {
+          String value = t.getDefaultValue(RenderConstants.radialGradient_cy);
+          if(value != null) {
+            RelAbsVector vec = new RelAbsVector(value);
+            return vec.isSetAbsoluteValue() || vec.isSetRelativeValue();
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_23026:
+      func = new ValidationFunction<DefaultValues>() {
+        @Override
+        public boolean check(ValidationContext ctx, DefaultValues t) {
+          String value = t.getDefaultValue(RenderConstants.radialGradient_cz);
+          if(value != null) {
+            RelAbsVector vec = new RelAbsVector(value);
+            return vec.isSetAbsoluteValue() || vec.isSetRelativeValue();
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_23027:
+      func = new ValidationFunction<DefaultValues>() {
+        @Override
+        public boolean check(ValidationContext ctx, DefaultValues t) {
+          String value = t.getDefaultValue(RenderConstants.radialGradient_r);
+          if(value != null) {
+            RelAbsVector vec = new RelAbsVector(value);
+            return vec.isSetAbsoluteValue() || vec.isSetRelativeValue();
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_23028:
+      func = new ValidationFunction<DefaultValues>() {
+        @Override
+        public boolean check(ValidationContext ctx, DefaultValues t) {
+          String value = t.getDefaultValue(RenderConstants.radialGradient_fx);
+          if(value != null) {
+            RelAbsVector vec = new RelAbsVector(value);
+            return vec.isSetAbsoluteValue() || vec.isSetRelativeValue();
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_23029:
+      func = new ValidationFunction<DefaultValues>() {
+        @Override
+        public boolean check(ValidationContext ctx, DefaultValues t) {
+          String value = t.getDefaultValue(RenderConstants.radialGradient_fy);
+          if(value != null) {
+            RelAbsVector vec = new RelAbsVector(value);
+            return vec.isSetAbsoluteValue() || vec.isSetRelativeValue();
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_23030:
+      func = new ValidationFunction<DefaultValues>() {
+        @Override
+        public boolean check(ValidationContext ctx, DefaultValues t) {
+          String value = t.getDefaultValue(RenderConstants.radialGradient_fz);
+          if(value != null) {
+            RelAbsVector vec = new RelAbsVector(value);
+            return vec.isSetAbsoluteValue() || vec.isSetRelativeValue();
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_23031:
+      func = new ValidationFunction<DefaultValues>() {
+        @Override
+        public boolean check(ValidationContext ctx, DefaultValues t) {
+          String value = t.getDefaultValue(RenderConstants.default_z);
+          if(value != null) {
+            RelAbsVector vec = new RelAbsVector(value);
+            return vec.isSetAbsoluteValue() || vec.isSetRelativeValue();
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_23032:
+      func = new ValidationFunction<DefaultValues>() {
+        @Override
+        public boolean check(ValidationContext ctx, DefaultValues t) {
+          String value = t.getDefaultValue(RenderConstants.fontSize);
+          if(value != null) {
+            RelAbsVector vec = new RelAbsVector(value);
+            return vec.isSetAbsoluteValue() || vec.isSetRelativeValue();
+          }
+          return true;
+        }
+      };
+      break;
+    }
+    return func;
+  }
+}

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/DefaultValuesConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/DefaultValuesConstraints.java
@@ -1,3 +1,22 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ *
+ * Copyright (C) 2009-2018 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The University of California, San Diego, La Jolla, CA, USA
+ * 5. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
 package org.sbml.jsbml.validator.offline.constraints;
 
 import java.util.Set;
@@ -17,7 +36,12 @@ import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeV
 import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
 import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
 
-
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the
+ * {@link DefaultValues} class.
+ * 
+ * @author David Emanuel Vetter
+ */
 public class DefaultValuesConstraints extends AbstractConstraintDeclaration {
 
   @Override

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/DefaultValuesConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/DefaultValuesConstraints.java
@@ -67,7 +67,7 @@ public class DefaultValuesConstraints extends AbstractConstraintDeclaration {
   @Override
   public ValidationFunction<?> getValidationFunction(int errorCode,
     ValidationContext context) {
-    ValidationFunction<DefaultValues> func = null;
+    ValidationFunction<DefaultValues> func;
     switch(errorCode) {
     case RENDER_23001:
       func = new UnknownCoreAttributeValidationFunction<DefaultValues>();
@@ -430,6 +430,10 @@ public class DefaultValuesConstraints extends AbstractConstraintDeclaration {
           return true;
         }
       };
+      break;
+      
+    default:
+      func = null;
       break;
     }
     return func;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/EllipseConstraint.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/EllipseConstraint.java
@@ -1,0 +1,147 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ *
+ * Copyright (C) 2009-2018 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The University of California, San Diego, La Jolla, CA, USA
+ * 5. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.JSBML;
+import org.sbml.jsbml.ext.render.Ellipse;
+import org.sbml.jsbml.ext.render.RenderConstants;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
+import org.sbml.jsbml.xml.XMLNode;
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the
+ * {@link Ellipse} class.
+ * 
+ * @author David Emanuel Vetter
+ */
+public class EllipseConstraint extends AbstractConstraintDeclaration {
+
+  @Override
+  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+    CHECK_CATEGORY category, ValidationContext context) {
+    switch(category) {
+    case GENERAL_CONSISTENCY:
+      addRangeToSet(set, RENDER_20601, RENDER_20609);
+      break;
+    default:
+      break;
+    }
+  }
+
+
+  @Override
+  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+    int version, String attributeName, ValidationContext context) {
+    // TODO Auto-generated method stub
+  }
+
+
+  @Override
+  public ValidationFunction<?> getValidationFunction(int errorCode,
+    ValidationContext context) {
+    ValidationFunction<Ellipse> func = null;
+    switch(errorCode) {
+    case RENDER_20601:
+      func = new UnknownCoreAttributeValidationFunction<Ellipse>();
+      break;
+    case RENDER_20602:
+      func = new UnknownCoreElementValidationFunction<Ellipse>();
+      break;
+    case RENDER_20603:
+      func = new UnknownPackageAttributeValidationFunction<Ellipse>(RenderConstants.shortLabel) {
+        @Override
+        public boolean check(ValidationContext ctx, Ellipse ellipse) {
+          return super.check(ctx, ellipse) && ellipse.isSetCx()
+            && ellipse.isSetCy() && ellipse.isSetRx();
+        }
+      };
+      break;
+    case RENDER_20604:
+      func = new ValidationFunction<Ellipse>() {
+        @Override
+        public boolean check(ValidationContext ctx, Ellipse ellipse) {
+          // See implementation of RelAbsVector: If the string does not conform
+          // with the rel-abs-vector-format, relative and absolute will be set
+          // to NaN (i.e. neither isSet); In any case: relative or absolute
+          // ought to be set when reading from file
+          return ellipse.isSetCx() && (ellipse.getCx().isSetAbsoluteValue()
+            || ellipse.getCx().isSetRelativeValue());
+        }
+      };
+      break;
+    case RENDER_20605:
+      func = new ValidationFunction<Ellipse>() {
+        @Override
+        public boolean check(ValidationContext ctx, Ellipse ellipse) {
+          return ellipse.isSetCy() && (ellipse.getCy().isSetAbsoluteValue()
+            || ellipse.getCy().isSetRelativeValue());
+        }
+      };
+      break;
+    case RENDER_20606:
+      func = new ValidationFunction<Ellipse>() {
+        @Override
+        public boolean check(ValidationContext ctx, Ellipse ellipse) {
+          return ellipse.isSetRx() && (ellipse.getRx().isSetAbsoluteValue()
+            || ellipse.getRx().isSetRelativeValue());
+        }
+      };
+      break;
+    case RENDER_20607:
+      func = new ValidationFunction<Ellipse>() {
+        @Override
+        public boolean check(ValidationContext ctx, Ellipse ellipse) {
+          if(ellipse.getUserObject(JSBML.UNKNOWN_XML) != null) {
+            XMLNode unknown = (XMLNode) ellipse.getUserObject(JSBML.UNKNOWN_XML);
+            return unknown.getAttrIndex(RenderConstants.ratio) == -1;
+            // != -1 means that ratio was not in a Number-format (invalid)
+          }
+          return true; // ratio may be infinite
+        }
+      };
+      break;
+    case RENDER_20608:
+      func = new ValidationFunction<Ellipse>() {
+        @Override
+        public boolean check(ValidationContext ctx, Ellipse ellipse) {
+          return !ellipse.isSetCz() || ellipse.getCz().isSetAbsoluteValue()
+            || ellipse.getCz().isSetRelativeValue();
+        }
+      };
+      break;
+    case RENDER_20609:
+      func = new ValidationFunction<Ellipse>() {
+        @Override
+        public boolean check(ValidationContext ctx, Ellipse ellipse) {
+          return !ellipse.isSetRy() || ellipse.getRy().isSetAbsoluteValue()
+            || ellipse.getRy().isSetRelativeValue();
+        }
+      };
+      break;
+    }
+    return func;
+  }
+}

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/EllipseConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/EllipseConstraints.java
@@ -21,15 +21,14 @@ package org.sbml.jsbml.validator.offline.constraints;
 
 import java.util.Set;
 
-import org.sbml.jsbml.JSBML;
 import org.sbml.jsbml.ext.render.Ellipse;
 import org.sbml.jsbml.ext.render.RenderConstants;
 import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
 import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.InvalidAttributeValidationFunction;
 import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
 import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
 import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
-import org.sbml.jsbml.xml.XMLNode;
 
 /**
  * Defines validation rules (as {@link ValidationFunction} instances) for the
@@ -111,17 +110,8 @@ public class EllipseConstraints extends AbstractConstraintDeclaration {
       };
       break;
     case RENDER_20607:
-      func = new ValidationFunction<Ellipse>() {
-        @Override
-        public boolean check(ValidationContext ctx, Ellipse ellipse) {
-          if(ellipse.getUserObject(JSBML.UNKNOWN_XML) != null) {
-            XMLNode unknown = (XMLNode) ellipse.getUserObject(JSBML.UNKNOWN_XML);
-            return unknown.getAttrIndex(RenderConstants.ratio) == -1;
-            // != -1 means that ratio was not in a Number-format (invalid)
-          }
-          return true; // ratio may be infinite
-        }
-      };
+      func =
+        new InvalidAttributeValidationFunction<Ellipse>(RenderConstants.ratio);
       break;
     case RENDER_20608:
       func = new ValidationFunction<Ellipse>() {

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/EllipseConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/EllipseConstraints.java
@@ -111,7 +111,11 @@ public class EllipseConstraints extends AbstractConstraintDeclaration {
       break;
     case RENDER_20607:
       func =
-        new InvalidAttributeValidationFunction<Ellipse>(RenderConstants.ratio);
+        new InvalidAttributeValidationFunction<Ellipse>(RenderConstants.ratio) {
+        public boolean check(ValidationContext ctx, Ellipse ellipse) {
+          return super.check(ctx, ellipse);
+        }
+      };
       break;
     case RENDER_20608:
       func = new ValidationFunction<Ellipse>() {

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/EllipseConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/EllipseConstraints.java
@@ -37,7 +37,7 @@ import org.sbml.jsbml.xml.XMLNode;
  * 
  * @author David Emanuel Vetter
  */
-public class EllipseConstraint extends AbstractConstraintDeclaration {
+public class EllipseConstraints extends AbstractConstraintDeclaration {
 
   @Override
   public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
@@ -62,6 +62,7 @@ public class EllipseConstraint extends AbstractConstraintDeclaration {
   @Override
   public ValidationFunction<?> getValidationFunction(int errorCode,
     ValidationContext context) {
+    System.out.println("Checking ellipse for " + errorCode);
     ValidationFunction<Ellipse> func = null;
     switch(errorCode) {
     case RENDER_20601:
@@ -96,6 +97,7 @@ public class EllipseConstraint extends AbstractConstraintDeclaration {
       func = new ValidationFunction<Ellipse>() {
         @Override
         public boolean check(ValidationContext ctx, Ellipse ellipse) {
+          System.out.println("605: " + ellipse.isSetCy() + " " + ellipse.getCy());
           return ellipse.isSetCy() && (ellipse.getCy().isSetAbsoluteValue()
             || ellipse.getCy().isSetRelativeValue());
         }

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/EllipseConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/EllipseConstraints.java
@@ -62,7 +62,6 @@ public class EllipseConstraints extends AbstractConstraintDeclaration {
   @Override
   public ValidationFunction<?> getValidationFunction(int errorCode,
     ValidationContext context) {
-    System.out.println("Checking ellipse for " + errorCode);
     ValidationFunction<Ellipse> func = null;
     switch(errorCode) {
     case RENDER_20601:
@@ -97,7 +96,6 @@ public class EllipseConstraints extends AbstractConstraintDeclaration {
       func = new ValidationFunction<Ellipse>() {
         @Override
         public boolean check(ValidationContext ctx, Ellipse ellipse) {
-          System.out.println("605: " + ellipse.isSetCy() + " " + ellipse.getCy());
           return ellipse.isSetCy() && (ellipse.getCy().isSetAbsoluteValue()
             || ellipse.getCy().isSetRelativeValue());
         }

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/EllipseConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/EllipseConstraints.java
@@ -61,7 +61,7 @@ public class EllipseConstraints extends AbstractConstraintDeclaration {
   @Override
   public ValidationFunction<?> getValidationFunction(int errorCode,
     ValidationContext context) {
-    ValidationFunction<Ellipse> func = null;
+    ValidationFunction<Ellipse> func;
     switch(errorCode) {
     case RENDER_20601:
       func = new UnknownCoreAttributeValidationFunction<Ellipse>();
@@ -134,6 +134,10 @@ public class EllipseConstraints extends AbstractConstraintDeclaration {
             || ellipse.getRy().isSetRelativeValue();
         }
       };
+      break;
+      
+    default:
+      func = null;
       break;
     }
     return func;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GlobalRenderInformationConstraint.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GlobalRenderInformationConstraint.java
@@ -1,0 +1,142 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ *
+ * Copyright (C) 2009-2018 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The University of California, San Diego, La Jolla, CA, USA
+ * 5. The Babraham Institute, Cambridge, UK
+ * 6. Marquette University, Milwaukee, WI, USA
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.ListOf;
+import org.sbml.jsbml.ext.render.GlobalRenderInformation;
+import org.sbml.jsbml.ext.render.LocalStyle;
+import org.sbml.jsbml.ext.render.RenderConstants;
+import org.sbml.jsbml.ext.render.Style;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.DuplicatedElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageElementValidationFunction;
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the
+ * {@link GlobalRenderInformation} class.
+ * 
+ * @author David Emanuel Vetter
+ */
+public class GlobalRenderInformationConstraint
+  extends AbstractConstraintDeclaration {
+
+  @Override
+  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+    CHECK_CATEGORY category, ValidationContext context) {
+    switch(category) {
+    case GENERAL_CONSISTENCY:
+      addRangeToSet(set, RENDER_20701, RENDER_20706);
+      break;
+    default:
+      break;
+    }
+  }
+
+
+  @Override
+  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+    int version, String attributeName, ValidationContext context) {
+    // TODO Auto-generated method stub
+  }
+
+
+  @Override
+  public ValidationFunction<?> getValidationFunction(int errorCode,
+    ValidationContext context) {
+    ValidationFunction<GlobalRenderInformation> func = null;
+    switch(errorCode) {
+    case RENDER_20701:
+      func = new UnknownCoreAttributeValidationFunction<GlobalRenderInformation>();
+      break;
+    case RENDER_20702:
+      func = new UnknownCoreElementValidationFunction<GlobalRenderInformation>();
+      break;
+    case RENDER_20703:
+      func = new ValidationFunction<GlobalRenderInformation>() {
+
+        @Override
+        public boolean check(ValidationContext ctx, GlobalRenderInformation t) {
+          return new DuplicatedElementValidationFunction<GlobalRenderInformation>(
+            RenderConstants.shortLabel + ":" + RenderConstants.listOfStyles)
+                                                                            .check(
+                                                                              ctx,
+                                                                              t)
+            && new UnknownPackageElementValidationFunction<GlobalRenderInformation>(
+              RenderConstants.shortLabel).check(ctx, t);
+        }
+        
+      };
+      break;
+    case RENDER_20704:
+      func = new ValidationFunction<GlobalRenderInformation>() {
+        @Override
+        public boolean check(ValidationContext ctx, GlobalRenderInformation t) {
+          if(t.isSetListOfStyles()) {
+            // TODO 2020/03: Issue: GlobalRenderInformation#isSetListOfStyles counts empty as unset
+            return !t.getListOfStyles().isEmpty();
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_20705:
+      func = new ValidationFunction<GlobalRenderInformation>() {
+
+        @Override
+        public boolean check(ValidationContext ctx, GlobalRenderInformation t) {
+          if(t.isSetListOfStyles()) {
+            ListOf<Style> styles = t.getListOfStyles();
+            boolean coreElementsOk =
+              new UnknownCoreElementValidationFunction<ListOf<Style>>().check(
+                ctx, styles);
+            boolean allStylesGlobal = true;
+            // All the elements must be Style, but not LocalStyle  
+            for(Style style : styles)
+              allStylesGlobal &= !(style instanceof LocalStyle);
+            
+            return coreElementsOk && allStylesGlobal;
+          }
+          return true;
+        }
+        
+      };
+      break;
+    case RENDER_20706:
+      func = new ValidationFunction<GlobalRenderInformation>() {
+        @Override
+        public boolean check(ValidationContext ctx, GlobalRenderInformation t) {
+          if (t.isSetListOfStyles()) {
+            return new UnknownCoreAttributeValidationFunction<ListOf<Style>>().check(
+              ctx, t.getListOfStyles());
+          }
+          return true;
+        }
+      };
+      break;
+    }
+    return func;
+  }
+}

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GlobalRenderInformationConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GlobalRenderInformationConstraints.java
@@ -75,19 +75,13 @@ public class GlobalRenderInformationConstraints
       func = new UnknownCoreElementValidationFunction<GlobalRenderInformation>();
       break;
     case RENDER_20703:
-      func = new ValidationFunction<GlobalRenderInformation>() {
-
+      func = new UnknownPackageElementValidationFunction<GlobalRenderInformation>(RenderConstants.shortLabel) {
         @Override
         public boolean check(ValidationContext ctx, GlobalRenderInformation t) {
-          return new DuplicatedElementValidationFunction<GlobalRenderInformation>(
-            RenderConstants.shortLabel + ":" + RenderConstants.listOfStyles)
-                                                                            .check(
-                                                                              ctx,
-                                                                              t)
-            && new UnknownPackageElementValidationFunction<GlobalRenderInformation>(
-              RenderConstants.shortLabel).check(ctx, t);
+            return super.check(ctx, t)
+              && new DuplicatedElementValidationFunction<GlobalRenderInformation>(
+                RenderConstants.listOfStyles).check(ctx, t);
         }
-        
       };
       break;
     case RENDER_20704:

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GlobalRenderInformationConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GlobalRenderInformationConstraints.java
@@ -40,7 +40,7 @@ import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageElement
  * 
  * @author David Emanuel Vetter
  */
-public class GlobalRenderInformationConstraint
+public class GlobalRenderInformationConstraints
   extends AbstractConstraintDeclaration {
 
   @Override

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GlobalRenderInformationConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GlobalRenderInformationConstraints.java
@@ -94,11 +94,7 @@ public class GlobalRenderInformationConstraints
       func = new ValidationFunction<GlobalRenderInformation>() {
         @Override
         public boolean check(ValidationContext ctx, GlobalRenderInformation t) {
-          if(t.isSetListOfStyles()) {
-            // TODO 2020/03: Issue: GlobalRenderInformation#isSetListOfStyles counts empty as unset
-            return !t.getListOfStyles().isEmpty();
-          }
-          return true;
+          return !t.isListOfStylesEmpty();
         }
       };
       break;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GlobalRenderInformationConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GlobalRenderInformationConstraints.java
@@ -66,7 +66,7 @@ public class GlobalRenderInformationConstraints
   @Override
   public ValidationFunction<?> getValidationFunction(int errorCode,
     ValidationContext context) {
-    ValidationFunction<GlobalRenderInformation> func = null;
+    ValidationFunction<GlobalRenderInformation> func;
     switch(errorCode) {
     case RENDER_20701:
       func = new UnknownCoreAttributeValidationFunction<GlobalRenderInformation>();
@@ -125,6 +125,10 @@ public class GlobalRenderInformationConstraints
           return true;
         }
       };
+      break;
+
+    default:
+      func = null;
       break;
     }
     return func;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GlobalStyleConstraint.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GlobalStyleConstraint.java
@@ -1,0 +1,72 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ *
+ * Copyright (C) 2009-2018 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The University of California, San Diego, La Jolla, CA, USA
+ * 5. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.ext.render.Style;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the
+ * {@link Style} class.
+ * 
+ * @author David Emanuel Vetter
+ */
+public class GlobalStyleConstraint extends AbstractConstraintDeclaration {
+
+  @Override
+  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+    CHECK_CATEGORY category, ValidationContext context) {
+    switch(category) {
+    case GENERAL_CONSISTENCY:
+      addRangeToSet(set, RENDER_20801, RENDER_20802);
+      break;
+    default:
+      break;
+    }
+  }
+
+
+  @Override
+  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+    int version, String attributeName, ValidationContext context) {
+    // TODO Auto-generated method stub
+  }
+
+
+  @Override
+  public ValidationFunction<?> getValidationFunction(int errorCode,
+    ValidationContext context) {
+    ValidationFunction<Style> func = null;
+    switch(errorCode) {
+    case RENDER_20801:
+      func = new UnknownCoreAttributeValidationFunction<Style>();
+      break;
+    case RENDER_20802:
+      func = new UnknownCoreElementValidationFunction<Style>();
+      break;
+    }
+    return func;
+  }
+}

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GradientBaseConstraint.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GradientBaseConstraint.java
@@ -1,0 +1,119 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ *
+ * Copyright (C) 2009-2018 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The University of California, San Diego, La Jolla, CA, USA
+ * 5. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.JSBML;
+import org.sbml.jsbml.ext.render.GradientBase;
+import org.sbml.jsbml.ext.render.RenderConstants;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageElementValidationFunction;
+import org.sbml.jsbml.xml.XMLNode;
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the
+ * {@link GradientBase} class.
+ * 
+ * @author David Emanuel Vetter
+ */
+public class GradientBaseConstraint extends AbstractConstraintDeclaration {
+
+  @Override
+  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+    CHECK_CATEGORY category, ValidationContext context) {
+    switch(category) {
+    case GENERAL_CONSISTENCY:
+      addRangeToSet(set, RENDER_20901, RENDER_20906);
+      break;
+    default:
+      break;
+    }
+  }
+
+
+  @Override
+  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+    int version, String attributeName, ValidationContext context) {
+    // TODO Auto-generated method stub
+  }
+
+
+  @Override
+  public ValidationFunction<?> getValidationFunction(int errorCode,
+    ValidationContext context) {
+    ValidationFunction<GradientBase> func = null;
+    switch(errorCode) {
+    case RENDER_20901:
+      func = new UnknownCoreAttributeValidationFunction<GradientBase>();
+      break;
+    case RENDER_20902:
+      func = new UnknownCoreElementValidationFunction<GradientBase>();
+      break;
+    case RENDER_20903:
+      func = new UnknownPackageAttributeValidationFunction<GradientBase>(RenderConstants.shortLabel) {
+        @Override
+        public boolean check(ValidationContext ctx, GradientBase base) {
+          return super.check(ctx, base) && base.isSetId();
+        }
+      };
+      break;
+    case RENDER_20904:
+      func = new UnknownPackageElementValidationFunction<GradientBase>(RenderConstants.shortLabel) {
+        @Override
+        public boolean check(ValidationContext ctx, GradientBase base) {
+          boolean hasGradientStops = base.isSetListOfGradientStops()
+            && !base.getListOfGradientStops().isEmpty();
+          return hasGradientStops && super.check(ctx, base);
+        }
+      };
+      break;
+    case RENDER_20905:
+      func = new ValidationFunction<GradientBase>() {
+        @Override
+        public boolean check(ValidationContext ctx, GradientBase t) {
+          // Optional 'name' is a String: nothing to check.
+          return true;
+        }
+      };
+      break;
+    case RENDER_20906:
+      func = new ValidationFunction<GradientBase>() {
+
+        @Override
+        public boolean check(ValidationContext ctx, GradientBase base) {
+          if(base.getUserObject(JSBML.UNKNOWN_XML) != null) {
+            XMLNode unknown = (XMLNode) base.getUserObject(JSBML.UNKNOWN_XML);
+            return unknown.getAttrIndex(RenderConstants.spreadMethod) == -1;
+            // TODO 2020/03: does this work?
+          }
+          return true;
+        }
+        
+      };
+      break;
+    }
+    return func;
+  }
+}

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GradientBaseConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GradientBaseConstraints.java
@@ -62,7 +62,7 @@ public class GradientBaseConstraints extends AbstractConstraintDeclaration {
   @Override
   public ValidationFunction<?> getValidationFunction(int errorCode,
     ValidationContext context) {
-    ValidationFunction<GradientBase> func = null;
+    ValidationFunction<GradientBase> func;
     switch(errorCode) {
     case RENDER_20901:
       func = new UnknownCoreAttributeValidationFunction<GradientBase>();
@@ -97,6 +97,10 @@ public class GradientBaseConstraints extends AbstractConstraintDeclaration {
       break;
     case RENDER_20906:
       func = new InvalidAttributeValidationFunction<GradientBase>(RenderConstants.spreadMethod);
+      break;
+
+    default:
+      func = null;
       break;
     }
     return func;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GradientBaseConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GradientBaseConstraints.java
@@ -38,7 +38,7 @@ import org.sbml.jsbml.xml.XMLNode;
  * 
  * @author David Emanuel Vetter
  */
-public class GradientBaseConstraint extends AbstractConstraintDeclaration {
+public class GradientBaseConstraints extends AbstractConstraintDeclaration {
 
   @Override
   public void addErrorCodesForCheck(Set<Integer> set, int level, int version,

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GradientBaseConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GradientBaseConstraints.java
@@ -83,9 +83,7 @@ public class GradientBaseConstraints extends AbstractConstraintDeclaration {
       func = new UnknownPackageElementValidationFunction<GradientBase>(RenderConstants.shortLabel) {
         @Override
         public boolean check(ValidationContext ctx, GradientBase base) {
-          boolean hasGradientStops = base.isSetListOfGradientStops()
-            && !base.getListOfGradientStops().isEmpty();
-          return hasGradientStops && super.check(ctx, base);
+          return base.isSetListOfGradientStops() && super.check(ctx, base);
         }
       };
       break;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GradientBaseConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GradientBaseConstraints.java
@@ -21,16 +21,15 @@ package org.sbml.jsbml.validator.offline.constraints;
 
 import java.util.Set;
 
-import org.sbml.jsbml.JSBML;
 import org.sbml.jsbml.ext.render.GradientBase;
 import org.sbml.jsbml.ext.render.RenderConstants;
 import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
 import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.InvalidAttributeValidationFunction;
 import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
 import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
 import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
 import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageElementValidationFunction;
-import org.sbml.jsbml.xml.XMLNode;
 
 /**
  * Defines validation rules (as {@link ValidationFunction} instances) for the
@@ -97,19 +96,7 @@ public class GradientBaseConstraints extends AbstractConstraintDeclaration {
       };
       break;
     case RENDER_20906:
-      func = new ValidationFunction<GradientBase>() {
-
-        @Override
-        public boolean check(ValidationContext ctx, GradientBase base) {
-          if(base.getUserObject(JSBML.UNKNOWN_XML) != null) {
-            XMLNode unknown = (XMLNode) base.getUserObject(JSBML.UNKNOWN_XML);
-            return unknown.getAttrIndex(RenderConstants.spreadMethod) == -1;
-            // TODO 2020/03: does this work? it should
-          }
-          return true;
-        }
-        
-      };
+      func = new InvalidAttributeValidationFunction<GradientBase>(RenderConstants.spreadMethod);
       break;
     }
     return func;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GradientStopConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GradientStopConstraints.java
@@ -61,7 +61,7 @@ public class GradientStopConstraints extends AbstractConstraintDeclaration {
   @Override
   public ValidationFunction<?> getValidationFunction(int errorCode,
     ValidationContext context) {
-    ValidationFunction<GradientStop> func = null;
+    ValidationFunction<GradientStop> func;
     switch(errorCode) {
     case RENDER_21001:
       func = new UnknownCoreAttributeValidationFunction<GradientStop>();
@@ -94,6 +94,10 @@ public class GradientStopConstraints extends AbstractConstraintDeclaration {
             && stop.getOffset().isSetRelativeValue();
         }
       };
+      break;
+
+    default:
+      func = null;
       break;
     }
     return func;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GradientStopConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GradientStopConstraints.java
@@ -90,8 +90,8 @@ public class GradientStopConstraints extends AbstractConstraintDeclaration {
       func = new ValidationFunction<GradientStop>() {
         @Override
         public boolean check(ValidationContext ctx, GradientStop stop) {
-          return stop.isSetOffset() && (stop.getOffset().isSetAbsoluteValue()
-            || stop.getOffset().isSetRelativeValue());
+          return stop.isSetOffset() && !stop.getOffset().isSetAbsoluteValue()
+            && stop.getOffset().isSetRelativeValue();
         }
       };
       break;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GradientStopConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GradientStopConstraints.java
@@ -21,31 +21,29 @@ package org.sbml.jsbml.validator.offline.constraints;
 
 import java.util.Set;
 
-import org.sbml.jsbml.JSBML;
-import org.sbml.jsbml.ext.render.GradientBase;
+import org.sbml.jsbml.ext.render.GradientStop;
 import org.sbml.jsbml.ext.render.RenderConstants;
 import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
 import org.sbml.jsbml.validator.offline.ValidationContext;
 import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
 import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
 import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
-import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageElementValidationFunction;
-import org.sbml.jsbml.xml.XMLNode;
 
 /**
  * Defines validation rules (as {@link ValidationFunction} instances) for the
- * {@link GradientBase} class.
+ * {@link GradientStop} class.
  * 
  * @author David Emanuel Vetter
  */
-public class GradientBaseConstraints extends AbstractConstraintDeclaration {
+public class GradientStopConstraints extends AbstractConstraintDeclaration {
 
   @Override
   public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
     CHECK_CATEGORY category, ValidationContext context) {
     switch(category) {
     case GENERAL_CONSISTENCY:
-      addRangeToSet(set, RENDER_20901, RENDER_20906);
+      addRangeToSet(set, RENDER_21001, RENDER_21005);
+      // TODO 2020/03: there are two more constraints, but they are soft
       break;
     default:
       break;
@@ -63,54 +61,38 @@ public class GradientBaseConstraints extends AbstractConstraintDeclaration {
   @Override
   public ValidationFunction<?> getValidationFunction(int errorCode,
     ValidationContext context) {
-    ValidationFunction<GradientBase> func = null;
+    ValidationFunction<GradientStop> func = null;
     switch(errorCode) {
-    case RENDER_20901:
-      func = new UnknownCoreAttributeValidationFunction<GradientBase>();
+    case RENDER_21001:
+      func = new UnknownCoreAttributeValidationFunction<GradientStop>();
       break;
-    case RENDER_20902:
-      func = new UnknownCoreElementValidationFunction<GradientBase>();
+    case RENDER_21002:
+      func = new UnknownCoreElementValidationFunction<GradientStop>();
       break;
-    case RENDER_20903:
-      func = new UnknownPackageAttributeValidationFunction<GradientBase>(RenderConstants.shortLabel) {
+    case RENDER_21003:
+      func = new UnknownPackageAttributeValidationFunction<GradientStop>(RenderConstants.shortLabel) {
         @Override
-        public boolean check(ValidationContext ctx, GradientBase base) {
-          return super.check(ctx, base) && base.isSetId();
+        public boolean check(ValidationContext ctx, GradientStop stop) {
+          return super.check(ctx, stop) && stop.isSetStopColor() && stop.isSetOffset();
         }
       };
       break;
-    case RENDER_20904:
-      func = new UnknownPackageElementValidationFunction<GradientBase>(RenderConstants.shortLabel) {
+    case RENDER_21004:
+      func = new ValidationFunction<GradientStop>() {
         @Override
-        public boolean check(ValidationContext ctx, GradientBase base) {
-          boolean hasGradientStops = base.isSetListOfGradientStops()
-            && !base.getListOfGradientStops().isEmpty();
-          return hasGradientStops && super.check(ctx, base);
-        }
-      };
-      break;
-    case RENDER_20905:
-      func = new ValidationFunction<GradientBase>() {
-        @Override
-        public boolean check(ValidationContext ctx, GradientBase t) {
-          // Optional 'name' is a String: nothing to check.
+        public boolean check(ValidationContext ctx, GradientStop t) {
+          // Any string ok.
           return true;
         }
       };
       break;
-    case RENDER_20906:
-      func = new ValidationFunction<GradientBase>() {
-
+    case RENDER_21005:
+      func = new ValidationFunction<GradientStop>() {
         @Override
-        public boolean check(ValidationContext ctx, GradientBase base) {
-          if(base.getUserObject(JSBML.UNKNOWN_XML) != null) {
-            XMLNode unknown = (XMLNode) base.getUserObject(JSBML.UNKNOWN_XML);
-            return unknown.getAttrIndex(RenderConstants.spreadMethod) == -1;
-            // TODO 2020/03: does this work? it should
-          }
-          return true;
+        public boolean check(ValidationContext ctx, GradientStop stop) {
+          return stop.isSetOffset() && (stop.getOffset().isSetAbsoluteValue()
+            || stop.getOffset().isSetRelativeValue());
         }
-        
       };
       break;
     }

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GraphicalPrimitive1DConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GraphicalPrimitive1DConstraints.java
@@ -1,0 +1,95 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ *
+ * Copyright (C) 2009-2018 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The University of California, San Diego, La Jolla, CA, USA
+ * 5. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.ext.render.GraphicalPrimitive1D;
+import org.sbml.jsbml.ext.render.RenderConstants;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.InvalidAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the
+ * {@link GraphicalPrimitive1D} class.
+ * 
+ * @author David Emanuel Vetter
+ */
+public class GraphicalPrimitive1DConstraints
+  extends AbstractConstraintDeclaration {
+
+  @Override
+  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+    CHECK_CATEGORY category, ValidationContext context) {
+    switch(category) {
+    case GENERAL_CONSISTENCY:
+      addRangeToSet(set, RENDER_22601, RENDER_22606);
+      break;
+    default:
+      break;
+    }
+  }
+
+
+  @Override
+  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+    int version, String attributeName, ValidationContext context) {
+    // TODO Auto-generated method stub
+  }
+
+
+  @Override
+  public ValidationFunction<?> getValidationFunction(int errorCode,
+    ValidationContext context) {
+    ValidationFunction<GraphicalPrimitive1D> func = null;
+    switch(errorCode) {
+    case RENDER_22601:
+      func = new UnknownCoreAttributeValidationFunction<GraphicalPrimitive1D>();
+      break;
+    case RENDER_22602:
+      func = new UnknownCoreElementValidationFunction<GraphicalPrimitive1D>();
+      break;
+    case RENDER_22603:
+      func =
+        new UnknownPackageAttributeValidationFunction<GraphicalPrimitive1D>(
+          RenderConstants.shortLabel);
+      break;
+    case RENDER_22604:
+      func = new ValidationFunction<GraphicalPrimitive1D>() {
+        @Override
+        public boolean check(ValidationContext ctx, GraphicalPrimitive1D t) { return true; }
+      };
+      break;
+    case RENDER_22605:
+      func = new InvalidAttributeValidationFunction<GraphicalPrimitive1D>(
+        RenderConstants.strokeWidth);
+      break;
+    case RENDER_22606:
+      func = new InvalidAttributeValidationFunction<GraphicalPrimitive1D>(
+        RenderConstants.strokeDashArray);
+      break;
+    }
+    return func;
+  }
+}

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GraphicalPrimitive1DConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GraphicalPrimitive1DConstraints.java
@@ -62,7 +62,7 @@ public class GraphicalPrimitive1DConstraints
   @Override
   public ValidationFunction<?> getValidationFunction(int errorCode,
     ValidationContext context) {
-    ValidationFunction<GraphicalPrimitive1D> func = null;
+    ValidationFunction<GraphicalPrimitive1D> func;
     switch(errorCode) {
     case RENDER_22601:
       func = new UnknownCoreAttributeValidationFunction<GraphicalPrimitive1D>();
@@ -88,6 +88,10 @@ public class GraphicalPrimitive1DConstraints
     case RENDER_22606:
       func = new InvalidAttributeValidationFunction<GraphicalPrimitive1D>(
         RenderConstants.strokeDashArray);
+      break;
+
+    default:
+      func = null;
       break;
     }
     return func;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GraphicalPrimitive2DConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GraphicalPrimitive2DConstraints.java
@@ -21,31 +21,29 @@ package org.sbml.jsbml.validator.offline.constraints;
 
 import java.util.Set;
 
-import org.sbml.jsbml.ext.layout.LayoutConstants;
-import org.sbml.jsbml.ext.render.Polygon;
+import org.sbml.jsbml.ext.render.GraphicalPrimitive2D;
 import org.sbml.jsbml.ext.render.RenderConstants;
 import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
 import org.sbml.jsbml.validator.offline.ValidationContext;
-import org.sbml.jsbml.validator.offline.constraints.helper.DuplicatedElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.InvalidAttributeValidationFunction;
 import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
 import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
-import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
 
 /**
  * Defines validation rules (as {@link ValidationFunction} instances) for the
- * {@link Polygon} class.
+ * {@link GraphicalPrimitive2D} class.
  * 
  * @author David Emanuel Vetter
  */
-public class PolygonConstraints extends AbstractConstraintDeclaration {
+public class GraphicalPrimitive2DConstraints extends AbstractConstraintDeclaration {
 
   @Override
   public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
     CHECK_CATEGORY category, ValidationContext context) {
     switch(category) {
     case GENERAL_CONSISTENCY:
-      addRangeToSet(set, RENDER_21701, RENDER_21704);
-      // addRangeToSet(set, RENDER_23040, RENDER_23043); // TODO 2020/03: These constraints need be checked on RenderCurve and Polygon
+      addRangeToSet(set, RENDER_22701, RENDER_22705);
       break;
     default:
       break;
@@ -63,31 +61,30 @@ public class PolygonConstraints extends AbstractConstraintDeclaration {
   @Override
   public ValidationFunction<?> getValidationFunction(int errorCode,
     ValidationContext context) {
-    ValidationFunction<Polygon> func = null;
+    ValidationFunction<GraphicalPrimitive2D> func = null;
     switch(errorCode) {
-    case RENDER_21701:
-      func = new UnknownCoreAttributeValidationFunction<Polygon>();
+    case RENDER_22701:
+      func = new UnknownCoreAttributeValidationFunction<GraphicalPrimitive2D>();
       break;
-    case RENDER_21702:
-      func = new UnknownCoreElementValidationFunction<Polygon>();
+    case RENDER_22702:
+      func = new UnknownCoreElementValidationFunction<GraphicalPrimitive2D>();
       break;
-    case RENDER_21703:
-      func = new UnknownPackageElementValidationFunction<Polygon>(RenderConstants.shortLabel) {
-        public boolean check(ValidationContext ctx, Polygon poly) {
-          return super.check(ctx, poly)
-            && new DuplicatedElementValidationFunction<Polygon>(
-              RenderConstants.listOfElements).check(ctx, poly);
+    case RENDER_22703:
+      func =
+        new UnknownPackageAttributeValidationFunction<GraphicalPrimitive2D>(
+          RenderConstants.shortLabel);
+      break;
+    case RENDER_22704:
+      func = new ValidationFunction<GraphicalPrimitive2D>() {
+        @Override
+        public boolean check(ValidationContext ctx, GraphicalPrimitive2D t) {
+          // Any string
+          return true;
         }
       };
       break;
-    case RENDER_21704:
-      func = new UnknownPackageElementValidationFunction<Polygon>(LayoutConstants.shortLabel) {
-        public boolean check(ValidationContext ctx, Polygon poly) {
-          return super.check(ctx, poly)
-            && new DuplicatedElementValidationFunction<Polygon>(
-              LayoutConstants.listOfCurveSegments).check(ctx, poly);
-        }
-      };
+    case RENDER_22705:
+      func = new InvalidAttributeValidationFunction<GraphicalPrimitive2D>(RenderConstants.fillRule);
       break;
     }
     return func;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GraphicalPrimitive2DConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/GraphicalPrimitive2DConstraints.java
@@ -61,7 +61,7 @@ public class GraphicalPrimitive2DConstraints extends AbstractConstraintDeclarati
   @Override
   public ValidationFunction<?> getValidationFunction(int errorCode,
     ValidationContext context) {
-    ValidationFunction<GraphicalPrimitive2D> func = null;
+    ValidationFunction<GraphicalPrimitive2D> func;
     switch(errorCode) {
     case RENDER_22701:
       func = new UnknownCoreAttributeValidationFunction<GraphicalPrimitive2D>();
@@ -85,6 +85,10 @@ public class GraphicalPrimitive2DConstraints extends AbstractConstraintDeclarati
       break;
     case RENDER_22705:
       func = new InvalidAttributeValidationFunction<GraphicalPrimitive2D>(RenderConstants.fillRule);
+      break;
+      
+    default:
+      func = null;
       break;
     }
     return func;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/ImageConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/ImageConstraints.java
@@ -1,0 +1,158 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ *
+ * Copyright (C) 2009-2018 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The University of California, San Diego, La Jolla, CA, USA
+ * 5. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.io.File;
+import java.util.Set;
+
+import org.sbml.jsbml.ext.render.Image;
+import org.sbml.jsbml.ext.render.RenderConstants;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the
+ * {@link Image} class.
+ * 
+ * @author David Emanuel Vetter
+ */
+public class ImageConstraints extends AbstractConstraintDeclaration {
+
+  @Override
+  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+    CHECK_CATEGORY category, ValidationContext context) {
+    switch(category) {
+    case GENERAL_CONSISTENCY:
+      addRangeToSet(set, RENDER_21201, RENDER_21210);
+      break;
+    default:
+      break;
+    }
+  }
+
+
+  @Override
+  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+    int version, String attributeName, ValidationContext context) {
+    // TODO Auto-generated method stub
+  }
+
+
+  @Override
+  public ValidationFunction<?> getValidationFunction(int errorCode,
+    ValidationContext context) {
+    ValidationFunction<Image> func = null;
+    switch(errorCode) {
+    case RENDER_21201:
+      func = new UnknownCoreAttributeValidationFunction<Image>();
+      break;
+    case RENDER_21202:
+      func = new UnknownCoreElementValidationFunction<Image>();
+      break;
+    case RENDER_21203:
+      func = new UnknownPackageAttributeValidationFunction<Image>(RenderConstants.shortLabel) {
+        @Override
+        public boolean check(ValidationContext ctx, Image image) {
+          return super.check(ctx, image) 
+              && image.isSetHref() 
+              && image.isSetX() && image.isSetY() 
+              && image.isSetWidth() && image.isSetHeight();
+        }
+      };
+      break;
+    case RENDER_21204:
+      func = new ValidationFunction<Image>() {
+        @Override
+        public boolean check(ValidationContext ctx, Image image) {
+          // must be set, any string; for content cf. render-21209
+          return image.isSetHref();
+        }
+      };
+      break;
+    case RENDER_21205:
+      func = new ValidationFunction<Image>() {
+        @Override
+        public boolean check(ValidationContext ctx, Image image) {
+          return image.isSetX() && (image.getX().isSetAbsoluteValue()
+            || image.getX().isSetRelativeValue());
+        }
+      };
+      break;
+    case RENDER_21206:
+      func = new ValidationFunction<Image>() {
+        @Override
+        public boolean check(ValidationContext ctx, Image image) {
+          return image.isSetY() && (image.getY().isSetAbsoluteValue()
+            || image.getY().isSetRelativeValue());
+        }
+      };
+      break;
+    case RENDER_21207:
+      func = new ValidationFunction<Image>() {
+        @Override
+        public boolean check(ValidationContext ctx, Image image) {
+          return image.isSetWidth() && (image.getWidth().isSetAbsoluteValue()
+            || image.getWidth().isSetRelativeValue());
+        }
+      };
+      break;
+    case RENDER_21208:
+      func = new ValidationFunction<Image>() {
+        @Override
+        public boolean check(ValidationContext ctx, Image image) {
+          return image.isSetHeight() && (image.getHeight().isSetAbsoluteValue()
+            || image.getHeight().isSetRelativeValue());
+        }
+      };
+      break;
+    case RENDER_21209:
+      func = new ValidationFunction<Image>() {
+        @Override
+        public boolean check(ValidationContext ctx, Image image) {
+          if(image.isSetHref()) {
+            // TODO 2020/03: COULD check, whether file exists, but it is unclear
+            // from the spec whether that is actually required
+            // Could further check for whether local or URL
+            File file = new File(image.getHref()); 
+            return !file.isDirectory()
+              && (image.getHref().toLowerCase().endsWith(".png")
+                || image.getHref().toLowerCase().endsWith(".jpeg")
+                || image.getHref().toLowerCase().endsWith(".jpg")); // jpg=jpeg (synonymy)
+          }
+          return false;
+        }
+      };
+      break;
+    case RENDER_21210:
+      func = new ValidationFunction<Image>() {
+        @Override
+        public boolean check(ValidationContext ctx, Image image) {
+          return !image.isSetZ() || image.getZ().isSetAbsoluteValue()
+            || image.getZ().isSetRelativeValue();
+        }
+      };
+      break;
+    }
+    return func;
+  }
+}

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/ImageConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/ImageConstraints.java
@@ -61,7 +61,7 @@ public class ImageConstraints extends AbstractConstraintDeclaration {
   @Override
   public ValidationFunction<?> getValidationFunction(int errorCode,
     ValidationContext context) {
-    ValidationFunction<Image> func = null;
+    ValidationFunction<Image> func;
     switch(errorCode) {
     case RENDER_21201:
       func = new UnknownCoreAttributeValidationFunction<Image>();
@@ -151,6 +151,10 @@ public class ImageConstraints extends AbstractConstraintDeclaration {
             || image.getZ().isSetRelativeValue();
         }
       };
+      break;
+
+    default:
+      func = null;
       break;
     }
     return func;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/LineEndingConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/LineEndingConstraints.java
@@ -1,0 +1,100 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ *
+ * Copyright (C) 2009-2018 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The University of California, San Diego, La Jolla, CA, USA
+ * 5. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.ext.render.LineEnding;
+import org.sbml.jsbml.ext.render.RenderConstants;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.DuplicatedElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.InvalidAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageElementValidationFunction;
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the
+ * {@link LineEnding} class.
+ * 
+ * @author David Emanuel Vetter
+ */
+public class LineEndingConstraints extends AbstractConstraintDeclaration {
+
+  @Override
+  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+    CHECK_CATEGORY category, ValidationContext context) {
+    switch(category) {
+    case GENERAL_CONSISTENCY:
+      addRangeToSet(set, RENDER_21301, RENDER_21305);
+      break;
+    default:
+      break;
+    }
+  }
+
+
+  @Override
+  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+    int version, String attributeName, ValidationContext context) {
+    // TODO Auto-generated method stub
+  }
+
+
+  @Override
+  public ValidationFunction<?> getValidationFunction(int errorCode,
+    ValidationContext context) {
+    ValidationFunction<LineEnding> func = null;
+    switch(errorCode) {
+    case RENDER_21301:
+      func = new UnknownCoreAttributeValidationFunction<LineEnding>();
+      break;
+    case RENDER_21302:
+      func = new UnknownCoreElementValidationFunction<LineEnding>();
+      break;
+    case RENDER_21303:
+      func = new UnknownPackageAttributeValidationFunction<LineEnding>(RenderConstants.shortLabel) {
+        @Override
+        public boolean check(ValidationContext ctx, LineEnding ending) {
+          return super.check(ctx, ending) && ending.isSetId();
+        }
+      };
+      break;
+    case RENDER_21304:
+      func = new UnknownPackageElementValidationFunction<LineEnding>(RenderConstants.shortLabel) {
+        @Override
+        public boolean check(ValidationContext ctx, LineEnding ending) {
+          return super.check(ctx, ending)
+            && new DuplicatedElementValidationFunction<LineEnding>(
+              RenderConstants.boundingBox).check(ctx, ending)
+            && new DuplicatedElementValidationFunction<LineEnding>(
+              RenderConstants.group).check(ctx, ending);
+        }
+      };
+      break;
+    case RENDER_21305:
+      func = new InvalidAttributeValidationFunction<LineEnding>(RenderConstants.enableRotationMapping);
+      break;
+    }
+    return func;
+  }
+}

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/LineEndingConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/LineEndingConstraints.java
@@ -63,7 +63,7 @@ public class LineEndingConstraints extends AbstractConstraintDeclaration {
   @Override
   public ValidationFunction<?> getValidationFunction(int errorCode,
     ValidationContext context) {
-    ValidationFunction<LineEnding> func = null;
+    ValidationFunction<LineEnding> func;
     switch(errorCode) {
     case RENDER_21301:
       func = new UnknownCoreAttributeValidationFunction<LineEnding>();
@@ -93,6 +93,10 @@ public class LineEndingConstraints extends AbstractConstraintDeclaration {
       break;
     case RENDER_21305:
       func = new InvalidAttributeValidationFunction<LineEnding>(RenderConstants.enableRotationMapping);
+      break;
+
+    default:
+      func = null;
       break;
     }
     return func;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/LinearGradientConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/LinearGradientConstraints.java
@@ -1,0 +1,131 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ *
+ * Copyright (C) 2009-2018 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The University of California, San Diego, La Jolla, CA, USA
+ * 5. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.ext.render.LinearGradient;
+import org.sbml.jsbml.ext.render.RenderConstants;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the
+ * {@link LinearGradient} class.
+ * 
+ * @author David Emanuel Vetter
+ */
+public class LinearGradientConstraints extends AbstractConstraintDeclaration {
+
+  @Override
+  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+    CHECK_CATEGORY category, ValidationContext context) {
+    switch(category) {
+    case GENERAL_CONSISTENCY:
+      addRangeToSet(set, RENDER_21401, RENDER_21409);
+      break;
+    default:
+      break;
+    }
+  }
+  
+
+  @Override
+  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+    int version, String attributeName, ValidationContext context) {
+    // TODO Auto-generated method stub
+  }
+
+
+  @Override
+  public ValidationFunction<?> getValidationFunction(int errorCode,
+    ValidationContext context) {
+    ValidationFunction<LinearGradient> func = null; 
+    switch(errorCode) {
+    case RENDER_21401:
+      func = new UnknownCoreAttributeValidationFunction<LinearGradient>();
+      break;
+    case RENDER_21402:
+      func = new UnknownCoreElementValidationFunction<LinearGradient>();
+      break;
+    case RENDER_21403:
+      func = new UnknownPackageAttributeValidationFunction<LinearGradient>(RenderConstants.shortLabel);
+      break;
+    case RENDER_21404:
+      func = new ValidationFunction<LinearGradient>() {
+        @Override
+        public boolean check(ValidationContext ctx, LinearGradient gradient) {
+          return !gradient.isSetX1() || gradient.getX1().isSetAbsoluteValue()
+            || gradient.getX1().isSetRelativeValue();
+        }
+      }; 
+      break;
+    case RENDER_21405:
+      func = new ValidationFunction<LinearGradient>() {
+        @Override
+        public boolean check(ValidationContext ctx, LinearGradient gradient) {
+          return !gradient.isSetY1() || gradient.getY1().isSetAbsoluteValue()
+            || gradient.getY1().isSetRelativeValue();
+        }
+      };
+      break;
+    case RENDER_21406:
+      func = new ValidationFunction<LinearGradient>() {
+        @Override
+        public boolean check(ValidationContext ctx, LinearGradient gradient) {
+          return !gradient.isSetZ1() || gradient.getZ1().isSetAbsoluteValue()
+            || gradient.getZ1().isSetRelativeValue();
+        }
+      };
+      break;
+    case RENDER_21407:
+      func = new ValidationFunction<LinearGradient>() {
+        @Override
+        public boolean check(ValidationContext ctx, LinearGradient gradient) {
+          return !gradient.isSetX2() || gradient.getX2().isSetAbsoluteValue()
+            || gradient.getX2().isSetRelativeValue();
+        }
+      }; 
+      break;
+    case RENDER_21408:
+      func = new ValidationFunction<LinearGradient>() {
+        @Override
+        public boolean check(ValidationContext ctx, LinearGradient gradient) {
+          return !gradient.isSetY2() || gradient.getY2().isSetAbsoluteValue()
+            || gradient.getY2().isSetRelativeValue();
+        }
+      };
+      break;
+    case RENDER_21409:
+      func = new ValidationFunction<LinearGradient>() {
+        @Override
+        public boolean check(ValidationContext ctx, LinearGradient gradient) {
+          return !gradient.isSetZ2() || gradient.getZ2().isSetAbsoluteValue()
+            || gradient.getZ2().isSetRelativeValue();
+        }
+      };
+      break;
+    }
+    return func;
+  }
+}

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/LinearGradientConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/LinearGradientConstraints.java
@@ -60,7 +60,7 @@ public class LinearGradientConstraints extends AbstractConstraintDeclaration {
   @Override
   public ValidationFunction<?> getValidationFunction(int errorCode,
     ValidationContext context) {
-    ValidationFunction<LinearGradient> func = null; 
+    ValidationFunction<LinearGradient> func; 
     switch(errorCode) {
     case RENDER_21401:
       func = new UnknownCoreAttributeValidationFunction<LinearGradient>();
@@ -124,6 +124,10 @@ public class LinearGradientConstraints extends AbstractConstraintDeclaration {
             || gradient.getZ2().isSetRelativeValue();
         }
       };
+      break;
+
+    default:
+      func = null;
       break;
     }
     return func;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/LocalRenderInformationConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/LocalRenderInformationConstraints.java
@@ -86,8 +86,7 @@ public class LocalRenderInformationConstraints
       func = new ValidationFunction<LocalRenderInformation>() {
         @Override
         public boolean check(ValidationContext ctx, LocalRenderInformation lri) {
-          // TODO 2020/03: problem: isSet also considers empty to be unset. Go via userObjects?
-          return !lri.isSetListOfLocalStyles() || !lri.getListOfLocalStyles().isEmpty();
+          return !lri.isListOfLocalStylesEmpty();
         }
       };
       break;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/LocalRenderInformationConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/LocalRenderInformationConstraints.java
@@ -64,7 +64,7 @@ public class LocalRenderInformationConstraints
   @Override
   public ValidationFunction<?> getValidationFunction(int errorCode,
     ValidationContext context) {
-    ValidationFunction<LocalRenderInformation> func = null;
+    ValidationFunction<LocalRenderInformation> func;
     switch(errorCode) {
     case RENDER_21501:
       func = new UnknownCoreAttributeValidationFunction<LocalRenderInformation>();
@@ -117,6 +117,10 @@ public class LocalRenderInformationConstraints
           return true;
         }
       };
+      break;
+
+    default:
+      func = null;
       break;
     }
     return func;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/LocalRenderInformationConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/LocalRenderInformationConstraints.java
@@ -1,0 +1,125 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ *
+ * Copyright (C) 2009-2018 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The University of California, San Diego, La Jolla, CA, USA
+ * 5. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.ListOf;
+import org.sbml.jsbml.ext.render.LocalRenderInformation;
+import org.sbml.jsbml.ext.render.LocalStyle;
+import org.sbml.jsbml.ext.render.RenderConstants;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.DuplicatedElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageElementValidationFunction;
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the
+ * {@link LocalRenderInformation} class.
+ * 
+ * @author David Emanuel Vetter
+ */
+public class LocalRenderInformationConstraints
+  extends AbstractConstraintDeclaration {
+
+  @Override
+  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+    CHECK_CATEGORY category, ValidationContext context) {
+    switch(category) {
+    case GENERAL_CONSISTENCY:
+      addRangeToSet(set, RENDER_21501, RENDER_21506);
+      break;
+    default:
+      break;
+    }
+  }
+
+
+  @Override
+  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+    int version, String attributeName, ValidationContext context) {
+    // TODO Auto-generated method stub
+  }
+
+
+  @Override
+  public ValidationFunction<?> getValidationFunction(int errorCode,
+    ValidationContext context) {
+    ValidationFunction<LocalRenderInformation> func = null;
+    switch(errorCode) {
+    case RENDER_21501:
+      func = new UnknownCoreAttributeValidationFunction<LocalRenderInformation>();
+      break;
+    case RENDER_21502:
+      func = new UnknownCoreElementValidationFunction<LocalRenderInformation>();
+      break;
+    case RENDER_21503:
+      func = new UnknownPackageElementValidationFunction<LocalRenderInformation>(RenderConstants.shortLabel) {
+        @Override
+        public boolean check(ValidationContext ctx, LocalRenderInformation lri) {
+          return super.check(ctx, lri) 
+              && new DuplicatedElementValidationFunction<LocalRenderInformation>(
+                RenderConstants.listOfLocalStyles).check(ctx, lri);
+        }
+      };
+      break;
+    case RENDER_21504:
+      func = new ValidationFunction<LocalRenderInformation>() {
+        @Override
+        public boolean check(ValidationContext ctx, LocalRenderInformation lri) {
+          // TODO 2020/03: problem: isSet also considers empty to be unset. Go via userObjects?
+          return !lri.isSetListOfLocalStyles() || !lri.getListOfLocalStyles().isEmpty();
+        }
+      };
+      break;
+    case RENDER_21505:
+      func = new ValidationFunction<LocalRenderInformation>() {
+
+        @Override
+        public boolean check(ValidationContext ctx, LocalRenderInformation lri) {
+          if (lri.isSetListOfLocalStyles()) {
+            return new UnknownCoreElementValidationFunction<ListOf<LocalStyle>>().check(
+              ctx, lri.getListOfLocalStyles())
+              && new UnknownPackageElementValidationFunction<ListOf<LocalStyle>>(
+                RenderConstants.shortLabel).check(ctx,
+                  lri.getListOfLocalStyles());
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_21506:
+      func = new ValidationFunction<LocalRenderInformation>() {
+        @Override
+        public boolean check(ValidationContext ctx, LocalRenderInformation lri) {
+          if (lri.isSetListOfLocalStyles()) {
+            return new UnknownCoreAttributeValidationFunction<ListOf<LocalStyle>>().check(
+              ctx, lri.getListOfLocalStyles());
+          }
+          return true;
+        }
+      };
+      break;
+    }
+    return func;
+  }
+}

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/LocalStyleConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/LocalStyleConstraints.java
@@ -60,7 +60,7 @@ public class LocalStyleConstraints extends AbstractConstraintDeclaration {
   @Override
   public ValidationFunction<?> getValidationFunction(int errorCode,
     ValidationContext context) {
-    ValidationFunction<LocalStyle> func = null;
+    ValidationFunction<LocalStyle> func;
     switch(errorCode) {
     case RENDER_21601:
       func = new UnknownCoreAttributeValidationFunction<LocalStyle>();
@@ -79,6 +79,10 @@ public class LocalStyleConstraints extends AbstractConstraintDeclaration {
           return true;
         }
       };
+      break;
+
+    default:
+      func = null;
       break;
     }
     return func;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/LocalStyleConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/LocalStyleConstraints.java
@@ -1,0 +1,86 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ *
+ * Copyright (C) 2009-2018 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The University of California, San Diego, La Jolla, CA, USA
+ * 5. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.ext.render.LocalStyle;
+import org.sbml.jsbml.ext.render.RenderConstants;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the
+ * {@link LocalStyle} class.
+ * 
+ * @author David Emanuel Vetter
+ */
+public class LocalStyleConstraints extends AbstractConstraintDeclaration {
+
+  @Override
+  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+    CHECK_CATEGORY category, ValidationContext context) {
+    switch(category) {
+    case GENERAL_CONSISTENCY:
+      addRangeToSet(set, RENDER_21601, RENDER_21604);
+      break;
+    default:
+      break;
+    }
+  }
+
+
+  @Override
+  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+    int version, String attributeName, ValidationContext context) {
+    // TODO Auto-generated method stub
+  }
+
+
+  @Override
+  public ValidationFunction<?> getValidationFunction(int errorCode,
+    ValidationContext context) {
+    ValidationFunction<LocalStyle> func = null;
+    switch(errorCode) {
+    case RENDER_21601:
+      func = new UnknownCoreAttributeValidationFunction<LocalStyle>();
+      break;
+    case RENDER_21602:
+      func = new UnknownCoreElementValidationFunction<LocalStyle>();
+      break;
+    case RENDER_21603:
+      func = new UnknownPackageAttributeValidationFunction<LocalStyle>(RenderConstants.shortLabel);
+      break;
+    case RENDER_21604:
+      func = new ValidationFunction<LocalStyle>() {
+        @Override
+        public boolean check(ValidationContext ctx, LocalStyle t) {
+          // Any string
+          return true;
+        }
+      };
+      break;
+    }
+    return func;
+  }
+}

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/PolygonConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/PolygonConstraints.java
@@ -98,11 +98,7 @@ public class PolygonConstraints extends AbstractConstraintDeclaration {
         func = new ValidationFunction<Polygon>() {
           @Override
           public boolean check(ValidationContext ctx, Polygon t) {
-            if(t.isSetListOfElements()) {
-              // TODO 2020/03: add methods isListOf___Empty() to all the relevant classes
-              return t.getListOfElements().isEmpty();
-            }
-            return true;
+            return !t.isListOfElementsEmpty();
           }
         };
         break;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/PolygonConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/PolygonConstraints.java
@@ -21,9 +21,12 @@ package org.sbml.jsbml.validator.offline.constraints;
 
 import java.util.Set;
 
+import org.sbml.jsbml.ListOf;
 import org.sbml.jsbml.ext.layout.LayoutConstants;
 import org.sbml.jsbml.ext.render.Polygon;
 import org.sbml.jsbml.ext.render.RenderConstants;
+import org.sbml.jsbml.ext.render.RenderCubicBezier;
+import org.sbml.jsbml.ext.render.RenderPoint;
 import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
 import org.sbml.jsbml.validator.offline.ValidationContext;
 import org.sbml.jsbml.validator.offline.constraints.helper.DuplicatedElementValidationFunction;
@@ -45,7 +48,7 @@ public class PolygonConstraints extends AbstractConstraintDeclaration {
     switch(category) {
     case GENERAL_CONSISTENCY:
       addRangeToSet(set, RENDER_21701, RENDER_21704);
-      // addRangeToSet(set, RENDER_23040, RENDER_23043); // TODO 2020/03: These constraints need be checked on RenderCurve and Polygon
+      addRangeToSet(set, RENDER_23040, RENDER_23043);
       break;
     default:
       break;
@@ -89,6 +92,60 @@ public class PolygonConstraints extends AbstractConstraintDeclaration {
         }
       };
       break;
+      
+      // Cases common to RenderCurve and Polygon:
+      case RENDER_23040:
+        func = new ValidationFunction<Polygon>() {
+          @Override
+          public boolean check(ValidationContext ctx, Polygon t) {
+            if(t.isSetListOfElements()) {
+              // TODO 2020/03: add methods isListOf___Empty() to all the relevant classes
+              return t.getListOfElements().isEmpty();
+            }
+            return true;
+          }
+        };
+        break;
+      case RENDER_23041:
+        func = new ValidationFunction<Polygon>() {
+          @Override
+          public boolean check(ValidationContext ctx, Polygon t) {
+            if(t.isSetListOfElements()) {
+              return new UnknownCoreElementValidationFunction<ListOf<RenderPoint>>().check(
+                ctx, t.getListOfElements())
+                && new UnknownPackageElementValidationFunction<ListOf<RenderPoint>>(
+                  RenderConstants.shortLabel).check(ctx, t.getListOfElements());
+            }
+            return true;
+          }
+        };
+        break;
+      case RENDER_23042:
+        func = new ValidationFunction<Polygon>() {
+          @Override
+          public boolean check(ValidationContext ctx, Polygon t) {
+            if(t.isSetListOfElements()) {
+              return new UnknownCoreAttributeValidationFunction<ListOf<RenderPoint>>().check(
+                ctx, t.getListOfElements());
+            }
+            return true;
+          }
+        };
+        break;
+      case RENDER_23043:
+        func = new ValidationFunction<Polygon>() {
+          @Override
+          public boolean check(ValidationContext ctx, Polygon t) {
+            if(t.isSetListOfElements()) {
+              ListOf<RenderPoint> list = t.getListOfElements();
+              return !list.isEmpty() 
+                  && (list.get(0) instanceof RenderPoint) // not really needed, but here for completeness
+                  && !(list.get(0) instanceof RenderCubicBezier);
+            }
+            return true;
+          }
+        };
+        break;
     }
     return func;
   }

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/PolygonConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/PolygonConstraints.java
@@ -1,0 +1,94 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ *
+ * Copyright (C) 2009-2018 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The University of California, San Diego, La Jolla, CA, USA
+ * 5. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.ext.layout.LayoutConstants;
+import org.sbml.jsbml.ext.render.Polygon;
+import org.sbml.jsbml.ext.render.RenderConstants;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.DuplicatedElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageElementValidationFunction;
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the
+ * {@link Polygon} class.
+ * 
+ * @author David Emanuel Vetter
+ */
+public class PolygonConstraints extends AbstractConstraintDeclaration {
+
+  @Override
+  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+    CHECK_CATEGORY category, ValidationContext context) {
+    switch(category) {
+    case GENERAL_CONSISTENCY:
+      addRangeToSet(set, RENDER_21701, RENDER_21704);
+      break;
+    default:
+      break;
+    }
+  }
+
+
+  @Override
+  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+    int version, String attributeName, ValidationContext context) {
+    // TODO Auto-generated method stub
+  }
+
+
+  @Override
+  public ValidationFunction<?> getValidationFunction(int errorCode,
+    ValidationContext context) {
+    ValidationFunction<Polygon> func = null;
+    switch(errorCode) {
+    case RENDER_21701:
+      func = new UnknownCoreAttributeValidationFunction<Polygon>();
+      break;
+    case RENDER_21702:
+      func = new UnknownCoreElementValidationFunction<Polygon>();
+      break;
+    case RENDER_21703:
+      func = new UnknownPackageElementValidationFunction<Polygon>(RenderConstants.shortLabel) {
+        public boolean check(ValidationContext ctx, Polygon poly) {
+          return super.check(ctx, poly)
+            && new DuplicatedElementValidationFunction<Polygon>(
+              RenderConstants.listOfElements).check(ctx, poly);
+        }
+      };
+      break;
+    case RENDER_21704:
+      func = new UnknownPackageElementValidationFunction<Polygon>(LayoutConstants.shortLabel) {
+        public boolean check(ValidationContext ctx, Polygon poly) {
+          return super.check(ctx, poly)
+            && new DuplicatedElementValidationFunction<Polygon>(
+              LayoutConstants.listOfCurveSegments).check(ctx, poly);
+        }
+      };
+      break;
+    }
+    return func;
+  }
+}

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/PolygonConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/PolygonConstraints.java
@@ -66,7 +66,7 @@ public class PolygonConstraints extends AbstractConstraintDeclaration {
   @Override
   public ValidationFunction<?> getValidationFunction(int errorCode,
     ValidationContext context) {
-    ValidationFunction<Polygon> func = null;
+    ValidationFunction<Polygon> func;
     switch(errorCode) {
     case RENDER_21701:
       func = new UnknownCoreAttributeValidationFunction<Polygon>();
@@ -141,6 +141,10 @@ public class PolygonConstraints extends AbstractConstraintDeclaration {
             return true;
           }
         };
+        break;
+
+      default:
+        func = null;
         break;
     }
     return func;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RadialGradientConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RadialGradientConstraints.java
@@ -60,7 +60,7 @@ public class RadialGradientConstraints extends AbstractConstraintDeclaration {
   @Override
   public ValidationFunction<?> getValidationFunction(int errorCode,
     ValidationContext context) {
-    ValidationFunction<RadialGradient> func = null;
+    ValidationFunction<RadialGradient> func;
     switch(errorCode) {
     case RENDER_21801:
       func = new UnknownCoreAttributeValidationFunction<RadialGradient>();
@@ -133,6 +133,10 @@ public class RadialGradientConstraints extends AbstractConstraintDeclaration {
             || gradient.getFz().isSetRelativeValue();
         }
       };
+      break;
+
+    default:
+      func = null;
       break;
     }
     return func;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RadialGradientConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RadialGradientConstraints.java
@@ -1,0 +1,140 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ *
+ * Copyright (C) 2009-2018 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The University of California, San Diego, La Jolla, CA, USA
+ * 5. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.ext.render.RadialGradient;
+import org.sbml.jsbml.ext.render.RenderConstants;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the
+ * {@link RadialGradient} class.
+ * 
+ * @author David Emanuel Vetter
+ */
+public class RadialGradientConstraints extends AbstractConstraintDeclaration {
+
+  @Override
+  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+    CHECK_CATEGORY category, ValidationContext context) {
+    switch(category) {
+    case GENERAL_CONSISTENCY:
+      addRangeToSet(set, RENDER_21801, RENDER_21810);
+      break;
+    default:
+      break;
+    }
+  }
+
+
+  @Override
+  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+    int version, String attributeName, ValidationContext context) {
+    // TODO Auto-generated method stub
+  }
+
+
+  @Override
+  public ValidationFunction<?> getValidationFunction(int errorCode,
+    ValidationContext context) {
+    ValidationFunction<RadialGradient> func = null;
+    switch(errorCode) {
+    case RENDER_21801:
+      func = new UnknownCoreAttributeValidationFunction<RadialGradient>();
+      break;
+    case RENDER_21802:
+      func = new UnknownCoreElementValidationFunction<RadialGradient>();
+      break;
+    case RENDER_21803:
+      func = new UnknownPackageAttributeValidationFunction<RadialGradient>(RenderConstants.shortLabel);
+      break;
+    case RENDER_21804:
+      func = new ValidationFunction<RadialGradient>() {
+        @Override
+        public boolean check(ValidationContext ctx, RadialGradient gradient) {
+          return !gradient.isSetCx() || gradient.getCx().isSetAbsoluteValue()
+            || gradient.getCx().isSetRelativeValue();
+        }
+      };
+      break;
+    case RENDER_21805:
+      func = new ValidationFunction<RadialGradient>() {
+        @Override
+        public boolean check(ValidationContext ctx, RadialGradient gradient) {
+          return !gradient.isSetCy() || gradient.getCy().isSetAbsoluteValue()
+            || gradient.getCy().isSetRelativeValue();
+        }
+      };
+      break;
+    case RENDER_21806:
+      func = new ValidationFunction<RadialGradient>() {
+        @Override
+        public boolean check(ValidationContext ctx, RadialGradient gradient) {
+          return !gradient.isSetCz() || gradient.getCz().isSetAbsoluteValue()
+            || gradient.getCz().isSetRelativeValue();
+        }
+      };
+      break;
+    case RENDER_21807:
+      func = new ValidationFunction<RadialGradient>() {
+        @Override
+        public boolean check(ValidationContext ctx, RadialGradient gradient) {
+          return !gradient.isSetR() || gradient.getR().isSetAbsoluteValue()
+            || gradient.getR().isSetRelativeValue();
+        }
+      };
+      break;
+    case RENDER_21808:
+      func = new ValidationFunction<RadialGradient>() {
+        @Override
+        public boolean check(ValidationContext ctx, RadialGradient gradient) {
+          return !gradient.isSetFx() || gradient.getFx().isSetAbsoluteValue()
+            || gradient.getFx().isSetRelativeValue();
+        }
+      };
+      break;
+    case RENDER_21809:
+      func = new ValidationFunction<RadialGradient>() {
+        @Override
+        public boolean check(ValidationContext ctx, RadialGradient gradient) {
+          return !gradient.isSetFy() || gradient.getFy().isSetAbsoluteValue()
+            || gradient.getFy().isSetRelativeValue();
+        }
+      };
+      break;
+    case RENDER_21810:
+      func = new ValidationFunction<RadialGradient>() {
+        @Override
+        public boolean check(ValidationContext ctx, RadialGradient gradient) {
+          return !gradient.isSetFz() || gradient.getFz().isSetAbsoluteValue()
+            || gradient.getFz().isSetRelativeValue();
+        }
+      };
+      break;
+    }
+    return func;
+  }
+}

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RectangleConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RectangleConstraints.java
@@ -1,0 +1,150 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ *
+ * Copyright (C) 2009-2018 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The University of California, San Diego, La Jolla, CA, USA
+ * 5. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.ext.render.Rectangle;
+import org.sbml.jsbml.ext.render.RenderConstants;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.InvalidAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the
+ * {@link Rectangle} class.
+ * 
+ * @author David Emanuel Vetter
+ */
+public class RectangleConstraints extends AbstractConstraintDeclaration {
+
+  @Override
+  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+    CHECK_CATEGORY category, ValidationContext context) {
+    switch(category) {
+    case GENERAL_CONSISTENCY:
+      addRangeToSet(set, RENDER_21901, RENDER_21911);
+      break;
+    default:
+      break;
+    }
+  }
+
+
+  @Override
+  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+    int version, String attributeName, ValidationContext context) {
+    // TODO Auto-generated method stub
+  }
+
+
+  @Override
+  public ValidationFunction<?> getValidationFunction(int errorCode,
+    ValidationContext context) {
+    ValidationFunction<Rectangle> func = null;
+    switch(errorCode) {
+    case RENDER_21901:
+      func = new UnknownCoreAttributeValidationFunction<Rectangle>();
+      break;
+    case RENDER_21902:
+      func = new UnknownCoreElementValidationFunction<Rectangle>();
+      break;
+    case RENDER_21903:
+      func = new UnknownPackageAttributeValidationFunction<Rectangle>(RenderConstants.shortLabel) {
+        @Override
+        public boolean check(ValidationContext ctx, Rectangle r) {
+          return super.check(ctx, r) && r.isSetX() && r.isSetY()
+            && r.isSetWidth() && r.isSetHeight();
+        }
+      };
+      break;
+    case RENDER_21904:
+      func = new ValidationFunction<Rectangle>() {
+        @Override
+        public boolean check(ValidationContext ctx, Rectangle r) {
+          return r.isSetX()
+            && (r.getX().isSetAbsoluteValue() || r.getX().isSetRelativeValue());
+        }
+      };
+      break;
+    case RENDER_21905:
+      func = new ValidationFunction<Rectangle>() {
+        @Override
+        public boolean check(ValidationContext ctx, Rectangle r) {
+          return r.isSetY()
+            && (r.getY().isSetAbsoluteValue() || r.getY().isSetRelativeValue());
+        }
+      };
+      break;
+    case RENDER_21906:
+      func = new ValidationFunction<Rectangle>() {
+        @Override
+        public boolean check(ValidationContext ctx, Rectangle r) {
+          return r.isSetWidth()
+            && (r.getWidth().isSetAbsoluteValue() || r.getWidth().isSetRelativeValue());
+        }
+      };
+      break;
+    case RENDER_21907:
+      func = new ValidationFunction<Rectangle>() {
+        @Override
+        public boolean check(ValidationContext ctx, Rectangle r) {
+          return r.isSetHeight()
+            && (r.getHeight().isSetAbsoluteValue() || r.getHeight().isSetRelativeValue());
+        }
+      };
+      break;
+    case RENDER_21908:
+      func = new InvalidAttributeValidationFunction<Rectangle>(RenderConstants.ratio);
+      break;
+    case RENDER_21909:
+      func = new ValidationFunction<Rectangle>() {
+        @Override
+        public boolean check(ValidationContext ctx, Rectangle r) {
+          return !r.isSetZ() || r.getZ().isSetAbsoluteValue()
+            || r.getZ().isSetRelativeValue();
+        }
+      };
+      break;
+    case RENDER_21910:
+      func = new ValidationFunction<Rectangle>() {
+        @Override
+        public boolean check(ValidationContext ctx, Rectangle r) {
+          return !r.isSetRx() || r.getRx().isSetAbsoluteValue()
+            || r.getRx().isSetRelativeValue();
+        }
+      };
+      break;
+    case RENDER_21911:
+      func = new ValidationFunction<Rectangle>() {
+        @Override
+        public boolean check(ValidationContext ctx, Rectangle r) {
+          return !r.isSetRy() || r.getRy().isSetAbsoluteValue()
+            || r.getRy().isSetRelativeValue();
+        }
+      };
+      break;
+    }
+    return func;
+  }
+}

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RectangleConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RectangleConstraints.java
@@ -61,7 +61,7 @@ public class RectangleConstraints extends AbstractConstraintDeclaration {
   @Override
   public ValidationFunction<?> getValidationFunction(int errorCode,
     ValidationContext context) {
-    ValidationFunction<Rectangle> func = null;
+    ValidationFunction<Rectangle> func;
     switch(errorCode) {
     case RENDER_21901:
       func = new UnknownCoreAttributeValidationFunction<Rectangle>();
@@ -143,6 +143,10 @@ public class RectangleConstraints extends AbstractConstraintDeclaration {
             || r.getRy().isSetRelativeValue();
         }
       };
+      break;
+
+    default:
+      func = null;
       break;
     }
     return func;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderCubicBezierConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderCubicBezierConstraints.java
@@ -62,7 +62,7 @@ public class RenderCubicBezierConstraints
   @Override
   public ValidationFunction<?> getValidationFunction(int errorCode,
     ValidationContext context) {
-    ValidationFunction<RenderCubicBezier> func = null;
+    ValidationFunction<RenderCubicBezier> func;
     switch(errorCode) {
     case RENDER_22001:
       func = new UnknownCoreAttributeValidationFunction<RenderCubicBezier>();
@@ -132,6 +132,10 @@ public class RenderCubicBezierConstraints
             || r.getZ2().isSetRelativeValue());
         }
       };
+      break;
+
+    default:
+      func = null;
       break;
     }
     return func;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderCubicBezierConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderCubicBezierConstraints.java
@@ -1,0 +1,139 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ *
+ * Copyright (C) 2009-2018 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The University of California, San Diego, La Jolla, CA, USA
+ * 5. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.ext.render.RenderConstants;
+import org.sbml.jsbml.ext.render.RenderCubicBezier;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
+
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the
+ * {@link RenderCubicBezier} class.
+ * 
+ * @author David Emanuel Vetter
+ */
+public class RenderCubicBezierConstraints
+  extends AbstractConstraintDeclaration {
+
+  @Override
+  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+    CHECK_CATEGORY category, ValidationContext context) {
+    switch(category) {
+    case GENERAL_CONSISTENCY:
+      addRangeToSet(set, RENDER_22001, RENDER_22009);
+      break;
+    default:
+      break;
+    }
+  }
+
+
+  @Override
+  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+    int version, String attributeName, ValidationContext context) {
+    // TODO Auto-generated method stub
+  }
+
+
+  @Override
+  public ValidationFunction<?> getValidationFunction(int errorCode,
+    ValidationContext context) {
+    ValidationFunction<RenderCubicBezier> func = null;
+    switch(errorCode) {
+    case RENDER_22001:
+      func = new UnknownCoreAttributeValidationFunction<RenderCubicBezier>();
+      break;
+    case RENDER_22002:
+      func = new UnknownCoreElementValidationFunction<RenderCubicBezier>();
+      break;
+    case RENDER_22003:
+      func = new UnknownPackageAttributeValidationFunction<RenderCubicBezier>(RenderConstants.shortLabel) {
+        @Override
+        public boolean check(ValidationContext ctx, RenderCubicBezier rcb) {
+          return super.check(ctx, rcb) && rcb.isSetX1() && rcb.isSetY1()
+            && rcb.isSetX2() && rcb.isSetY2();
+        }
+      };
+      break;
+    case RENDER_22004:
+      func = new ValidationFunction<RenderCubicBezier>() {
+        @Override
+        public boolean check(ValidationContext ctx, RenderCubicBezier r) {
+          return r.isSetX1() && (r.getX1().isSetAbsoluteValue()
+            || r.getX1().isSetRelativeValue());
+        }
+      };
+      break;
+    case RENDER_22005:
+      func = new ValidationFunction<RenderCubicBezier>() {
+        @Override
+        public boolean check(ValidationContext ctx, RenderCubicBezier r) {
+          return r.isSetY1() && (r.getY1().isSetAbsoluteValue()
+            || r.getY1().isSetRelativeValue());
+        }
+      };
+      break;
+    case RENDER_22006:
+      func = new ValidationFunction<RenderCubicBezier>() {
+        @Override
+        public boolean check(ValidationContext ctx, RenderCubicBezier r) {
+          return r.isSetX2() && (r.getX2().isSetAbsoluteValue()
+            || r.getX2().isSetRelativeValue());
+        }
+      };
+      break;
+    case RENDER_22007:
+      func = new ValidationFunction<RenderCubicBezier>() {
+        @Override
+        public boolean check(ValidationContext ctx, RenderCubicBezier r) {
+          return r.isSetY2() && (r.getY2().isSetAbsoluteValue()
+            || r.getY2().isSetRelativeValue());
+        }
+      };
+      break;
+    case RENDER_22008:
+      func = new ValidationFunction<RenderCubicBezier>() {
+        @Override
+        public boolean check(ValidationContext ctx, RenderCubicBezier r) {
+          return r.isSetZ1() && (r.getZ1().isSetAbsoluteValue()
+            || r.getZ1().isSetRelativeValue());
+        }
+      };
+      break;
+    case RENDER_22009:
+      func = new ValidationFunction<RenderCubicBezier>() {
+        @Override
+        public boolean check(ValidationContext ctx, RenderCubicBezier r) {
+          return r.isSetZ2() && (r.getZ2().isSetAbsoluteValue()
+            || r.getZ2().isSetRelativeValue());
+        }
+      };
+      break;
+    }
+    return func;
+  }
+}

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderCurveConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderCurveConstraints.java
@@ -69,7 +69,7 @@ public class RenderCurveConstraints extends AbstractConstraintDeclaration {
   @Override
   public ValidationFunction<?> getValidationFunction(int errorCode,
     ValidationContext context) {
-    ValidationFunction<RenderCurve> func = null;
+    ValidationFunction<RenderCurve> func;
     switch(errorCode) {
     case RENDER_22101:
       func = new UnknownCoreAttributeValidationFunction<RenderCurve>();
@@ -162,6 +162,10 @@ public class RenderCurveConstraints extends AbstractConstraintDeclaration {
           return true;
         }
       };
+      break;
+
+    default:
+      func = null;
       break;
     }
     return func;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderCurveConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderCurveConstraints.java
@@ -21,10 +21,13 @@ package org.sbml.jsbml.validator.offline.constraints;
 
 import java.util.Set;
 
+import org.sbml.jsbml.ListOf;
 import org.sbml.jsbml.SBase;
 import org.sbml.jsbml.ext.render.LineEnding;
 import org.sbml.jsbml.ext.render.RenderConstants;
+import org.sbml.jsbml.ext.render.RenderCubicBezier;
 import org.sbml.jsbml.ext.render.RenderCurve;
+import org.sbml.jsbml.ext.render.RenderPoint;
 import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
 import org.sbml.jsbml.validator.offline.ValidationContext;
 import org.sbml.jsbml.validator.offline.constraints.helper.DuplicatedElementValidationFunction;
@@ -48,7 +51,7 @@ public class RenderCurveConstraints extends AbstractConstraintDeclaration {
     switch(category) {
     case GENERAL_CONSISTENCY:
       addRangeToSet(set, RENDER_22101, RENDER_22106);
-      // addRangeToSet(set, RENDER_23040, RENDER_23043); // TODO 2020/03: These constraints need be checked on RenderCurve and Polygon
+      addRangeToSet(set, RENDER_23040, RENDER_23043);
       break;
     default:
       break;
@@ -105,6 +108,60 @@ public class RenderCurveConstraints extends AbstractConstraintDeclaration {
           if (rc.isSetEndHead()) {
             SBase referenced = rc.getModel().getSBaseById(rc.getEndHead());
             return referenced != null && referenced instanceof LineEnding;
+          }
+          return true;
+        }
+      };
+      break;
+      
+    // Cases common to RenderCurve and Polygon:
+    case RENDER_23040:
+      func = new ValidationFunction<RenderCurve>() {
+        @Override
+        public boolean check(ValidationContext ctx, RenderCurve t) {
+          if(t.isSetListOfElements()) {
+            // TODO 2020/03: add methods isListOf___Empty() to all the relevant classes
+            return t.getListOfElements().isEmpty();
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_23041:
+      func = new ValidationFunction<RenderCurve>() {
+        @Override
+        public boolean check(ValidationContext ctx, RenderCurve t) {
+          if(t.isSetListOfElements()) {
+            return new UnknownCoreElementValidationFunction<ListOf<RenderPoint>>().check(
+              ctx, t.getListOfElements())
+              && new UnknownPackageElementValidationFunction<ListOf<RenderPoint>>(
+                RenderConstants.shortLabel).check(ctx, t.getListOfElements());
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_23042:
+      func = new ValidationFunction<RenderCurve>() {
+        @Override
+        public boolean check(ValidationContext ctx, RenderCurve t) {
+          if(t.isSetListOfElements()) {
+            return new UnknownCoreAttributeValidationFunction<ListOf<RenderPoint>>().check(
+              ctx, t.getListOfElements());
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_23043:
+      func = new ValidationFunction<RenderCurve>() {
+        @Override
+        public boolean check(ValidationContext ctx, RenderCurve t) {
+          if(t.isSetListOfElements()) {
+            ListOf<RenderPoint> list = t.getListOfElements();
+            return !list.isEmpty() 
+                && (list.get(0) instanceof RenderPoint) // not really needed, but here for completeness
+                && !(list.get(0) instanceof RenderCubicBezier);
           }
           return true;
         }

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderCurveConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderCurveConstraints.java
@@ -1,0 +1,115 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ *
+ * Copyright (C) 2009-2018 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The University of California, San Diego, La Jolla, CA, USA
+ * 5. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.SBase;
+import org.sbml.jsbml.ext.render.LineEnding;
+import org.sbml.jsbml.ext.render.RenderConstants;
+import org.sbml.jsbml.ext.render.RenderCurve;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.DuplicatedElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageElementValidationFunction;
+
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the
+ * {@link RenderCurve} class.
+ * 
+ * @author David Emanuel Vetter
+ */
+public class RenderCurveConstraints extends AbstractConstraintDeclaration {
+
+  @Override
+  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+    CHECK_CATEGORY category, ValidationContext context) {
+    switch(category) {
+    case GENERAL_CONSISTENCY:
+      addRangeToSet(set, RENDER_22101, RENDER_22106);
+      break;
+    default:
+      break;
+    }
+  }
+
+
+  @Override
+  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+    int version, String attributeName, ValidationContext context) {
+    // TODO Auto-generated method stub
+  }
+
+
+  @Override
+  public ValidationFunction<?> getValidationFunction(int errorCode,
+    ValidationContext context) {
+    ValidationFunction<RenderCurve> func = null;
+    switch(errorCode) {
+    case RENDER_22101:
+      func = new UnknownCoreAttributeValidationFunction<RenderCurve>();
+      break;
+    case RENDER_22102:
+      func = new UnknownCoreElementValidationFunction<RenderCurve>();
+      break;
+    case RENDER_22103:
+      func = new UnknownPackageAttributeValidationFunction<RenderCurve>(RenderConstants.shortLabel);
+      break;
+    case RENDER_22104:
+      func = new UnknownPackageElementValidationFunction<RenderCurve>(RenderConstants.shortLabel) {
+        public boolean check(ValidationContext ctx, RenderCurve rc) {
+          return super.check(ctx, rc)
+            && new DuplicatedElementValidationFunction<RenderCurve>(
+              RenderConstants.listOfElements).check(ctx, rc);
+        }
+      };
+      break;
+    case RENDER_22105:
+      func = new ValidationFunction<RenderCurve>() {
+        @Override
+        public boolean check(ValidationContext ctx, RenderCurve rc) {
+          if (rc.isSetStartHead()) {
+            SBase referenced = rc.getModel().getSBaseById(rc.getStartHead());
+            return referenced != null && referenced instanceof LineEnding;
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_22106:
+      func = new ValidationFunction<RenderCurve>() {
+        @Override
+        public boolean check(ValidationContext ctx, RenderCurve rc) {
+          if (rc.isSetEndHead()) {
+            SBase referenced = rc.getModel().getSBaseById(rc.getEndHead());
+            return referenced != null && referenced instanceof LineEnding;
+          }
+          return true;
+        }
+      };
+      break;
+    }
+    return func;
+  }
+}

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderCurveConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderCurveConstraints.java
@@ -48,6 +48,7 @@ public class RenderCurveConstraints extends AbstractConstraintDeclaration {
     switch(category) {
     case GENERAL_CONSISTENCY:
       addRangeToSet(set, RENDER_22101, RENDER_22106);
+      // addRangeToSet(set, RENDER_23040, RENDER_23043); // TODO 2020/03: These constraints need be checked on RenderCurve and Polygon
       break;
     default:
       break;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderCurveConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderCurveConstraints.java
@@ -119,11 +119,7 @@ public class RenderCurveConstraints extends AbstractConstraintDeclaration {
       func = new ValidationFunction<RenderCurve>() {
         @Override
         public boolean check(ValidationContext ctx, RenderCurve t) {
-          if(t.isSetListOfElements()) {
-            // TODO 2020/03: add methods isListOf___Empty() to all the relevant classes
-            return t.getListOfElements().isEmpty();
-          }
-          return true;
+          return !t.isListOfElementsEmpty();
         }
       };
       break;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderGraphicalObjectPluginConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderGraphicalObjectPluginConstraints.java
@@ -1,0 +1,83 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ *
+ * Copyright (C) 2009-2018 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The University of California, San Diego, La Jolla, CA, USA
+ * 5. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.ext.render.RenderConstants;
+import org.sbml.jsbml.ext.render.RenderGraphicalObjectPlugin;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
+
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the
+ * {@link RenderGraphicalObjectPlugin} class.
+ * 
+ * @author David Emanuel Vetter
+ */
+public class RenderGraphicalObjectPluginConstraints
+  extends AbstractConstraintDeclaration {
+
+  @Override
+  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+    CHECK_CATEGORY category, ValidationContext context) {
+    switch(category) {
+    case GENERAL_CONSISTENCY:
+      addRangeToSet(set, RENDER_20201, RENDER_20202);
+      break;
+      default:
+        break;
+    }
+  }
+
+
+  @Override
+  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+    int version, String attributeName, ValidationContext context) {
+    // TODO Auto-generated method stub
+  }
+
+
+  @Override
+  public ValidationFunction<?> getValidationFunction(int errorCode,
+    ValidationContext context) {
+    ValidationFunction<RenderGraphicalObjectPlugin> func = null;
+    switch(errorCode) {
+    case RENDER_20201:
+      func =
+        new UnknownPackageAttributeValidationFunction<RenderGraphicalObjectPlugin>(
+          RenderConstants.shortLabel);
+      break;
+    case RENDER_20202:
+      func = new ValidationFunction<RenderGraphicalObjectPlugin>() {
+
+        @Override
+        public boolean check(ValidationContext ctx, RenderGraphicalObjectPlugin t) {
+          // objectRole just can be any String and is optional: nothing to check 
+          return true;
+        }
+      };
+      break;
+    }
+    return func;
+  }
+}

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderGraphicalObjectPluginConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderGraphicalObjectPluginConstraints.java
@@ -60,7 +60,7 @@ public class RenderGraphicalObjectPluginConstraints
   @Override
   public ValidationFunction<?> getValidationFunction(int errorCode,
     ValidationContext context) {
-    ValidationFunction<RenderGraphicalObjectPlugin> func = null;
+    ValidationFunction<RenderGraphicalObjectPlugin> func;
     switch(errorCode) {
     case RENDER_20201:
       func =
@@ -76,6 +76,10 @@ public class RenderGraphicalObjectPluginConstraints
           return true;
         }
       };
+      break;
+
+    default:
+      func = null;
       break;
     }
     return func;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderGroupConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderGroupConstraints.java
@@ -65,7 +65,7 @@ public class RenderGroupConstraints extends AbstractConstraintDeclaration {
   @Override
   public ValidationFunction<?> getValidationFunction(int errorCode,
     ValidationContext context) {
-    ValidationFunction<RenderGroup> func = null;
+    ValidationFunction<RenderGroup> func;
     switch(errorCode) {
     case RENDER_21101:
       func = new UnknownCoreAttributeValidationFunction<RenderGroup>();
@@ -137,6 +137,10 @@ public class RenderGroupConstraints extends AbstractConstraintDeclaration {
     case RENDER_21111:
       func = new InvalidAttributeValidationFunction<RenderGroup>(
         RenderConstants.vTextAnchor);
+      break;
+
+    default:
+      func = null;
       break;
     }
     return func;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderGroupConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderGroupConstraints.java
@@ -1,0 +1,144 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ *
+ * Copyright (C) 2009-2018 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The University of California, San Diego, La Jolla, CA, USA
+ * 5. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.SBase;
+import org.sbml.jsbml.ext.render.LineEnding;
+import org.sbml.jsbml.ext.render.RenderConstants;
+import org.sbml.jsbml.ext.render.RenderGroup;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.DuplicatedElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.InvalidAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageElementValidationFunction;
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the
+ * {@link RenderGroup} class.
+ * 
+ * @author David Emanuel Vetter
+ */
+public class RenderGroupConstraints extends AbstractConstraintDeclaration {
+
+  @Override
+  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+    CHECK_CATEGORY category, ValidationContext context) {
+    switch(category) {
+    case GENERAL_CONSISTENCY:
+      addRangeToSet(set, RENDER_21101, RENDER_21111);
+      break;
+    default:
+      break;
+    }
+  }
+
+
+  @Override
+  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+    int version, String attributeName, ValidationContext context) {
+    // TODO Auto-generated method stub
+  }
+
+
+  @Override
+  public ValidationFunction<?> getValidationFunction(int errorCode,
+    ValidationContext context) {
+    ValidationFunction<RenderGroup> func = null;
+    switch(errorCode) {
+    case RENDER_21101:
+      func = new UnknownCoreAttributeValidationFunction<RenderGroup>();
+      break;
+    case RENDER_21102:
+      func = new UnknownCoreElementValidationFunction<RenderGroup>();
+      break;
+    case RENDER_21103:
+      func = new UnknownPackageAttributeValidationFunction<RenderGroup>(RenderConstants.shortLabel);
+      break;
+    case RENDER_21104:
+      func = new UnknownPackageElementValidationFunction<RenderGroup>(RenderConstants.shortLabel) {
+        @Override
+        public boolean check(ValidationContext ctx, RenderGroup group) {
+          return super.check(ctx, group)
+            && new DuplicatedElementValidationFunction<RenderGroup>(
+              RenderConstants.shortLabel + ":" + RenderConstants.listOfElements)
+                                                                              .check(
+                                                                                ctx,
+                                                                                group);
+        }
+      };
+      break;
+    case RENDER_21105:
+      func = new ValidationFunction<RenderGroup>() {
+        @Override
+        public boolean check(ValidationContext ctx, RenderGroup group) {
+          if(group.isSetStartHead()) {
+            SBase referenced = group.getModel().getSBaseById(group.getStartHead());
+            return referenced != null && referenced instanceof LineEnding;
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_21106:
+      func = new ValidationFunction<RenderGroup>() {
+        @Override
+        public boolean check(ValidationContext ctx, RenderGroup group) {
+          if(group.isSetEndHead()) {
+            SBase referenced = group.getModel().getSBaseById(group.getEndHead());
+            return referenced != null && referenced instanceof LineEnding;
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_21107:
+      func = new ValidationFunction<RenderGroup>() {
+        @Override
+        public boolean check(ValidationContext ctx, RenderGroup t) {
+          // Any string.
+          return true;
+        }
+      };
+      break;
+    case RENDER_21108:
+      func = new InvalidAttributeValidationFunction<RenderGroup>(
+          RenderConstants.fontWeightBold);
+      break;
+    case RENDER_21109:
+      func = new InvalidAttributeValidationFunction<RenderGroup>(
+        RenderConstants.fontStyleItalic);
+      break;
+    case RENDER_21110:
+      func = new InvalidAttributeValidationFunction<RenderGroup>(
+        RenderConstants.textAnchor);
+      break;
+    case RENDER_21111:
+      func = new InvalidAttributeValidationFunction<RenderGroup>(
+        RenderConstants.vTextAnchor);
+      break;
+    }
+    return func;
+  }
+}

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderInformationBaseConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderInformationBaseConstraints.java
@@ -129,18 +129,9 @@ public class RenderInformationBaseConstraints
       func = new ValidationFunction<RenderInformationBase>() {
         @Override
         public boolean check(ValidationContext ctx, RenderInformationBase t) {
-          // TODO 2020/03: the isSet-methods count empty lists as not set, thus
-          // rendering these checks futile
-          if(t.isSetListOfColorDefinitions() && t.getListOfColorDefinitions().isEmpty()) {
-            return false;
-          }
-          if(t.isSetListOfGradientDefinitions() && t.getListOfGradientDefinitions().isEmpty()) {
-            return false;
-          }
-          if(t.isSetListOfLineEndings() && t.getListOfLineEndings().isEmpty()) {
-            return false;
-          }
-          return true;
+          return !(t.isListOfColorDefinitionsEmpty()
+            || t.isListOfGradientDefinitionsEmpty()
+            || t.isListOfLineEndingsEmpty());
         }
       };
       break;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderInformationBaseConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderInformationBaseConstraints.java
@@ -68,7 +68,7 @@ public class RenderInformationBaseConstraints
   @Override
   public ValidationFunction<?> getValidationFunction(int errorCode,
     ValidationContext context) {
-    ValidationFunction<RenderInformationBase> func = null;
+    ValidationFunction<RenderInformationBase> func;
     switch(errorCode) {
     case RENDER_22901:
       func = new UnknownCoreAttributeValidationFunction<RenderInformationBase>();
@@ -214,6 +214,10 @@ public class RenderInformationBaseConstraints
           return true;
         }
       };
+      break;
+
+    default:
+      func = null;
       break;
     }
     return func;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderInformationBaseConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderInformationBaseConstraints.java
@@ -1,0 +1,230 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ *
+ * Copyright (C) 2009-2018 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The University of California, San Diego, La Jolla, CA, USA
+ * 5. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.SBase;
+import org.sbml.jsbml.ListOf;
+import org.sbml.jsbml.ext.render.RenderConstants;
+import org.sbml.jsbml.ext.render.ColorDefinition;
+import org.sbml.jsbml.ext.render.GradientBase;
+import org.sbml.jsbml.ext.render.LineEnding;
+import org.sbml.jsbml.ext.render.RenderInformationBase;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.DuplicatedElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageElementValidationFunction;
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the
+ * {@link RenderInformationBase} class.
+ * 
+ * @author David Emanuel Vetter
+ */
+public class RenderInformationBaseConstraints
+  extends AbstractConstraintDeclaration {
+
+  @Override
+  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+    CHECK_CATEGORY category, ValidationContext context) {
+    switch(category) {
+    case GENERAL_CONSISTENCY:
+      addRangeToSet(set, RENDER_22901, RENDER_22916);
+      break;
+    default:
+      break;
+    }
+  }
+
+
+  @Override
+  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+    int version, String attributeName, ValidationContext context) {
+    // TODO Auto-generated method stub
+  }
+
+
+  @Override
+  public ValidationFunction<?> getValidationFunction(int errorCode,
+    ValidationContext context) {
+    ValidationFunction<RenderInformationBase> func = null;
+    switch(errorCode) {
+    case RENDER_22901:
+      func = new UnknownCoreAttributeValidationFunction<RenderInformationBase>();
+      break;
+    case RENDER_22902:
+      func = new UnknownCoreElementValidationFunction<RenderInformationBase>();
+      break;
+    case RENDER_22903:
+      func =
+        new UnknownPackageAttributeValidationFunction<RenderInformationBase>(
+          RenderConstants.shortLabel)
+        {
+          public boolean check(ValidationContext ctx,
+            RenderInformationBase rib) {
+            return super.check(ctx, rib) && rib.isSetId();
+          }
+        };
+      break;
+    case RENDER_22904:
+      func =
+      new UnknownPackageElementValidationFunction<RenderInformationBase>(
+        RenderConstants.shortLabel)
+      {
+        public boolean check(ValidationContext ctx,
+          RenderInformationBase rib) {
+          return super.check(ctx, rib)
+              && new DuplicatedElementValidationFunction<RenderInformationBase>(
+                RenderConstants.listOfColorDefinitions).check(ctx, rib)
+              && new DuplicatedElementValidationFunction<RenderInformationBase>(
+                  RenderConstants.listOfGradientDefinitions).check(ctx, rib)
+              && new DuplicatedElementValidationFunction<RenderInformationBase>(
+                  RenderConstants.listOfLineEndings).check(ctx, rib);
+        }
+      };
+      break;
+    case RENDER_22905:
+    case RENDER_22906:
+    case RENDER_22907:
+    case RENDER_22909:
+      func = new ValidationFunction<RenderInformationBase>() {
+        @Override // any string
+        public boolean check(ValidationContext ctx, RenderInformationBase t) { return true; }
+      };
+      break;
+    case RENDER_22908:
+      func = new ValidationFunction<RenderInformationBase>() {
+        @Override
+        public boolean check(ValidationContext ctx, RenderInformationBase rib) {
+          if(rib.isSetReferenceRenderInformation()) {
+            SBase referenced = rib.getModel().getSBaseById(rib.getReferenceRenderInformation());
+            return referenced != null && referenced instanceof RenderInformationBase;
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_22910:
+      func = new ValidationFunction<RenderInformationBase>() {
+        @Override
+        public boolean check(ValidationContext ctx, RenderInformationBase t) {
+          // TODO 2020/03: the isSet-methods count empty lists as not set, thus
+          // rendering these checks futile
+          if(t.isSetListOfColorDefinitions() && t.getListOfColorDefinitions().isEmpty()) {
+            return false;
+          }
+          if(t.isSetListOfGradientDefinitions() && t.getListOfGradientDefinitions().isEmpty()) {
+            return false;
+          }
+          if(t.isSetListOfLineEndings() && t.getListOfLineEndings().isEmpty()) {
+            return false;
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_22911:
+      func = new ValidationFunction<RenderInformationBase>() {
+        @Override
+        public boolean check(ValidationContext ctx, RenderInformationBase t) {
+          if(t.isSetListOfColorDefinitions()) {
+            return new UnknownPackageElementValidationFunction<ListOf<ColorDefinition>>(
+              RenderConstants.shortLabel).check(ctx,
+                t.getListOfColorDefinitions())
+              && new UnknownCoreElementValidationFunction<ListOf<ColorDefinition>>().check(
+                ctx, t.getListOfColorDefinitions());
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_22912:
+      func = new ValidationFunction<RenderInformationBase>() {
+        @Override
+        public boolean check(ValidationContext ctx, RenderInformationBase t) {
+          if (t.isSetListOfGradientDefinitions()) {
+            return new UnknownPackageElementValidationFunction<ListOf<GradientBase>>(
+              RenderConstants.shortLabel).check(ctx,
+                t.getListOfGradientDefinitions())
+              && new UnknownCoreElementValidationFunction<ListOf<GradientBase>>().check(
+                ctx, t.getListOfGradientDefinitions());
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_22913:
+      func = new ValidationFunction<RenderInformationBase>() {
+        @Override
+        public boolean check(ValidationContext ctx, RenderInformationBase t) {
+          if(t.isSetListOfLineEndings()) {
+            return new UnknownPackageElementValidationFunction<ListOf<LineEnding>>(
+              RenderConstants.shortLabel).check(ctx, t.getListOfLineEndings())
+              && new UnknownCoreElementValidationFunction<ListOf<LineEnding>>().check(
+                ctx, t.getListOfLineEndings());
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_22914:
+      func = new ValidationFunction<RenderInformationBase>() {
+        @Override
+        public boolean check(ValidationContext ctx, RenderInformationBase t) {
+          if(t.isSetListOfColorDefinitions()) {
+            return new UnknownCoreAttributeValidationFunction<ListOf<ColorDefinition>>().check(ctx,
+                t.getListOfColorDefinitions());
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_22915:
+      func = new ValidationFunction<RenderInformationBase>() {
+        @Override
+        public boolean check(ValidationContext ctx, RenderInformationBase t) {
+          if(t.isSetListOfGradientDefinitions()) {
+            return new UnknownCoreAttributeValidationFunction<ListOf<GradientBase>>().check(ctx,
+                t.getListOfGradientDefinitions());
+          }
+          return true;
+        }
+      };
+      break;
+    case RENDER_22916:
+      func = new ValidationFunction<RenderInformationBase>() {
+        @Override
+        public boolean check(ValidationContext ctx, RenderInformationBase t) {
+          if(t.isSetListOfLineEndings()) {
+            return new UnknownCoreAttributeValidationFunction<ListOf<LineEnding>>().check(ctx,
+                t.getListOfLineEndings());
+          }
+          return true;
+        }
+      };
+      break;
+    }
+    return func;
+  }
+}

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderLayoutPluginConstraint.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderLayoutPluginConstraint.java
@@ -1,0 +1,133 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ *
+ * Copyright (C) 2009-2018 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The University of California, San Diego, La Jolla, CA, USA
+ * 5. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.ext.layout.Layout;
+import org.sbml.jsbml.ext.render.ListOfLocalRenderInformation;
+import org.sbml.jsbml.ext.render.RenderConstants;
+import org.sbml.jsbml.ext.render.RenderLayoutPlugin;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.DuplicatedElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageElementValidationFunction;
+
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the
+ * {@link RenderLayoutPluginConstraint} class.
+ * 
+ * @author David Emanuel Vetter
+ */
+public class RenderLayoutPluginConstraint extends AbstractConstraintDeclaration {
+
+  @Override
+  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+    CHECK_CATEGORY category, ValidationContext context) {
+    switch(category) {
+    case GENERAL_CONSISTENCY:
+      addRangeToSet(set, RENDER_20301, RENDER_20307);
+      break;
+    default:
+      break;
+    }
+  }
+
+
+  @Override
+  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+    int version, String attributeName, ValidationContext context) {
+    // TODO Auto-generated method stub
+  }
+
+
+  @Override
+  public ValidationFunction<?> getValidationFunction(int errorCode,
+    ValidationContext context) {
+    ValidationFunction<RenderLayoutPlugin> func = null;
+    switch(errorCode) {
+    case RENDER_20301:
+      func = new ValidationFunction<RenderLayoutPlugin>() {
+
+        @Override
+        public boolean check(ValidationContext ctx, RenderLayoutPlugin rlp) {
+          Layout extendedLayout = (Layout) rlp.getExtendedSBase();
+          return new DuplicatedElementValidationFunction<Layout>(
+            RenderConstants.shortLabel + ":"
+              + RenderConstants.listOfLocalRenderInformation).check(ctx,
+                extendedLayout)
+            && new UnknownPackageElementValidationFunction<Layout>(
+              RenderConstants.shortLabel).check(ctx, extendedLayout);
+        }
+      };
+      break;
+      
+    case RENDER_20302:
+      func = new ValidationFunction<RenderLayoutPlugin>() {
+
+        @Override
+        public boolean check(ValidationContext ctx, RenderLayoutPlugin t) {
+          if(t.isSetListOfLocalRenderInformation()) {
+            // TODO 2020/03: isSet will ignore empty List (i.e. empty-list is
+            // considered not set) -> Figure out how to check whether empty
+            // (getList... will set the list)
+            return !t.getListOfLocalRenderInformation().isEmpty();
+          }
+          // Need not be set:
+          return true;
+        }
+      };
+      break;
+      
+    case RENDER_20303:
+      func = new ValidationFunction<RenderLayoutPlugin>() {
+
+        @Override
+        public boolean check(ValidationContext ctx, RenderLayoutPlugin rlp) {
+          if(rlp.isSetListOfLocalRenderInformation()) {
+            return new UnknownElementValidationFunction<ListOfLocalRenderInformation>().check(
+              ctx, rlp.getListOfLocalRenderInformation());
+          }
+          return true;
+        }
+      };
+      break;
+      
+    case RENDER_20304:
+      func = new ValidationFunction<RenderLayoutPlugin>() {
+
+        @Override
+        public boolean check(ValidationContext ctx, RenderLayoutPlugin rlp) {
+          if(rlp.isSetListOfLocalRenderInformation()) {
+            return new UnknownAttributeValidationFunction<ListOfLocalRenderInformation>().check(
+              ctx, rlp.getListOfLocalRenderInformation());
+          }
+          return true;
+        }
+      };
+      break;
+    }
+    
+    return func;
+  }
+}

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderLayoutPluginConstraint.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderLayoutPluginConstraint.java
@@ -21,6 +21,7 @@ package org.sbml.jsbml.validator.offline.constraints;
 
 import java.util.Set;
 
+import org.sbml.jsbml.JSBML;
 import org.sbml.jsbml.ext.layout.Layout;
 import org.sbml.jsbml.ext.render.ListOfLocalRenderInformation;
 import org.sbml.jsbml.ext.render.RenderConstants;
@@ -28,14 +29,16 @@ import org.sbml.jsbml.ext.render.RenderLayoutPlugin;
 import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
 import org.sbml.jsbml.validator.offline.ValidationContext;
 import org.sbml.jsbml.validator.offline.constraints.helper.DuplicatedElementValidationFunction;
-import org.sbml.jsbml.validator.offline.constraints.helper.UnknownAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
 import org.sbml.jsbml.validator.offline.constraints.helper.UnknownElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
 import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageElementValidationFunction;
+import org.sbml.jsbml.xml.XMLNode;
 
 
 /**
  * Defines validation rules (as {@link ValidationFunction} instances) for the
- * {@link RenderLayoutPluginConstraint} class.
+ * {@link RenderLayoutPlugin} class.
  * 
  * @author David Emanuel Vetter
  */
@@ -113,19 +116,82 @@ public class RenderLayoutPluginConstraint extends AbstractConstraintDeclaration 
       };
       break;
       
+    // Core attributes on ListOfLocalRenderInformation
     case RENDER_20304:
       func = new ValidationFunction<RenderLayoutPlugin>() {
 
         @Override
         public boolean check(ValidationContext ctx, RenderLayoutPlugin rlp) {
           if(rlp.isSetListOfLocalRenderInformation()) {
-            return new UnknownAttributeValidationFunction<ListOfLocalRenderInformation>().check(
+            return new UnknownCoreAttributeValidationFunction<ListOfLocalRenderInformation>().check(
               ctx, rlp.getListOfLocalRenderInformation());
           }
           return true;
         }
       };
       break;
+      
+    // Package attributes on ListOfLocalRenderInformation
+    case RENDER_20305:
+      func = new ValidationFunction<RenderLayoutPlugin>() {
+
+        @Override
+        public boolean check(ValidationContext ctx, RenderLayoutPlugin rlp) {
+          if(rlp.isSetListOfLocalRenderInformation()) {
+            return new UnknownPackageAttributeValidationFunction<ListOfLocalRenderInformation>(
+              RenderConstants.shortLabel).check(ctx,
+                rlp.getListOfLocalRenderInformation());
+          }
+          return true;
+        }
+      };
+      break;
+      
+    case RENDER_20306:
+      func=new ValidationFunction<RenderLayoutPlugin>() {
+
+        @Override
+        public boolean check(ValidationContext ctx, RenderLayoutPlugin rlp) {
+
+          if (rlp.isSetListOfLocalRenderInformation()) {
+            ListOfLocalRenderInformation lris = rlp.getListOfLocalRenderInformation();
+            // a) Check that versionMajor is nonnegative, if it is a correct number
+            if (lris.isSetVersionMajor()) {
+              return lris.getVersionMajor() >= 0;
+            } else if (lris.getUserObject(JSBML.UNKNOWN_XML) != null) {
+              XMLNode unknown = (XMLNode) lris.getUserObject(JSBML.UNKNOWN_XML);
+              // If the versionMajor is found in the unknown-object: There was a
+              // numberformat-exception, and the file is invalid (return false);
+              // If it isn't, the index will be -1 and the file is not invalid
+              return unknown.getAttrIndex(RenderConstants.versionMajor) == -1;
+            }
+          }
+                    
+          return true;
+        }
+      };
+      break;
+      
+    case RENDER_20307:
+      func=new ValidationFunction<RenderLayoutPlugin>() {
+
+        @Override
+        public boolean check(ValidationContext ctx, RenderLayoutPlugin rlp) {
+
+          if (rlp.isSetListOfLocalRenderInformation()) {
+            ListOfLocalRenderInformation lris = rlp.getListOfLocalRenderInformation();
+            if (lris.isSetVersionMinor()) {
+              return lris.getVersionMinor() >= 0;
+            } else if (lris.getUserObject(JSBML.UNKNOWN_XML) != null) {
+              XMLNode unknown = (XMLNode) lris.getUserObject(JSBML.UNKNOWN_XML);
+              return unknown.getAttrIndex(RenderConstants.versionMinor) == -1;
+            }
+          }
+                    
+          return true;
+        }
+      };
+      break;    
     }
     
     return func;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderLayoutPluginConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderLayoutPluginConstraints.java
@@ -66,7 +66,7 @@ public class RenderLayoutPluginConstraints extends AbstractConstraintDeclaration
   @Override
   public ValidationFunction<?> getValidationFunction(int errorCode,
     ValidationContext context) {
-    ValidationFunction<RenderLayoutPlugin> func = null;
+    ValidationFunction<RenderLayoutPlugin> func;
     switch(errorCode) {
     case RENDER_20301:
       func = new ValidationFunction<RenderLayoutPlugin>() {
@@ -179,7 +179,11 @@ public class RenderLayoutPluginConstraints extends AbstractConstraintDeclaration
           return true;
         }
       };
-      break;    
+      break;  
+
+    default:
+      func = null;
+      break;
     }
     
     return func;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderLayoutPluginConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderLayoutPluginConstraints.java
@@ -21,7 +21,6 @@ package org.sbml.jsbml.validator.offline.constraints;
 
 import java.util.Set;
 
-import org.sbml.jsbml.JSBML;
 import org.sbml.jsbml.ext.layout.Layout;
 import org.sbml.jsbml.ext.render.ListOfLocalRenderInformation;
 import org.sbml.jsbml.ext.render.RenderConstants;
@@ -29,11 +28,11 @@ import org.sbml.jsbml.ext.render.RenderLayoutPlugin;
 import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
 import org.sbml.jsbml.validator.offline.ValidationContext;
 import org.sbml.jsbml.validator.offline.constraints.helper.DuplicatedElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.InvalidAttributeValidationFunction;
 import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
 import org.sbml.jsbml.validator.offline.constraints.helper.UnknownElementValidationFunction;
 import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
 import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageElementValidationFunction;
-import org.sbml.jsbml.xml.XMLNode;
 
 
 /**
@@ -155,15 +154,12 @@ public class RenderLayoutPluginConstraints extends AbstractConstraintDeclaration
 
           if (rlp.isSetListOfLocalRenderInformation()) {
             ListOfLocalRenderInformation lris = rlp.getListOfLocalRenderInformation();
-            // a) Check that versionMajor is nonnegative, if it is a correct number
+            // Check that versionMajor is nonnegative, if it is a correct number
             if (lris.isSetVersionMajor()) {
               return lris.getVersionMajor() >= 0;
-            } else if (lris.getUserObject(JSBML.UNKNOWN_XML) != null) {
-              XMLNode unknown = (XMLNode) lris.getUserObject(JSBML.UNKNOWN_XML);
-              // If the versionMajor is found in the unknown-object: There was a
-              // numberformat-exception, and the file is invalid (return false);
-              // If it isn't, the index will be -1 and the file is not invalid
-              return unknown.getAttrIndex(RenderConstants.versionMajor) == -1;
+            } else {
+              return new InvalidAttributeValidationFunction<ListOfLocalRenderInformation>(
+                  RenderConstants.versionMajor).check(ctx, lris); 
             }
           }
                     
@@ -182,9 +178,9 @@ public class RenderLayoutPluginConstraints extends AbstractConstraintDeclaration
             ListOfLocalRenderInformation lris = rlp.getListOfLocalRenderInformation();
             if (lris.isSetVersionMinor()) {
               return lris.getVersionMinor() >= 0;
-            } else if (lris.getUserObject(JSBML.UNKNOWN_XML) != null) {
-              XMLNode unknown = (XMLNode) lris.getUserObject(JSBML.UNKNOWN_XML);
-              return unknown.getAttrIndex(RenderConstants.versionMinor) == -1;
+            } else  {
+              return new InvalidAttributeValidationFunction<ListOfLocalRenderInformation>(
+                  RenderConstants.versionMinor).check(ctx, lris); 
             }
           }
                     

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderLayoutPluginConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderLayoutPluginConstraints.java
@@ -86,17 +86,9 @@ public class RenderLayoutPluginConstraints extends AbstractConstraintDeclaration
       
     case RENDER_20302:
       func = new ValidationFunction<RenderLayoutPlugin>() {
-
         @Override
         public boolean check(ValidationContext ctx, RenderLayoutPlugin t) {
-          if(t.isSetListOfLocalRenderInformation()) {
-            // TODO 2020/03: isSet will ignore empty List (i.e. empty-list is
-            // considered not set) -> Figure out how to check whether empty
-            // (getList... will set the list)
-            return !t.getListOfLocalRenderInformation().isEmpty();
-          }
-          // Need not be set:
-          return true;
+          return !t.isListOfLocalRenderInformationEmpty();
         }
       };
       break;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderLayoutPluginConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderLayoutPluginConstraints.java
@@ -42,7 +42,7 @@ import org.sbml.jsbml.xml.XMLNode;
  * 
  * @author David Emanuel Vetter
  */
-public class RenderLayoutPluginConstraint extends AbstractConstraintDeclaration {
+public class RenderLayoutPluginConstraints extends AbstractConstraintDeclaration {
 
   @Override
   public void addErrorCodesForCheck(Set<Integer> set, int level, int version,

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderListOfLayoutsPluginConstraint.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderListOfLayoutsPluginConstraint.java
@@ -1,0 +1,192 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ *
+ * Copyright (C) 2009-2018 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The University of California, San Diego, La Jolla, CA, USA
+ * 5. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.JSBML;
+import org.sbml.jsbml.ListOf;
+import org.sbml.jsbml.ext.layout.Layout;
+import org.sbml.jsbml.ext.render.ListOfGlobalRenderInformation;
+import org.sbml.jsbml.ext.render.RenderConstants;
+import org.sbml.jsbml.ext.render.RenderListOfLayoutsPlugin;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.DuplicatedElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageElementValidationFunction;
+import org.sbml.jsbml.xml.XMLNode;
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the
+ * {@link RenderListOfLayoutsPlugin} class.
+ * 
+ * @author David Emanuel Vetter
+ */
+public class RenderListOfLayoutsPluginConstraint
+  extends AbstractConstraintDeclaration {
+
+  @Override
+  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+    CHECK_CATEGORY category, ValidationContext context) {
+    switch(category) {
+    case GENERAL_CONSISTENCY:
+      addRangeToSet(set, RENDER_20401, RENDER_20407);
+      break;
+    default:
+      break;
+    }
+  }
+
+
+  @Override
+  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+    int version, String attributeName, ValidationContext context) {
+    // TODO Auto-generated method stub
+  }
+
+
+  @Override
+  public ValidationFunction<?> getValidationFunction(int errorCode,
+    ValidationContext context) {
+    ValidationFunction<RenderListOfLayoutsPlugin> func = null;
+    switch(errorCode) {
+    case RENDER_20401:
+      func = new ValidationFunction<RenderListOfLayoutsPlugin>() {
+
+        @Override
+        public boolean check(ValidationContext ctx,
+          RenderListOfLayoutsPlugin rlp) {
+          ListOf<Layout> extendedList = (ListOf<Layout>) rlp.getExtendedSBase();
+          return new DuplicatedElementValidationFunction<ListOf<Layout>>(
+            RenderConstants.shortLabel + ":"
+              + RenderConstants.listOfGlobalRenderInformation).check(ctx,
+                extendedList)
+            && new UnknownPackageElementValidationFunction<ListOf<Layout>>(
+              RenderConstants.shortLabel).check(ctx, extendedList);
+        }
+      };
+      break;
+      
+    case RENDER_20402:
+      func = new ValidationFunction<RenderListOfLayoutsPlugin>() {
+
+        @Override
+        public boolean check(ValidationContext ctx, RenderListOfLayoutsPlugin t) {
+          if(t.isSetListOfGlobalRenderInformation()) {
+            return !t.getListOfGlobalRenderInformation().isEmpty();
+          }
+          // Need not be set:
+          return true;
+        }
+      };
+      break;
+      
+    case RENDER_20403:
+      func = new ValidationFunction<RenderListOfLayoutsPlugin>() {
+
+        @Override
+        public boolean check(ValidationContext ctx, RenderListOfLayoutsPlugin rlp) {
+          if(rlp.isSetListOfGlobalRenderInformation()) {
+            return new UnknownElementValidationFunction<ListOfGlobalRenderInformation>().check(
+              ctx, rlp.getListOfGlobalRenderInformation());
+          }
+          return true;
+        }
+      };
+      break;
+      
+    case RENDER_20404:
+      func = new ValidationFunction<RenderListOfLayoutsPlugin>() {
+
+        @Override
+        public boolean check(ValidationContext ctx, RenderListOfLayoutsPlugin rlp) {
+          if(rlp.isSetListOfGlobalRenderInformation()) {
+            return new UnknownCoreAttributeValidationFunction<ListOfGlobalRenderInformation>().check(
+              ctx, rlp.getListOfGlobalRenderInformation());
+          }
+          return true;
+        }
+      };
+      break;
+      
+    case RENDER_20405:
+      func = new ValidationFunction<RenderListOfLayoutsPlugin>() {
+
+        @Override
+        public boolean check(ValidationContext ctx, RenderListOfLayoutsPlugin rlp) {
+          if(rlp.isSetListOfGlobalRenderInformation()) {
+            return new UnknownPackageAttributeValidationFunction<ListOfGlobalRenderInformation>(
+              RenderConstants.shortLabel).check(ctx,
+                rlp.getListOfGlobalRenderInformation());
+          }
+          return true;
+        }
+      };
+      break;
+      
+    case RENDER_20406:
+      func=new ValidationFunction<RenderListOfLayoutsPlugin>() {
+
+        @Override
+        public boolean check(ValidationContext ctx, RenderListOfLayoutsPlugin rlp) {
+
+          if (rlp.isSetListOfGlobalRenderInformation()) {
+            ListOfGlobalRenderInformation gris = rlp.getListOfGlobalRenderInformation();
+            if (gris.isSetVersionMajor()) {
+              return gris.getVersionMajor() >= 0;
+            } else if (gris.getUserObject(JSBML.UNKNOWN_XML) != null) {
+              XMLNode unknown = (XMLNode) gris.getUserObject(JSBML.UNKNOWN_XML);
+              return unknown.getAttrIndex(RenderConstants.versionMajor) == -1;
+            }
+          }
+                    
+          return true;
+        }
+      };
+      break;
+      
+    case RENDER_20407:
+      func=new ValidationFunction<RenderListOfLayoutsPlugin>() {
+
+        @Override
+        public boolean check(ValidationContext ctx, RenderListOfLayoutsPlugin rlp) {
+
+          if (rlp.isSetListOfGlobalRenderInformation()) {
+            ListOfGlobalRenderInformation gris = rlp.getListOfGlobalRenderInformation();
+            if (gris.isSetVersionMinor()) {
+              return gris.getVersionMinor() >= 0;
+            } else if (gris.getUserObject(JSBML.UNKNOWN_XML) != null) {
+              XMLNode unknown = (XMLNode) gris.getUserObject(JSBML.UNKNOWN_XML);
+              return unknown.getAttrIndex(RenderConstants.versionMinor) == -1;
+            }
+          }
+                    
+          return true;
+        }
+      };
+      break;    
+    }
+    
+    return func;
+  }
+}

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderListOfLayoutsPluginConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderListOfLayoutsPluginConstraints.java
@@ -75,6 +75,8 @@ public class RenderListOfLayoutsPluginConstraints
         @Override
         public boolean check(ValidationContext ctx,
           RenderListOfLayoutsPlugin rlp) {
+          // Coupling: RenderListOfLayouts is known to extend a ListOf<Layout>
+          @SuppressWarnings("unchecked") 
           ListOf<Layout> extendedList = (ListOf<Layout>) rlp.getExtendedSBase();
           return new DuplicatedElementValidationFunction<ListOf<Layout>>(
             RenderConstants.shortLabel + ":"

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderListOfLayoutsPluginConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderListOfLayoutsPluginConstraints.java
@@ -21,7 +21,6 @@ package org.sbml.jsbml.validator.offline.constraints;
 
 import java.util.Set;
 
-import org.sbml.jsbml.JSBML;
 import org.sbml.jsbml.ListOf;
 import org.sbml.jsbml.ext.layout.Layout;
 import org.sbml.jsbml.ext.render.ListOfGlobalRenderInformation;
@@ -30,11 +29,11 @@ import org.sbml.jsbml.ext.render.RenderListOfLayoutsPlugin;
 import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
 import org.sbml.jsbml.validator.offline.ValidationContext;
 import org.sbml.jsbml.validator.offline.constraints.helper.DuplicatedElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.InvalidAttributeValidationFunction;
 import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
 import org.sbml.jsbml.validator.offline.constraints.helper.UnknownElementValidationFunction;
 import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
 import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageElementValidationFunction;
-import org.sbml.jsbml.xml.XMLNode;
 
 /**
  * Defines validation rules (as {@link ValidationFunction} instances) for the
@@ -154,9 +153,9 @@ public class RenderListOfLayoutsPluginConstraints
             ListOfGlobalRenderInformation gris = rlp.getListOfGlobalRenderInformation();
             if (gris.isSetVersionMajor()) {
               return gris.getVersionMajor() >= 0;
-            } else if (gris.getUserObject(JSBML.UNKNOWN_XML) != null) {
-              XMLNode unknown = (XMLNode) gris.getUserObject(JSBML.UNKNOWN_XML);
-              return unknown.getAttrIndex(RenderConstants.versionMajor) == -1;
+            } else {
+              return new InvalidAttributeValidationFunction<ListOfGlobalRenderInformation>(
+                  RenderConstants.versionMajor).check(ctx, gris); 
             }
           }
                     
@@ -175,9 +174,9 @@ public class RenderListOfLayoutsPluginConstraints
             ListOfGlobalRenderInformation gris = rlp.getListOfGlobalRenderInformation();
             if (gris.isSetVersionMinor()) {
               return gris.getVersionMinor() >= 0;
-            } else if (gris.getUserObject(JSBML.UNKNOWN_XML) != null) {
-              XMLNode unknown = (XMLNode) gris.getUserObject(JSBML.UNKNOWN_XML);
-              return unknown.getAttrIndex(RenderConstants.versionMinor) == -1;
+            } else {
+              return new InvalidAttributeValidationFunction<ListOfGlobalRenderInformation>(
+                  RenderConstants.versionMinor).check(ctx, gris); 
             }
           }
                     

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderListOfLayoutsPluginConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderListOfLayoutsPluginConstraints.java
@@ -67,7 +67,7 @@ public class RenderListOfLayoutsPluginConstraints
   @Override
   public ValidationFunction<?> getValidationFunction(int errorCode,
     ValidationContext context) {
-    ValidationFunction<RenderListOfLayoutsPlugin> func = null;
+    ValidationFunction<RenderListOfLayoutsPlugin> func;
     switch(errorCode) {
     case RENDER_20401:
       func = new ValidationFunction<RenderListOfLayoutsPlugin>() {
@@ -181,7 +181,11 @@ public class RenderListOfLayoutsPluginConstraints
           return true;
         }
       };
-      break;    
+      break;   
+
+    default:
+      func = null;
+      break;
     }
     
     return func;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderListOfLayoutsPluginConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderListOfLayoutsPluginConstraints.java
@@ -91,11 +91,7 @@ public class RenderListOfLayoutsPluginConstraints
 
         @Override
         public boolean check(ValidationContext ctx, RenderListOfLayoutsPlugin t) {
-          if(t.isSetListOfGlobalRenderInformation()) {
-            return !t.getListOfGlobalRenderInformation().isEmpty();
-          }
-          // Need not be set:
-          return true;
+          return !t.isListOfGlobalRenderInformationEmpty();
         }
       };
       break;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderListOfLayoutsPluginConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderListOfLayoutsPluginConstraints.java
@@ -42,7 +42,7 @@ import org.sbml.jsbml.xml.XMLNode;
  * 
  * @author David Emanuel Vetter
  */
-public class RenderListOfLayoutsPluginConstraint
+public class RenderListOfLayoutsPluginConstraints
   extends AbstractConstraintDeclaration {
 
   @Override

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderPointConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderPointConstraints.java
@@ -61,7 +61,7 @@ public class RenderPointConstraints extends AbstractConstraintDeclaration {
   @Override
   public ValidationFunction<?> getValidationFunction(int errorCode,
     ValidationContext context) {
-    ValidationFunction<RenderPoint> func = null;
+    ValidationFunction<RenderPoint> func;
     switch(errorCode) {
     case RENDER_22201:
       func = new UnknownCoreAttributeValidationFunction<RenderPoint>();
@@ -102,6 +102,10 @@ public class RenderPointConstraints extends AbstractConstraintDeclaration {
             || r.getZ().isSetRelativeValue();
         }
       };
+      break;
+
+    default:
+      func = null;
       break;
     }
     return func;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderPointConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/RenderPointConstraints.java
@@ -1,0 +1,109 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ *
+ * Copyright (C) 2009-2018 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The University of California, San Diego, La Jolla, CA, USA
+ * 5. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.ext.render.RenderConstants;
+import org.sbml.jsbml.ext.render.RenderPoint;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
+
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the
+ * {@link RenderPoint} class.
+ * 
+ * @author David Emanuel Vetter
+ */
+public class RenderPointConstraints extends AbstractConstraintDeclaration {
+
+  @Override
+  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+    CHECK_CATEGORY category, ValidationContext context) {
+    switch(category) {
+    case GENERAL_CONSISTENCY:
+      addRangeToSet(set, RENDER_22201, RENDER_22206);
+      break;
+    default:
+      break;
+    }
+  }
+
+
+  @Override
+  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+    int version, String attributeName, ValidationContext context) {
+    // TODO Auto-generated method stub
+  }
+
+
+  @Override
+  public ValidationFunction<?> getValidationFunction(int errorCode,
+    ValidationContext context) {
+    ValidationFunction<RenderPoint> func = null;
+    switch(errorCode) {
+    case RENDER_22201:
+      func = new UnknownCoreAttributeValidationFunction<RenderPoint>();
+      break;
+    case RENDER_22202:
+      func = new UnknownCoreElementValidationFunction<RenderPoint>();
+      break;
+    case RENDER_22203:
+      func = new UnknownPackageAttributeValidationFunction<RenderPoint>(RenderConstants.shortLabel) {
+        public boolean check(ValidationContext ctx, RenderPoint p) {
+          return super.check(ctx, p) && p.isSetX() && p.isSetY();
+        }
+      };
+      break;
+    case RENDER_22204:
+      func = new ValidationFunction<RenderPoint>() {
+        @Override
+        public boolean check(ValidationContext ctx, RenderPoint r) {
+          return r.isSetX()
+            && (r.getX().isSetAbsoluteValue() || r.getX().isSetRelativeValue());
+        }
+      };
+      break;
+    case RENDER_22205:
+      func = new ValidationFunction<RenderPoint>() {
+        @Override
+        public boolean check(ValidationContext ctx, RenderPoint r) {
+          return r.isSetY()
+            && (r.getY().isSetAbsoluteValue() || r.getY().isSetRelativeValue());
+        }
+      };
+      break;
+    case RENDER_22206:
+      func = new ValidationFunction<RenderPoint>() {
+        @Override
+        public boolean check(ValidationContext ctx, RenderPoint r) {
+          return !r.isSetZ() || r.getZ().isSetAbsoluteValue()
+            || r.getZ().isSetRelativeValue();
+        }
+      };
+      break;
+    }
+    return func;
+  }
+}

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/StyleConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/StyleConstraints.java
@@ -67,7 +67,7 @@ public class StyleConstraints extends AbstractConstraintDeclaration {
   @Override
   public ValidationFunction<?> getValidationFunction(int errorCode,
     ValidationContext context) {
-    ValidationFunction<Style> func = null;
+    ValidationFunction<Style> func;
     switch(errorCode) {
     case RENDER_20801:
     case RENDER_22801:
@@ -97,6 +97,10 @@ public class StyleConstraints extends AbstractConstraintDeclaration {
         @Override // any string
         public boolean check(ValidationContext ctx, Style t) { return true; }
       };    
+      break;
+
+    default:
+      func = null;
       break;
     }
     return func;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/StyleConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/StyleConstraints.java
@@ -33,7 +33,7 @@ import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementVal
  * 
  * @author David Emanuel Vetter
  */
-public class GlobalStyleConstraint extends AbstractConstraintDeclaration {
+public class StyleConstraints extends AbstractConstraintDeclaration {
 
   @Override
   public void addErrorCodesForCheck(Set<Integer> set, int level, int version,

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/StyleConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/StyleConstraints.java
@@ -21,15 +21,23 @@ package org.sbml.jsbml.validator.offline.constraints;
 
 import java.util.Set;
 
+import org.sbml.jsbml.ext.render.RenderConstants;
 import org.sbml.jsbml.ext.render.Style;
 import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
 import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.DuplicatedElementValidationFunction;
 import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
 import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageElementValidationFunction;
 
 /**
  * Defines validation rules (as {@link ValidationFunction} instances) for the
- * {@link Style} class.
+ * {@link Style} class.<br> 
+ * <b>Note:</b> Since global styles are not explicitly implemented
+ * in JSBML, this class combines the constraints placed on both Style and
+ * GlobalStyle (which is not a problem, since GlobalStyle does not add any
+ * meaningfully new constraints)
  * 
  * @author David Emanuel Vetter
  */
@@ -40,7 +48,8 @@ public class StyleConstraints extends AbstractConstraintDeclaration {
     CHECK_CATEGORY category, ValidationContext context) {
     switch(category) {
     case GENERAL_CONSISTENCY:
-      addRangeToSet(set, RENDER_20801, RENDER_20802);
+      addRangeToSet(set, RENDER_20801, RENDER_20802); // Constraints on GlobalStyle
+      addRangeToSet(set, RENDER_22801, RENDER_22807); // Constraints on any Style
       break;
     default:
       break;
@@ -61,10 +70,33 @@ public class StyleConstraints extends AbstractConstraintDeclaration {
     ValidationFunction<Style> func = null;
     switch(errorCode) {
     case RENDER_20801:
+    case RENDER_22801:
       func = new UnknownCoreAttributeValidationFunction<Style>();
       break;
     case RENDER_20802:
+    case RENDER_22802:
       func = new UnknownCoreElementValidationFunction<Style>();
+      break;
+      
+    case RENDER_22803:
+      func = new UnknownPackageAttributeValidationFunction<Style>(RenderConstants.shortLabel);
+      break;
+    case RENDER_22804:
+      func = new UnknownPackageElementValidationFunction<Style>(RenderConstants.shortLabel) {
+        public boolean check(ValidationContext ctx, Style style) {
+          return super.check(ctx, style)
+            && new DuplicatedElementValidationFunction<Style>(
+              RenderConstants.group).check(ctx, style);
+        }
+      };
+      break;
+    case RENDER_22805:
+    case RENDER_22806:
+    case RENDER_22807:
+      func = new ValidationFunction<Style>() {
+        @Override // any string
+        public boolean check(ValidationContext ctx, Style t) { return true; }
+      };    
       break;
     }
     return func;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/TextConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/TextConstraints.java
@@ -1,0 +1,143 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ *
+ * Copyright (C) 2009-2018 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The University of California, San Diego, La Jolla, CA, USA
+ * 5. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.ext.render.RenderConstants;
+import org.sbml.jsbml.ext.render.Text;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.InvalidAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the
+ * {@link Text} class.
+ * 
+ * @author David Emanuel Vetter
+ */
+public class TextConstraints extends AbstractConstraintDeclaration {
+
+  @Override
+  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+    CHECK_CATEGORY category, ValidationContext context) {
+    switch(category) {
+    case GENERAL_CONSISTENCY:
+      addRangeToSet(set, RENDER_22301, RENDER_22312);
+      break;
+    default:
+      break;
+    }
+  }
+
+
+  @Override
+  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+    int version, String attributeName, ValidationContext context) {
+    // TODO Auto-generated method stub
+  }
+
+
+  @Override
+  public ValidationFunction<?> getValidationFunction(int errorCode,
+    ValidationContext context) {
+    ValidationFunction<Text> func = null;
+    switch(errorCode) {
+    case RENDER_22301:
+      func = new UnknownCoreAttributeValidationFunction<Text>();
+      break;
+    case RENDER_22302:
+      func = new UnknownCoreElementValidationFunction<Text>();
+      break;
+    case RENDER_22303:
+      func = new UnknownPackageAttributeValidationFunction<Text>(RenderConstants.shortLabel) {
+        public boolean check(ValidationContext ctx, Text t) {
+          return super.check(ctx, t) && t.isSetX() && t.isSetY();
+        }
+      };
+      break;
+    case RENDER_22304:
+      func = new ValidationFunction<Text>() {
+        @Override
+        public boolean check(ValidationContext ctx, Text t) {
+          return t.isSetX()
+            && (t.getX().isSetAbsoluteValue() || t.getX().isSetRelativeValue());
+        }
+      };
+      break;
+    case RENDER_22305:
+      func = new ValidationFunction<Text>() {
+        @Override
+        public boolean check(ValidationContext ctx, Text t) {
+          return t.isSetY()
+            && (t.getY().isSetAbsoluteValue() || t.getY().isSetRelativeValue());
+        }
+      };
+      break;
+    case RENDER_22306:
+      func = new ValidationFunction<Text>() {
+        @Override
+        public boolean check(ValidationContext ctx, Text t) {
+          // Any string
+          return true;
+        }
+      };
+      break;
+    case RENDER_22307:
+      func = new InvalidAttributeValidationFunction<Text>(
+          RenderConstants.fontWeightBold);
+      break;
+    case RENDER_22308:
+      func = new InvalidAttributeValidationFunction<Text>(
+          RenderConstants.fontStyleItalic);
+      break;
+    case RENDER_22309:
+      func = new InvalidAttributeValidationFunction<Text>(
+          RenderConstants.textAnchor);
+      break;
+    case RENDER_22310:
+      func = new InvalidAttributeValidationFunction<Text>(
+          RenderConstants.vTextAnchor);
+      break;
+    case RENDER_22311:
+      func = new ValidationFunction<Text>() {
+        @Override
+        public boolean check(ValidationContext ctx, Text t) {
+          return !t.isSetZ() || t.getZ().isSetAbsoluteValue()
+            || t.getZ().isSetRelativeValue();
+        }
+      };
+      break;
+    case RENDER_22312:
+      func = new ValidationFunction<Text>() {
+        @Override
+        public boolean check(ValidationContext ctx, Text t) {
+          return !t.isSetFontSize() || t.getFontSize().isSetAbsoluteValue()
+            || t.getZ().isSetRelativeValue();
+        }
+      };
+      break;
+    }
+    return func;
+  }
+}

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/TextConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/TextConstraints.java
@@ -61,7 +61,7 @@ public class TextConstraints extends AbstractConstraintDeclaration {
   @Override
   public ValidationFunction<?> getValidationFunction(int errorCode,
     ValidationContext context) {
-    ValidationFunction<Text> func = null;
+    ValidationFunction<Text> func;
     switch(errorCode) {
     case RENDER_22301:
       func = new UnknownCoreAttributeValidationFunction<Text>();
@@ -136,6 +136,10 @@ public class TextConstraints extends AbstractConstraintDeclaration {
             || t.getZ().isSetRelativeValue();
         }
       };
+      break;
+
+    default:
+      func = null;
       break;
     }
     return func;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/Transformation2DConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/Transformation2DConstraints.java
@@ -58,13 +58,17 @@ public class Transformation2DConstraints extends AbstractConstraintDeclaration {
   @Override
   public ValidationFunction<?> getValidationFunction(int errorCode,
     ValidationContext context) {
-    ValidationFunction<Transformation2D> func = null;
+    ValidationFunction<Transformation2D> func;
     switch(errorCode) {
     case RENDER_22401:
       func = new UnknownCoreAttributeValidationFunction<Transformation2D>();
       break;
     case RENDER_22402:
       func = new UnknownCoreElementValidationFunction<Transformation2D>();
+      break;
+
+    default:
+      func = null;
       break;
     }
     return func;

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/Transformation2DConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/Transformation2DConstraints.java
@@ -1,0 +1,72 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ *
+ * Copyright (C) 2009-2018 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The University of California, San Diego, La Jolla, CA, USA
+ * 5. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.ext.render.Transformation2D;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the
+ * {@link Transformation2D} class.
+ * 
+ * @author David Emanuel Vetter
+ */
+public class Transformation2DConstraints extends AbstractConstraintDeclaration {
+
+  @Override
+  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+    CHECK_CATEGORY category, ValidationContext context) {
+    switch(category) {
+    case GENERAL_CONSISTENCY:
+      addRangeToSet(set, RENDER_22401, RENDER_22402);
+      break;
+    default:
+      break;
+    }
+  }
+
+
+  @Override
+  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+    int version, String attributeName, ValidationContext context) {
+    // TODO Auto-generated method stub
+  }
+
+
+  @Override
+  public ValidationFunction<?> getValidationFunction(int errorCode,
+    ValidationContext context) {
+    ValidationFunction<Transformation2D> func = null;
+    switch(errorCode) {
+    case RENDER_22401:
+      func = new UnknownCoreAttributeValidationFunction<Transformation2D>();
+      break;
+    case RENDER_22402:
+      func = new UnknownCoreElementValidationFunction<Transformation2D>();
+      break;
+    }
+    return func;
+  }
+}

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/TransformationConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/TransformationConstraints.java
@@ -1,0 +1,87 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ *
+ * Copyright (C) 2009-2018 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The University of California, San Diego, La Jolla, CA, USA
+ * 5. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+package org.sbml.jsbml.validator.offline.constraints;
+
+import java.util.Set;
+
+import org.sbml.jsbml.ext.render.RenderConstants;
+import org.sbml.jsbml.ext.render.Transformation;
+import org.sbml.jsbml.validator.SBMLValidator.CHECK_CATEGORY;
+import org.sbml.jsbml.validator.offline.ValidationContext;
+import org.sbml.jsbml.validator.offline.constraints.helper.InvalidAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreAttributeValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownCoreElementValidationFunction;
+import org.sbml.jsbml.validator.offline.constraints.helper.UnknownPackageAttributeValidationFunction;
+
+/**
+ * Defines validation rules (as {@link ValidationFunction} instances) for the
+ * {@link Transformation} class.
+ * 
+ * @author David Emanuel Vetter
+ */
+public class TransformationConstraints extends AbstractConstraintDeclaration {
+
+  @Override
+  public void addErrorCodesForCheck(Set<Integer> set, int level, int version,
+    CHECK_CATEGORY category, ValidationContext context) {
+    switch(category) {
+    case GENERAL_CONSISTENCY:
+      addRangeToSet(set, RENDER_22501, RENDER_22505);
+      break;
+    default:
+      break;
+    }
+  }
+
+
+  @Override
+  public void addErrorCodesForAttribute(Set<Integer> set, int level,
+    int version, String attributeName, ValidationContext context) {
+    // TODO Auto-generated method stub
+  }
+
+
+  @Override
+  public ValidationFunction<?> getValidationFunction(int errorCode,
+    ValidationContext context) {
+    ValidationFunction<Transformation> func = null;
+    switch(errorCode) {
+    case RENDER_22501:
+      func = new UnknownCoreAttributeValidationFunction<Transformation>();
+      break;
+    case RENDER_22502:
+      func = new UnknownCoreElementValidationFunction<Transformation>();
+      break;
+    case RENDER_22503:
+      func = new UnknownPackageAttributeValidationFunction<Transformation>(RenderConstants.shortLabel);
+      break;
+    case RENDER_22504:
+      func = new InvalidAttributeValidationFunction<Transformation>(RenderConstants.transform);
+      break;
+    case RENDER_22505:
+      func = new ValidationFunction<Transformation>() {
+        @Override // Any string
+        public boolean check(ValidationContext ctx, Transformation t) { return true; }
+      };
+      break;
+    }
+    return func;
+  }
+}

--- a/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/TransformationConstraints.java
+++ b/extensions/render/src/org/sbml/jsbml/validator/offline/constraints/TransformationConstraints.java
@@ -61,7 +61,7 @@ public class TransformationConstraints extends AbstractConstraintDeclaration {
   @Override
   public ValidationFunction<?> getValidationFunction(int errorCode,
     ValidationContext context) {
-    ValidationFunction<Transformation> func = null;
+    ValidationFunction<Transformation> func;
     switch(errorCode) {
     case RENDER_22501:
       func = new UnknownCoreAttributeValidationFunction<Transformation>();
@@ -80,6 +80,10 @@ public class TransformationConstraints extends AbstractConstraintDeclaration {
         @Override // Any string
         public boolean check(ValidationContext ctx, Transformation t) { return true; }
       };
+      break;
+
+    default:
+      func = null;
       break;
     }
     return func;

--- a/extensions/render/src/org/sbml/jsbml/xml/parsers/RenderParser.java
+++ b/extensions/render/src/org/sbml/jsbml/xml/parsers/RenderParser.java
@@ -187,6 +187,10 @@ public class RenderParser extends AbstractReaderWriter  implements PackageParser
       }
     }
     else if (contextObject instanceof RenderInformationBase) {
+      // TODO 2020/03: calls like this might need be added to more of the cases (wherever child-elements play a role)
+      // keep order of elements for later validation
+      AbstractReaderWriter.storeElementsOrder(elementName, contextObject);
+      
       RenderInformationBase renderInformation = (RenderInformationBase) contextObject;
       SBase newElement = null;
 

--- a/extensions/render/src/org/sbml/jsbml/xml/parsers/RenderParser.java
+++ b/extensions/render/src/org/sbml/jsbml/xml/parsers/RenderParser.java
@@ -153,7 +153,7 @@ public class RenderParser extends AbstractReaderWriter  implements PackageParser
     }
     
     if (contextObject instanceof LayoutModelPlugin) {
-      // TODO: This seems to never actually get used.
+      // TODO 2020/03: This seems to never actually get used.
       LayoutModelPlugin layoutModel = (LayoutModelPlugin) contextObject;
       
       ListOf<Layout> listOfLayouts = layoutModel.getListOfLayouts();

--- a/extensions/render/test/org/sbml/jsbml/ext/render/test/CurveTest.java
+++ b/extensions/render/test/org/sbml/jsbml/ext/render/test/CurveTest.java
@@ -21,6 +21,7 @@
 package org.sbml.jsbml.ext.render.test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -140,5 +141,30 @@ public class CurveTest {
     assertTrue(!curve.isSetListOfElements());
     curve.setListOfElements(list);
     assertTrue(curve.isSetListOfElements());
+  }
+  
+  
+  /**
+   * Tests {@link org.sbml.jsbml.ext.render.RenderCurve#isSetListOfElements()}
+   * and {@link org.sbml.jsbml.ext.render.RenderCurve#isListOfElementsEmpty()}.
+   */
+  @Test
+  public void testIsSetListOfElements() {
+    RenderCurve curve=new RenderCurve();
+    assertFalse(curve.isSetListOfElements());
+    assertFalse(curve.isListOfElementsEmpty()); // there is none
+    
+    ListOf<RenderPoint> list=new ListOf<RenderPoint>();
+    curve.setListOfElements(list);
+    assertFalse(curve.isSetListOfElements());
+    assertTrue(curve.isListOfElementsEmpty());
+    
+    RenderPoint point=new RenderPoint();
+    point.setX(new RelAbsVector(.01d));
+    point.setY(new RelAbsVector(.01d));
+    point.setZ(new RelAbsVector(.01d));
+    curve.addElement(point);
+    assertTrue(curve.isSetListOfElements());
+    assertFalse(curve.isListOfElementsEmpty());
   }
 }

--- a/extensions/render/test/org/sbml/jsbml/ext/render/test/RelAbsVectorTest.java
+++ b/extensions/render/test/org/sbml/jsbml/ext/render/test/RelAbsVectorTest.java
@@ -291,6 +291,10 @@ public class RelAbsVectorTest {
     rav.setCoordinate((String) null);
     assertFalse(rav.isSetAbsoluteValue());
     assertFalse(rav.isSetRelativeValue());
+    
+    rav.setCoordinate("%2");
+    assertFalse(rav.isSetAbsoluteValue());
+    assertFalse(rav.isSetRelativeValue());
   }
 
   /** Test for {@link RelAbsVector#getCoordinate()} 

--- a/extensions/render/test/org/sbml/jsbml/ext/render/test/RenderWriteTest.java
+++ b/extensions/render/test/org/sbml/jsbml/ext/render/test/RenderWriteTest.java
@@ -190,7 +190,7 @@ public class RenderWriteTest {
   public void testWriteReadText() throws SBMLException, XMLStreamException {
     RenderGroup group = new RenderGroup();
     Text questionmark = group.createText();
-    questionmark.setFontSize((short) 10);
+    questionmark.setFontSize(new RelAbsVector(10));
     questionmark.setFontFamily("monospace");
     questionmark.setTextAnchor(HTextAnchor.START);
     questionmark.setVTextAnchor(VTextAnchor.TOP);    

--- a/extensions/render/test/org/sbml/jsbml/ext/render/test/TextTest.java
+++ b/extensions/render/test/org/sbml/jsbml/ext/render/test/TextTest.java
@@ -68,7 +68,7 @@ public class TextTest {
    */
   @Test
   public void testGetFontSize() {
-    short fontSize=18;
+    RelAbsVector fontSize=new RelAbsVector(18);
     Text textType=new Text();
     assertTrue(!textType.isSetFontSize());
     textType.setFontSize(fontSize);
@@ -177,7 +177,7 @@ public class TextTest {
    */
   @Test
   public void testIsSetFontSize() {
-    short fontSize=18;
+    RelAbsVector fontSize=new RelAbsVector(18);
     Text textType=new Text();
     assertTrue(!textType.isSetFontSize());
     textType.setFontSize(fontSize);
@@ -311,7 +311,7 @@ public class TextTest {
    */
   @Test
   public void testSetFontSize() {
-    short fontSize=19;
+    RelAbsVector fontSize=new RelAbsVector(19);
     Text textType=new Text();
     assertTrue(!textType.isSetFontSize());
     textType.setFontSize(fontSize);

--- a/extensions/render/test/org/sbml/jsbml/ext/render/validator/test/TestRenderValidation.java
+++ b/extensions/render/test/org/sbml/jsbml/ext/render/validator/test/TestRenderValidation.java
@@ -1,0 +1,35 @@
+package org.sbml.jsbml.ext.render.validator.test;
+
+import static org.junit.Assert.*;
+
+import java.io.InputStream;
+import javax.xml.stream.XMLStreamException;
+import org.junit.Test;
+import org.sbml.jsbml.SBMLDocument;
+import org.sbml.jsbml.SBMLErrorLog;
+import org.sbml.jsbml.SBMLError;
+import org.sbml.jsbml.SBMLReader;
+
+
+public class TestRenderValidation {
+
+  @Test
+  public void test() throws XMLStreamException {
+    
+    // Read some file
+    InputStream in = getClass().getResourceAsStream("/org/sbml/jsbml/ext/render/validator/test/data/invalid.xml");
+    SBMLDocument doc = SBMLReader.read(in);
+    int nErrors = doc.checkConsistencyOffline();
+    SBMLErrorLog errors = doc.getErrorLog();
+    System.out.println("\n" +  nErrors + " Errors: ");
+    for(int i = 0; i < errors.getErrorCount(); i++) {
+      SBMLError error = errors.getError(i);
+      System.out.println(
+        error.getCode() + (("" + error.getCode()).startsWith("13")
+          ? (": " + error.getMessage() + "\n") : "")); // Do assertions here
+    }
+      
+    
+    fail("Not yet implemented");
+  }
+}

--- a/extensions/render/test/org/sbml/jsbml/ext/render/validator/test/TestRenderValidation.java
+++ b/extensions/render/test/org/sbml/jsbml/ext/render/validator/test/TestRenderValidation.java
@@ -28,7 +28,6 @@ public class TestRenderValidation {
         error.getCode() + (("" + error.getCode()).startsWith("13")
           ? (": " + error.getMessage() + "\n") : "")); // Do assertions here
     }
-      
     
     fail("Not yet implemented");
   }

--- a/extensions/render/test/org/sbml/jsbml/ext/render/validator/test/data/invalid.xml
+++ b/extensions/render/test/org/sbml/jsbml/ext/render/validator/test/data/invalid.xml
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<!-- Created by Render-example version 1 on 2020-03-13 at 09:52:23 MEZ with JSBML version 1.5-SNAPSHOT. -->
+<!-- Created by Render-example version 1 on 2020-03-17 at 11:03:45 MEZ with JSBML version 1.5-SNAPSHOT. -->
 <sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" layout:required="false" level="3" render:required="false" version="1" xmlns:layout="http://www.sbml.org/sbml/level3/version1/layout/version1" xmlns:render="http://www.sbml.org/sbml/level3/version1/render/version1">
   <model id="Ring" timeUnits="time">
     <layout:listOfLayouts xmlns:layout="http://www.sbml.org/sbml/level3/version1/layout/version1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-      <layout:layout layout:id="_350d07b1_2736_4748_9871_bc244b7b2000" layout:name="auto_layout">
+      <layout:layout layout:id="e4443365_0f29_4c83_a8a8_cd6a490fec81" layout:name="auto_layout">
         <render:listOfRenderInformation xmlns:render="http://www.sbml.org/sbml/level3/version1/render/version1">
-          <render:renderInformation render:id="_350d07b1_2736_4748_9871_bc244b7b2000_render">
+          <render:renderInformation render:id="e4443365_0f29_4c83_a8a8_cd6a490fec81_render">
             <render:listOfColorDefinitions>
               <render:colorDefinition render:id="red" render:value="#FF0000FF"/>
               <render:colorDefinition render:id="black" render:value="#000000FF"/>
@@ -138,17 +138,17 @@
               <render:style id="TextGylphStyle" render:typeList="TEXTGLYPH">
                 <render:g render:font-family="monospace" render:font-size="10" render:text-anchor="middle" render:vtext-anchor="middle"/>
               </render:style>
-              <render:style id="styleOf__92316df2_d22b_4b44_af26_74c082559170" render:idList="_92316df2_d22b_4b44_af26_74c082559170">
+              <render:style id="styleOf__6bee86a4_ee78_488c_9a2a_ad8f4f7c9195" render:idList="_6bee86a4_ee78_488c_9a2a_ad8f4f7c9195">
                 <render:g>
                   <render:rectangle render:fill="compartmentFill" render:height="122.13106741667367" render:stroke="compartmentStroke" render:stroke-width="0.3" render:width="176.80753550602049" render:x="0" render:y="0"/>
                 </render:g>
               </render:style>
-              <render:style id="styleOf__10a4c427_0db0_4b50_885b_61e256a5da58" render:idList="_10a4c427_0db0_4b50_885b_61e256a5da58">
+              <render:style id="styleOf__941e5043_8eda_464d_9fd9_4a49dd1fe7d7" render:idList="_941e5043_8eda_464d_9fd9_4a49dd1fe7d7">
                 <render:g>
                   <render:rectangle render:fill="compartmentFill" render:height="122.13106741667367" render:stroke="compartmentStroke" render:stroke-width="0.3" render:width="255.1789024783502" render:x="0" render:y="0"/>
                 </render:g>
               </render:style>
-              <render:style id="styleOf__44634e92_9ba8_4b4b_86a8_b866ab4ca27e" render:idList="_44634e92_9ba8_4b4b_86a8_b866ab4ca27e">
+              <render:style id="styleOf__02bdf2cc_18ca_475f_99cf_d6f11d38d716" render:idList="_02bdf2cc_18ca_475f_99cf_d6f11d38d716">
                 <render:g>
                   <render:rectangle render:fill="compartmentFill" render:height="112.40453183331931" render:stroke="compartmentStroke" render:stroke-width="0.3" render:width="50.000000000000014" render:x="0" render:y="0"/>
                 </render:g>
@@ -161,14 +161,14 @@
               </render:style>
               <render:style id="styleOf_B_glyph_" render:idList="B_glyph_">
                 <render:g>
-                  <render:ellipse render:cx="+50.0%" render:cy="+50.0%" render:fill="simpleChemicalFill" render:rx="10.0" render:stroke="black" render:stroke-width="0.0"/>
-                  <render:ellipse render:cx="+50.0%" render:cy="+50.0%" render:rx="10.0" render:stroke="black" render:stroke-width="1.0"/>
+                  <render:ellipse render:cx="50.0%" render:cy="50.0%" render:fill="simpleChemicalFill" render:rx="10.0" render:stroke="black" render:stroke-width="0.0"/>
+                  <render:ellipse render:cx="50.0%" render:cy="50.0%" render:rx="10.0" render:stroke="black" render:stroke-width="1.0"/>
                 </render:g>
               </render:style>
               <render:style id="styleOf_C_glyph_" render:idList="C_glyph_">
                 <render:g>
-                  <render:ellipse render:cx="+50.0%" render:cy="+50.0%" render:fill="simpleChemicalFill" render:rx="10.0" render:stroke="black" render:stroke-width="0.0"/>
-                  <render:ellipse render:cx="+50.0%" render:cy="+50.0%" render:rx="10.0" render:stroke="black" render:stroke-width="1.0"/>
+                  <render:ellipse render:cx="50.0%" render:cy="50.0%" render:fill="simpleChemicalFill" render:rx="10.0" render:stroke="black" render:stroke-width="0.0"/>
+                  <render:ellipse render:cx="50.0%" render:cy="50.0%" render:rx="10.0" render:stroke="black" render:stroke-width="1.0"/>
                 </render:g>
               </render:style>
               <render:style id="styleOf_D_glyph_" render:idList="D_glyph_">
@@ -179,14 +179,14 @@
               </render:style>
               <render:style id="styleOf_E_glyph_" render:idList="E_glyph_">
                 <render:g>
-                  <render:ellipse render:cx="+50.0%" render:cy="+50.0%" render:fill="simpleChemicalFill" render:rx="10.0" render:stroke="black" render:stroke-width="0.0"/>
-                  <render:ellipse render:cx="+50.0%" render:cy="+50.0%" render:rx="10.0" render:stroke="black" render:stroke-width="1.0"/>
+                  <render:ellipse render:cx="50.0%" render:cy="50.0%" render:fill="simpleChemicalFill" render:rx="10.0" render:stroke="black" render:stroke-width="0.0"/>
+                  <render:ellipse render:cx="50.0%" render:cy="50.0%" render:rx="10.0" render:stroke="black" render:stroke-width="1.0"/>
                 </render:g>
               </render:style>
               <render:style id="styleOf_F_glyph_" render:idList="F_glyph_">
                 <render:g>
-                  <render:ellipse render:cx="+50.0%" render:cy="+50.0%" render:fill="simpleChemicalFill" render:rx="10.0" render:stroke="black" render:stroke-width="0.0"/>
-                  <render:ellipse render:cx="+50.0%" render:cy="+50.0%" render:rx="10.0" render:stroke="black" render:stroke-width="1.0"/>
+                  <render:ellipse render:cx="50.0%" render:cy="50.0%" render:fill="simpleChemicalFill" render:rx="10.0" render:stroke="black" render:stroke-width="0.0"/>
+                  <render:ellipse render:cx="50.0%" render:cy="50.0%" render:rx="10.0" render:stroke="black" render:stroke-width="1.0"/>
                 </render:g>
               </render:style>
               <render:style id="styleOf_G_glyph_" render:idList="G_glyph_">
@@ -197,14 +197,14 @@
               </render:style>
               <render:style id="styleOf_H_glyph_" render:idList="H_glyph_">
                 <render:g>
-                  <render:ellipse render:cx="+50.0%" render:cy="+50.0%" render:fill="simpleChemicalFill" render:rx="10.0" render:stroke="black" render:stroke-width="0.0"/>
-                  <render:ellipse render:cx="+50.0%" render:cy="+50.0%" render:rx="10.0" render:stroke="black" render:stroke-width="1.0"/>
+                  <render:ellipse render:cx="50.0%" render:cy="50.0%" render:fill="simpleChemicalFill" render:rx="10.0" render:stroke="black" render:stroke-width="0.0"/>
+                  <render:ellipse render:cx="50.0%" render:cy="50.0%" render:rx="10.0" render:stroke="black" render:stroke-width="1.0"/>
                 </render:g>
               </render:style>
               <render:style id="styleOf_I_glyph_" render:idList="I_glyph_">
                 <render:g>
-                  <render:ellipse render:cx="+50.0%" render:cy="+50.0%" render:fill="simpleChemicalFill" render:rx="10.0" render:stroke="black" render:stroke-width="0.0"/>
-                  <render:ellipse render:cx="+50.0%" render:cy="+50.0%" render:rx="10.0" render:stroke="black" render:stroke-width="1.0"/>
+                  <render:ellipse render:cx="50.0%" render:cy="50.0%" render:fill="simpleChemicalFill" render:rx="10.0" render:stroke="black" render:stroke-width="0.0"/>
+                  <render:ellipse render:cx="50.0%" render:cy="50.0%" render:rx="10.0" render:stroke="black" render:stroke-width="1.0"/>
                 </render:g>
               </render:style>
               <render:style id="styleOf_empty_glyph_" render:idList="empty_glyph_">
@@ -218,7 +218,7 @@
                   </render:polygon>
                 </render:g>
               </render:style>
-              <render:style render:idList="_4641e4aa_2fb4_47d5_beef_f7865441ba9a">
+              <render:style render:idList="c2a5f753_fe54_4f03_935a_fedc8d166beb">
                 <render:g render:stroke="black" render:stroke-width="1.0">
                   <render:polygon render:fill="white">
                     <render:listOfElements>
@@ -230,7 +230,7 @@
                   </render:polygon>
                 </render:g>
               </render:style>
-              <render:style render:idList="_4037dff4_c70e_4431_a53b_75813a602854">
+              <render:style render:idList="_7e68a061_6e95_4408_a456_f8e7db6a9b16">
                 <render:g render:stroke="black" render:stroke-width="1.0">
                   <render:polygon render:fill="white">
                     <render:listOfElements>
@@ -242,7 +242,7 @@
                   </render:polygon>
                 </render:g>
               </render:style>
-              <render:style render:idList="_2ba86b91_45fb_49ab_8a5c_0be0a09db021">
+              <render:style render:idList="_87c6949f_7d39_4755_a83e_70a1e9ca9003">
                 <render:g render:stroke="black" render:stroke-width="1.0">
                   <render:polygon render:fill="white">
                     <render:listOfElements>
@@ -254,7 +254,7 @@
                   </render:polygon>
                 </render:g>
               </render:style>
-              <render:style render:idList="_98713161_2be6_4f31_ae59_25511e2b2fd6">
+              <render:style render:idList="df94c99d_8b7b_4b73_a09b_4e12f92d749d">
                 <render:g render:stroke="black" render:stroke-width="1.0">
                   <render:polygon render:fill="white">
                     <render:listOfElements>
@@ -266,7 +266,7 @@
                   </render:polygon>
                 </render:g>
               </render:style>
-              <render:style render:idList="c63e47e3_86a3_446e_9440_e434c85ad7d3">
+              <render:style render:idList="c17a9a94_f1a0_44ad_b8b8_a23ff04ab53e">
                 <render:g render:stroke="black" render:stroke-width="1.0">
                   <render:polygon render:fill="white">
                     <render:listOfElements>
@@ -283,19 +283,19 @@
         </render:listOfRenderInformation>
         <layout:dimensions layout:depth="100" layout:height="800" layout:width="800"/>
         <layout:listOfCompartmentGlyphs>
-          <layout:compartmentGlyph layout:compartment="extracellular" layout:id="_92316df2_d22b_4b44_af26_74c082559170">
+          <layout:compartmentGlyph layout:compartment="extracellular" layout:id="_6bee86a4_ee78_488c_9a2a_ad8f4f7c9195">
             <layout:boundingBox>
               <layout:position layout:x="395" layout:y="261.66666666666663" layout:z="-2"/>
               <layout:dimensions layout:depth="1" layout:height="122.13106741667367" layout:width="176.80753550602049"/>
             </layout:boundingBox>
           </layout:compartmentGlyph>
-          <layout:compartmentGlyph layout:compartment="cytosol" layout:id="_10a4c427_0db0_4b50_885b_61e256a5da58">
+          <layout:compartmentGlyph layout:compartment="cytosol" layout:id="_941e5043_8eda_464d_9fd9_4a49dd1fe7d7">
             <layout:boundingBox>
               <layout:position layout:x="316.6286330276703" layout:y="436.20226591665966" layout:z="-3"/>
               <layout:dimensions layout:depth="1" layout:height="122.13106741667367" layout:width="255.1789024783502"/>
             </layout:boundingBox>
           </layout:compartmentGlyph>
-          <layout:compartmentGlyph layout:compartment="vesicle" layout:id="_44634e92_9ba8_4b4b_86a8_b866ab4ca27e">
+          <layout:compartmentGlyph layout:compartment="vesicle" layout:id="_02bdf2cc_18ca_475f_99cf_d6f11d38d716">
             <layout:boundingBox>
               <layout:position layout:x="268.1924644939795" layout:y="353.79773408334034" layout:z="-1"/>
               <layout:dimensions layout:depth="1" layout:height="112.40453183331931" layout:width="50.000000000000014"/>
@@ -365,7 +365,7 @@
           </layout:speciesGlyph>
         </layout:listOfSpeciesGlyphs>
         <layout:listOfReactionGlyphs>
-          <layout:reactionGlyph layout:id="_4641e4aa_2fb4_47d5_beef_f7865441ba9a" layout:reaction="R1">
+          <layout:reactionGlyph layout:id="c2a5f753_fe54_4f03_935a_fedc8d166beb" layout:reaction="R1">
             <layout:boundingBox>
               <layout:position layout:x="474.4360806896183" layout:y="317.24245248926627" layout:z="0"/>
               <layout:dimensions layout:depth="0" layout:height="10" layout:width="10"/>
@@ -417,7 +417,7 @@
               </layout:speciesReferenceGlyph>
             </layout:listOfSpeciesReferenceGlyphs>
           </layout:reactionGlyph>
-          <layout:reactionGlyph layout:id="_4037dff4_c70e_4431_a53b_75813a602854" layout:reaction="R2">
+          <layout:reactionGlyph layout:id="_7e68a061_6e95_4408_a456_f8e7db6a9b16" layout:reaction="R2">
             <layout:boundingBox>
               <layout:position layout:x="450.14185839563527" layout:y="415.43273898766824" layout:z="0"/>
               <layout:dimensions layout:depth="0" layout:height="10" layout:width="10"/>
@@ -469,7 +469,7 @@
               </layout:speciesReferenceGlyph>
             </layout:listOfSpeciesReferenceGlyphs>
           </layout:reactionGlyph>
-          <layout:reactionGlyph layout:id="_2ba86b91_45fb_49ab_8a5c_0be0a09db021" layout:reaction="R3">
+          <layout:reactionGlyph layout:id="_87c6949f_7d39_4755_a83e_70a1e9ca9003" layout:reaction="R3">
             <layout:boundingBox>
               <layout:position layout:x="438.7908513947403" layout:y="410.20226585616547" layout:z="0"/>
               <layout:dimensions layout:depth="0" layout:height="10" layout:width="10"/>
@@ -545,7 +545,7 @@
               </layout:speciesReferenceGlyph>
             </layout:listOfSpeciesReferenceGlyphs>
           </layout:reactionGlyph>
-          <layout:reactionGlyph layout:id="_98713161_2be6_4f31_ae59_25511e2b2fd6" layout:reaction="R4">
+          <layout:reactionGlyph layout:id="df94c99d_8b7b_4b73_a09b_4e12f92d749d" layout:reaction="R4">
             <layout:boundingBox>
               <layout:position layout:x="338.81194329538914" layout:y="459.9448844024854" layout:z="0"/>
               <layout:dimensions layout:depth="0" layout:height="10" layout:width="10"/>
@@ -609,7 +609,7 @@
               </layout:speciesReferenceGlyph>
             </layout:listOfSpeciesReferenceGlyphs>
           </layout:reactionGlyph>
-          <layout:reactionGlyph layout:id="c63e47e3_86a3_446e_9440_e434c85ad7d3" layout:reaction="EX1">
+          <layout:reactionGlyph layout:id="c17a9a94_f1a0_44ad_b8b8_a23ff04ab53e" layout:reaction="EX1">
             <layout:boundingBox>
               <layout:position layout:x="344.1898111697849" layout:y="404.29422478735734" layout:z="0"/>
               <layout:dimensions layout:depth="0" layout:height="10" layout:width="10"/>
@@ -651,73 +651,73 @@
           </layout:reactionGlyph>
         </layout:listOfReactionGlyphs>
         <layout:listOfTextGlyphs>
-          <layout:textGlyph layout:graphicalObject="_92316df2_d22b_4b44_af26_74c082559170" layout:id="_796423e1_1146_4b81_8793_923c84632946" layout:originOfText="extracellular">
+          <layout:textGlyph layout:graphicalObject="_6bee86a4_ee78_488c_9a2a_ad8f4f7c9195" layout:id="ec4fb70e_2f4d_49c7_8483_ed3f88eb636c" layout:originOfText="extracellular">
             <layout:boundingBox>
               <layout:position layout:x="395" layout:y="261.66666666666663" layout:z="-2"/>
               <layout:dimensions layout:depth="1" layout:height="122.13106741667367" layout:width="176.80753550602049"/>
             </layout:boundingBox>
           </layout:textGlyph>
-          <layout:textGlyph layout:graphicalObject="_10a4c427_0db0_4b50_885b_61e256a5da58" layout:id="_70fa5f7c_e000_4103_94e0_de89999e6090" layout:originOfText="cytosol">
+          <layout:textGlyph layout:graphicalObject="_941e5043_8eda_464d_9fd9_4a49dd1fe7d7" layout:id="_06dfbafc_c04a_4aa2_868c_91c480b63427" layout:originOfText="cytosol">
             <layout:boundingBox>
               <layout:position layout:x="316.6286330276703" layout:y="436.20226591665966" layout:z="-3"/>
               <layout:dimensions layout:depth="1" layout:height="122.13106741667367" layout:width="255.1789024783502"/>
             </layout:boundingBox>
           </layout:textGlyph>
-          <layout:textGlyph layout:graphicalObject="_44634e92_9ba8_4b4b_86a8_b866ab4ca27e" layout:id="_6a6c8edb_af57_49db_bdf3_bbbed160b41a" layout:originOfText="vesicle">
+          <layout:textGlyph layout:graphicalObject="_02bdf2cc_18ca_475f_99cf_d6f11d38d716" layout:id="_23805b59_30d8_44df_a1b3_0d9bed9846e3" layout:originOfText="vesicle">
             <layout:boundingBox>
               <layout:position layout:x="268.1924644939795" layout:y="353.79773408334034" layout:z="-1"/>
               <layout:dimensions layout:depth="1" layout:height="112.40453183331931" layout:width="50.000000000000014"/>
             </layout:boundingBox>
           </layout:textGlyph>
-          <layout:textGlyph layout:graphicalObject="A_glyph_" layout:id="_02314a81_0917_479e_9b60_ce8d03e3f70c" layout:originOfText="A">
+          <layout:textGlyph layout:graphicalObject="A_glyph_" layout:id="_3675e7a5_e6df_4cf6_879f_8d079c6123a6" layout:originOfText="A">
             <layout:boundingBox>
               <layout:position layout:x="400" layout:y="266.66666666666663" layout:z="0"/>
               <layout:dimensions layout:depth="1" layout:height="20" layout:width="40"/>
             </layout:boundingBox>
           </layout:textGlyph>
-          <layout:textGlyph layout:graphicalObject="B_glyph_" layout:id="ce87d64c_f1bb_4269_8700_9c84955bd7d3" layout:originOfText="B">
+          <layout:textGlyph layout:graphicalObject="B_glyph_" layout:id="_77a70260_e63f_4be8_bc73_893cdae6c2bf" layout:originOfText="B">
             <layout:boundingBox>
               <layout:position layout:x="478.3713669723297" layout:y="292.13106741667366" layout:z="0"/>
               <layout:dimensions layout:depth="1" layout:height="20" layout:width="40"/>
             </layout:boundingBox>
           </layout:textGlyph>
-          <layout:textGlyph layout:graphicalObject="C_glyph_" layout:id="_4b6232d3_bdc1_4e13_9453_d56f041c0995" layout:originOfText="C">
+          <layout:textGlyph layout:graphicalObject="C_glyph_" layout:id="_9f87243a_c08a_48ae_b06c_83e1c0dbf3e6" layout:originOfText="C">
             <layout:boundingBox>
               <layout:position layout:x="526.8075355060205" layout:y="358.79773408334034" layout:z="0"/>
               <layout:dimensions layout:depth="1" layout:height="20" layout:width="40"/>
             </layout:boundingBox>
           </layout:textGlyph>
-          <layout:textGlyph layout:graphicalObject="D_glyph_" layout:id="f420a3ec_3ea9_4f26_bfd7_692df42ec56f" layout:originOfText="D">
+          <layout:textGlyph layout:graphicalObject="D_glyph_" layout:id="ff8ab5b6_5cee_46bd_9aa7_145e019aa3af" layout:originOfText="D">
             <layout:boundingBox>
               <layout:position layout:x="526.8075355060205" layout:y="441.20226591665966" layout:z="0"/>
               <layout:dimensions layout:depth="1" layout:height="20" layout:width="40"/>
             </layout:boundingBox>
           </layout:textGlyph>
-          <layout:textGlyph layout:graphicalObject="E_glyph_" layout:id="_2ea3e9a6_6019_4ab2_87fe_84fa40b8107a" layout:originOfText="E">
+          <layout:textGlyph layout:graphicalObject="E_glyph_" layout:id="c6850277_a64c_42c0_a5bb_f5e430307773" layout:originOfText="E">
             <layout:boundingBox>
               <layout:position layout:x="478.3713669723297" layout:y="507.86893258332634" layout:z="0"/>
               <layout:dimensions layout:depth="1" layout:height="20" layout:width="40"/>
             </layout:boundingBox>
           </layout:textGlyph>
-          <layout:textGlyph layout:graphicalObject="F_glyph_" layout:id="e6fda986_2962_43d5_9d30_b913e7c45641" layout:originOfText="F">
+          <layout:textGlyph layout:graphicalObject="F_glyph_" layout:id="_05cfd41e_a999_484a_8a63_467990d19d5f" layout:originOfText="F">
             <layout:boundingBox>
               <layout:position layout:x="400" layout:y="533.3333333333334" layout:z="0"/>
               <layout:dimensions layout:depth="1" layout:height="20" layout:width="40"/>
             </layout:boundingBox>
           </layout:textGlyph>
-          <layout:textGlyph layout:graphicalObject="G_glyph_" layout:id="_44ac3580_3e29_446a_9940_43adc5a04e00" layout:originOfText="G">
+          <layout:textGlyph layout:graphicalObject="G_glyph_" layout:id="f2a4f624_bf6f_48cd_8f9e_1624370b5a9a" layout:originOfText="G">
             <layout:boundingBox>
               <layout:position layout:x="321.6286330276703" layout:y="507.86893258332634" layout:z="0"/>
               <layout:dimensions layout:depth="1" layout:height="20" layout:width="40"/>
             </layout:boundingBox>
           </layout:textGlyph>
-          <layout:textGlyph layout:graphicalObject="H_glyph_" layout:id="_4f1e0a62_3293_47ab_b52b_bf9aed2d6baa" layout:originOfText="H">
+          <layout:textGlyph layout:graphicalObject="H_glyph_" layout:id="_189cc1d5_14dd_4a35_91ad_ee6049031609" layout:originOfText="H">
             <layout:boundingBox>
               <layout:position layout:x="273.1924644939795" layout:y="441.20226591665966" layout:z="0"/>
               <layout:dimensions layout:depth="1" layout:height="20" layout:width="40"/>
             </layout:boundingBox>
           </layout:textGlyph>
-          <layout:textGlyph layout:graphicalObject="I_glyph_" layout:id="e04b2718_4e0d_4710_aaf5_389bd840a832" layout:originOfText="I">
+          <layout:textGlyph layout:graphicalObject="I_glyph_" layout:id="be5e4f11_2d87_4301_a13f_c7f6b5eba892" layout:originOfText="I">
             <layout:boundingBox>
               <layout:position layout:x="273.1924644939795" layout:y="358.79773408334034" layout:z="0"/>
               <layout:dimensions layout:depth="1" layout:height="20" layout:width="40"/>

--- a/extensions/render/test/org/sbml/jsbml/ext/render/validator/test/data/invalid.xml
+++ b/extensions/render/test/org/sbml/jsbml/ext/render/validator/test/data/invalid.xml
@@ -1,0 +1,813 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created by Render-example version 1 on 2020-03-13 at 09:52:23 MEZ with JSBML version 1.5-SNAPSHOT. -->
+<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" layout:required="false" level="3" render:required="false" version="1" xmlns:layout="http://www.sbml.org/sbml/level3/version1/layout/version1" xmlns:render="http://www.sbml.org/sbml/level3/version1/render/version1">
+  <model id="Ring" timeUnits="time">
+    <layout:listOfLayouts xmlns:layout="http://www.sbml.org/sbml/level3/version1/layout/version1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <layout:layout layout:id="_350d07b1_2736_4748_9871_bc244b7b2000" layout:name="auto_layout">
+        <render:listOfRenderInformation xmlns:render="http://www.sbml.org/sbml/level3/version1/render/version1">
+          <render:renderInformation render:id="_350d07b1_2736_4748_9871_bc244b7b2000_render">
+            <render:listOfColorDefinitions>
+              <render:colorDefinition render:id="red" render:value="#FF0000FF"/>
+              <render:colorDefinition render:id="black" render:value="#000000FF"/>
+              <render:colorDefinition render:id="white" render:value="#FFFFFFFF"/>
+              <render:colorDefinition render:id="compartmentFill" render:value="#F3F3BFFF"/>
+              <render:colorDefinition render:id="compartmentStroke" render:value="#CCCC00FF"/>
+              <render:colorDefinition render:id="geneFill" render:value="#FFFF00FF"/>
+              <render:colorDefinition render:id="macromoleculeFill" render:value="#00CD00FF"/>
+              <render:colorDefinition render:id="simpleChemicalFill" render:value="#B0E2FFFF"/>
+              <render:colorDefinition render:id="sourceSinkFill" render:value="#FFCCCCFF"/>
+              <render:colorDefinition render:id="perturbingAgentFill" render:value="#FF00FFFF"/>
+            </render:listOfColorDefinitions>
+            <render:listOfLineEndings>
+              <render:lineEnding render:enable-rotation-mapping="true" render:id="productionHead">
+                <layout:boundingBox>
+                  <layout:position layout:x="-4.800000000000001" layout:y="-3" layout:z="0"/>
+                  <layout:dimensions layout:depth="0" layout:height="6" layout:width="5.4"/>
+                </layout:boundingBox>
+                <render:g>
+                  <render:polygon render:fill="black" render:stroke="black" render:stroke-width="0.3">
+                    <render:listOfElements>
+                      <render:element render:x="0" render:y="0" xsi:type="RenderPoint"/>
+                      <render:element render:x="5.4" render:y="3.0" xsi:type="RenderPoint"/>
+                      <render:element render:x="0" render:y="6.0" xsi:type="RenderPoint"/>
+                    </render:listOfElements>
+                  </render:polygon>
+                </render:g>
+              </render:lineEnding>
+              <render:lineEnding render:enable-rotation-mapping="true" render:id="stimulationHead">
+                <layout:boundingBox>
+                  <layout:position layout:x="-4.800000000000001" layout:y="-3" layout:z="0"/>
+                  <layout:dimensions layout:depth="0" layout:height="6" layout:width="5.4"/>
+                </layout:boundingBox>
+                <render:g>
+                  <render:polygon render:fill="white" render:stroke="black" render:stroke-width="0.3">
+                    <render:listOfElements>
+                      <render:element render:x="0" render:y="0" xsi:type="RenderPoint"/>
+                      <render:element render:x="5.4" render:y="3.0" xsi:type="RenderPoint"/>
+                      <render:element render:x="0" render:y="6.0" xsi:type="RenderPoint"/>
+                    </render:listOfElements>
+                  </render:polygon>
+                </render:g>
+              </render:lineEnding>
+              <render:lineEnding render:enable-rotation-mapping="true" render:id="catalysisHead">
+                <layout:boundingBox>
+                  <layout:position layout:x="-5.4" layout:y="-3" layout:z="0"/>
+                  <layout:dimensions layout:depth="0" layout:height="6" layout:width="6"/>
+                </layout:boundingBox>
+                <render:g>
+                  <render:ellipse render:cx="3.5999999999999996" render:cy="3.0" render:fill="white" render:rx="3.0" render:stroke="black" render:stroke-width="0.3"/>
+                </render:g>
+              </render:lineEnding>
+              <render:lineEnding render:enable-rotation-mapping="true" render:id="inhibitionHead">
+                <layout:boundingBox>
+                  <layout:position layout:x="-0.6000000000000001" layout:y="-3" layout:z="0"/>
+                  <layout:dimensions layout:depth="0" layout:height="6" layout:width="1.2000000000000002"/>
+                </layout:boundingBox>
+                <render:g>
+                  <render:polygon render:fill="white" render:stroke="black" render:stroke-width="0.3">
+                    <render:listOfElements>
+                      <render:element render:x="0.6000000000000001" render:y="0" xsi:type="RenderPoint"/>
+                      <render:element render:x="0.6000000000000001" render:y="6.0" xsi:type="RenderPoint"/>
+                    </render:listOfElements>
+                  </render:polygon>
+                </render:g>
+              </render:lineEnding>
+              <render:lineEnding render:enable-rotation-mapping="true" render:id="necessaryStimulationHead">
+                <layout:boundingBox>
+                  <layout:position layout:x="-7.199999999999999" layout:y="-3" layout:z="0"/>
+                  <layout:dimensions layout:depth="0" layout:height="6" layout:width="7.800000000000001"/>
+                </layout:boundingBox>
+                <render:g>
+                  <render:polygon render:fill="white" render:stroke="black" render:stroke-width="0.3">
+                    <render:listOfElements>
+                      <render:element render:x="0.6000000000000001" render:y="0" xsi:type="RenderPoint"/>
+                      <render:element render:x="0.6000000000000001" render:y="6.0" xsi:type="RenderPoint"/>
+                    </render:listOfElements>
+                  </render:polygon>
+                  <render:polygon render:fill="white" render:stroke="black" render:stroke-width="0.3">
+                    <render:listOfElements>
+                      <render:element render:x="2.4000000000000004" render:y="0" xsi:type="RenderPoint"/>
+                      <render:element render:x="7.800000000000001" render:y="3.0" xsi:type="RenderPoint"/>
+                      <render:element render:x="2.4000000000000004" render:y="6.0" xsi:type="RenderPoint"/>
+                    </render:listOfElements>
+                  </render:polygon>
+                </render:g>
+              </render:lineEnding>
+              <render:lineEnding render:enable-rotation-mapping="true" render:id="modulationHead">
+                <layout:boundingBox>
+                  <layout:position layout:x="-5.4" layout:y="-3" layout:z="0"/>
+                  <layout:dimensions layout:depth="0" layout:height="6" layout:width="6"/>
+                </layout:boundingBox>
+                <render:g>
+                  <render:polygon render:fill="white" render:stroke="black" render:stroke-width="0.3">
+                    <render:listOfElements>
+                      <render:element render:x="0" render:y="3.0" xsi:type="RenderPoint"/>
+                      <render:element render:x="3.0" render:y="0" xsi:type="RenderPoint"/>
+                      <render:element render:x="6.0" render:y="3.0" xsi:type="RenderPoint"/>
+                      <render:element render:x="3.0" render:y="6.0" xsi:type="RenderPoint"/>
+                    </render:listOfElements>
+                  </render:polygon>
+                </render:g>
+              </render:lineEnding>
+            </render:listOfLineEndings>
+            <render:listOfStyles>
+              <render:style id="consumptionStyle" render:idList="A_glyph__1 B_glyph__1 A_glyph__2 C_glyph__2 D_glyph__2 F_glyph__2">
+                <render:g render:stroke="black" render:stroke-width="1.0"/>
+              </render:style>
+              <render:style id="productionStyle" render:idList="C_glyph__1 F_glyph__1 B_glyph__2 G_glyph__1 H_glyph__1 H_glyph__2 I_glyph__1 empty_glyph__1">
+                <render:g render:endHead="productionHead" render:stroke="black" render:stroke-width="1.0"/>
+              </render:style>
+              <render:style id="reversibleConsumptionStyle" render:idList="G_glyph__3">
+                <render:g render:endHead="productionHead" render:stroke="black" render:stroke-width="1.0"/>
+              </render:style>
+              <render:style id="stimulationStyle" render:idList="">
+                <render:g render:endHead="stimulationHead" render:stroke="black" render:stroke-width="1.0"/>
+              </render:style>
+              <render:style id="catalysisStyle" render:idList="">
+                <render:g render:endHead="catalysisHead" render:stroke="black" render:stroke-width="1.0"/>
+              </render:style>
+              <render:style id="inhibitionStyle" render:idList="">
+                <render:g render:endHead="inhibitionHead" render:stroke="black" render:stroke-width="1.0"/>
+              </render:style>
+              <render:style id="necessaryStimulationStyle" render:idList="">
+                <render:g render:endHead="necessaryStimulationHead" render:stroke="black" render:stroke-width="1.0"/>
+              </render:style>
+              <render:style id="modulationStyle" render:idList="D_glyph__1 G_glyph__2">
+                <render:g render:endHead="modulationHead" render:stroke="black" render:stroke-width="1.0"/>
+              </render:style>
+              <render:style id="TextGylphStyle" render:typeList="TEXTGLYPH">
+                <render:g render:font-family="monospace" render:font-size="10" render:text-anchor="middle" render:vtext-anchor="middle"/>
+              </render:style>
+              <render:style id="styleOf__92316df2_d22b_4b44_af26_74c082559170" render:idList="_92316df2_d22b_4b44_af26_74c082559170">
+                <render:g>
+                  <render:rectangle render:fill="compartmentFill" render:height="122.13106741667367" render:stroke="compartmentStroke" render:stroke-width="0.3" render:width="176.80753550602049" render:x="0" render:y="0"/>
+                </render:g>
+              </render:style>
+              <render:style id="styleOf__10a4c427_0db0_4b50_885b_61e256a5da58" render:idList="_10a4c427_0db0_4b50_885b_61e256a5da58">
+                <render:g>
+                  <render:rectangle render:fill="compartmentFill" render:height="122.13106741667367" render:stroke="compartmentStroke" render:stroke-width="0.3" render:width="255.1789024783502" render:x="0" render:y="0"/>
+                </render:g>
+              </render:style>
+              <render:style id="styleOf__44634e92_9ba8_4b4b_86a8_b866ab4ca27e" render:idList="_44634e92_9ba8_4b4b_86a8_b866ab4ca27e">
+                <render:g>
+                  <render:rectangle render:fill="compartmentFill" render:height="112.40453183331931" render:stroke="compartmentStroke" render:stroke-width="0.3" render:width="50.000000000000014" render:x="0" render:y="0"/>
+                </render:g>
+              </render:style>
+              <render:style id="styleOf_A_glyph_" render:idList="A_glyph_">
+                <render:g>
+                  <render:rectangle render:fill="macromoleculeFill" render:height="20.0" render:rx="4.0" render:stroke="black" render:stroke-width="0.0" render:width="40.0" render:x="0" render:y="0"/>
+                  <render:rectangle render:height="20.0" render:rx="4.0" render:stroke="black" render:stroke-width="1.0" render:width="40.0" render:x="0" render:y="0"/>
+                </render:g>
+              </render:style>
+              <render:style id="styleOf_B_glyph_" render:idList="B_glyph_">
+                <render:g>
+                  <render:ellipse render:cx="+50.0%" render:cy="+50.0%" render:fill="simpleChemicalFill" render:rx="10.0" render:stroke="black" render:stroke-width="0.0"/>
+                  <render:ellipse render:cx="+50.0%" render:cy="+50.0%" render:rx="10.0" render:stroke="black" render:stroke-width="1.0"/>
+                </render:g>
+              </render:style>
+              <render:style id="styleOf_C_glyph_" render:idList="C_glyph_">
+                <render:g>
+                  <render:ellipse render:cx="+50.0%" render:cy="+50.0%" render:fill="simpleChemicalFill" render:rx="10.0" render:stroke="black" render:stroke-width="0.0"/>
+                  <render:ellipse render:cx="+50.0%" render:cy="+50.0%" render:rx="10.0" render:stroke="black" render:stroke-width="1.0"/>
+                </render:g>
+              </render:style>
+              <render:style id="styleOf_D_glyph_" render:idList="D_glyph_">
+                <render:g>
+                  <render:rectangle render:fill="macromoleculeFill" render:height="20.0" render:rx="4.0" render:stroke="black" render:stroke-width="0.0" render:width="40.0" render:x="0" render:y="0"/>
+                  <render:rectangle render:height="20.0" render:rx="4.0" render:stroke="black" render:stroke-width="1.0" render:width="40.0" render:x="0" render:y="0"/>
+                </render:g>
+              </render:style>
+              <render:style id="styleOf_E_glyph_" render:idList="E_glyph_">
+                <render:g>
+                  <render:ellipse render:cx="+50.0%" render:cy="+50.0%" render:fill="simpleChemicalFill" render:rx="10.0" render:stroke="black" render:stroke-width="0.0"/>
+                  <render:ellipse render:cx="+50.0%" render:cy="+50.0%" render:rx="10.0" render:stroke="black" render:stroke-width="1.0"/>
+                </render:g>
+              </render:style>
+              <render:style id="styleOf_F_glyph_" render:idList="F_glyph_">
+                <render:g>
+                  <render:ellipse render:cx="+50.0%" render:cy="+50.0%" render:fill="simpleChemicalFill" render:rx="10.0" render:stroke="black" render:stroke-width="0.0"/>
+                  <render:ellipse render:cx="+50.0%" render:cy="+50.0%" render:rx="10.0" render:stroke="black" render:stroke-width="1.0"/>
+                </render:g>
+              </render:style>
+              <render:style id="styleOf_G_glyph_" render:idList="G_glyph_">
+                <render:g>
+                  <render:rectangle render:fill="macromoleculeFill" render:height="20.0" render:rx="4.0" render:stroke="black" render:stroke-width="0.0" render:width="40.0" render:x="0" render:y="0"/>
+                  <render:rectangle render:height="20.0" render:rx="4.0" render:stroke="black" render:stroke-width="1.0" render:width="40.0" render:x="0" render:y="0"/>
+                </render:g>
+              </render:style>
+              <render:style id="styleOf_H_glyph_" render:idList="H_glyph_">
+                <render:g>
+                  <render:ellipse render:cx="+50.0%" render:cy="+50.0%" render:fill="simpleChemicalFill" render:rx="10.0" render:stroke="black" render:stroke-width="0.0"/>
+                  <render:ellipse render:cx="+50.0%" render:cy="+50.0%" render:rx="10.0" render:stroke="black" render:stroke-width="1.0"/>
+                </render:g>
+              </render:style>
+              <render:style id="styleOf_I_glyph_" render:idList="I_glyph_">
+                <render:g>
+                  <render:ellipse render:cx="+50.0%" render:cy="+50.0%" render:fill="simpleChemicalFill" render:rx="10.0" render:stroke="black" render:stroke-width="0.0"/>
+                  <render:ellipse render:cx="+50.0%" render:cy="+50.0%" render:rx="10.0" render:stroke="black" render:stroke-width="1.0"/>
+                </render:g>
+              </render:style>
+              <render:style id="styleOf_empty_glyph_" render:idList="empty_glyph_">
+                <render:g>
+                  <render:ellipse render:cx="20.0" render:cy="10.0" render:fill="sourceSinkFill" render:rx="9.0" render:stroke="black" render:stroke-width="1.0"/>
+                  <render:polygon render:fill="sourceSinkFill" render:stroke="black" render:stroke-width="1.0">
+                    <render:listOfElements>
+                      <render:element render:x="30.0" render:y="0" xsi:type="RenderPoint"/>
+                      <render:element render:x="10.0" render:y="20.0" xsi:type="RenderPoint"/>
+                    </render:listOfElements>
+                  </render:polygon>
+                </render:g>
+              </render:style>
+              <render:style render:idList="_4641e4aa_2fb4_47d5_beef_f7865441ba9a">
+                <render:g render:stroke="black" render:stroke-width="1.0">
+                  <render:polygon render:fill="white">
+                    <render:listOfElements>
+                      <render:element render:x="4.405948968185809" render:y="-2.0460700657600963" xsi:type="RenderPoint"/>
+                      <render:element render:x="-2.0460700657600963" render:y="5.594051031814191" xsi:type="RenderPoint"/>
+                      <render:element render:x="5.594051031814191" render:y="12.046070065760096" xsi:type="RenderPoint"/>
+                      <render:element render:x="12.046070065760096" render:y="4.405948968185809" xsi:type="RenderPoint"/>
+                    </render:listOfElements>
+                  </render:polygon>
+                </render:g>
+              </render:style>
+              <render:style render:idList="_4037dff4_c70e_4431_a53b_75813a602854">
+                <render:g render:stroke="black" render:stroke-width="1.0">
+                  <render:polygon render:fill="white">
+                    <render:listOfElements>
+                      <render:element render:x="9.822437830038234" render:y="-0.17146916991836392" xsi:type="RenderPoint"/>
+                      <render:element render:x="-0.17146916991836392" render:y="0.17756216996176555" xsi:type="RenderPoint"/>
+                      <render:element render:x="0.17756216996176555" render:y="10.171469169918364" xsi:type="RenderPoint"/>
+                      <render:element render:x="10.171469169918364" render:y="9.822437830038234" xsi:type="RenderPoint"/>
+                    </render:listOfElements>
+                  </render:polygon>
+                </render:g>
+              </render:style>
+              <render:style render:idList="_2ba86b91_45fb_49ab_8a5c_0be0a09db021">
+                <render:g render:stroke="black" render:stroke-width="1.0">
+                  <render:polygon render:fill="white">
+                    <render:listOfElements>
+                      <render:element render:x="10.465565065670862" render:y="9.486379220810282" xsi:type="RenderPoint"/>
+                      <render:element render:x="9.486379220810282" render:y="-0.4655650656708632" xsi:type="RenderPoint"/>
+                      <render:element render:x="-0.4655650656708632" render:y="0.5136207791897194" xsi:type="RenderPoint"/>
+                      <render:element render:x="0.5136207791897194" render:y="10.465565065670862" xsi:type="RenderPoint"/>
+                    </render:listOfElements>
+                  </render:polygon>
+                </render:g>
+              </render:style>
+              <render:style render:idList="_98713161_2be6_4f31_ae59_25511e2b2fd6">
+                <render:g render:stroke="black" render:stroke-width="1.0">
+                  <render:polygon render:fill="white">
+                    <render:listOfElements>
+                      <render:element render:x="4.762638678090282" render:y="12.06708282128215" xsi:type="RenderPoint"/>
+                      <render:element render:x="12.06708282128215" render:y="5.237361321909718" xsi:type="RenderPoint"/>
+                      <render:element render:x="5.237361321909718" render:y="-2.067082821282151" xsi:type="RenderPoint"/>
+                      <render:element render:x="-2.067082821282151" render:y="4.762638678090282" xsi:type="RenderPoint"/>
+                    </render:listOfElements>
+                  </render:polygon>
+                </render:g>
+              </render:style>
+              <render:style render:idList="c63e47e3_86a3_446e_9440_e434c85ad7d3">
+                <render:g render:stroke="black" render:stroke-width="1.0">
+                  <render:polygon render:fill="white">
+                    <render:listOfElements>
+                      <render:element render:x="0.1251959686089288" render:y="10.12213682514762" xsi:type="RenderPoint"/>
+                      <render:element render:x="10.12213682514762" render:y="9.874804031391072" xsi:type="RenderPoint"/>
+                      <render:element render:x="9.874804031391072" render:y="-0.12213682514762159" xsi:type="RenderPoint"/>
+                      <render:element render:x="-0.12213682514762159" render:y="0.1251959686089288" xsi:type="RenderPoint"/>
+                    </render:listOfElements>
+                  </render:polygon>
+                </render:g>
+              </render:style>
+            </render:listOfStyles>
+          </render:renderInformation>
+        </render:listOfRenderInformation>
+        <layout:dimensions layout:depth="100" layout:height="800" layout:width="800"/>
+        <layout:listOfCompartmentGlyphs>
+          <layout:compartmentGlyph layout:compartment="extracellular" layout:id="_92316df2_d22b_4b44_af26_74c082559170">
+            <layout:boundingBox>
+              <layout:position layout:x="395" layout:y="261.66666666666663" layout:z="-2"/>
+              <layout:dimensions layout:depth="1" layout:height="122.13106741667367" layout:width="176.80753550602049"/>
+            </layout:boundingBox>
+          </layout:compartmentGlyph>
+          <layout:compartmentGlyph layout:compartment="cytosol" layout:id="_10a4c427_0db0_4b50_885b_61e256a5da58">
+            <layout:boundingBox>
+              <layout:position layout:x="316.6286330276703" layout:y="436.20226591665966" layout:z="-3"/>
+              <layout:dimensions layout:depth="1" layout:height="122.13106741667367" layout:width="255.1789024783502"/>
+            </layout:boundingBox>
+          </layout:compartmentGlyph>
+          <layout:compartmentGlyph layout:compartment="vesicle" layout:id="_44634e92_9ba8_4b4b_86a8_b866ab4ca27e">
+            <layout:boundingBox>
+              <layout:position layout:x="268.1924644939795" layout:y="353.79773408334034" layout:z="-1"/>
+              <layout:dimensions layout:depth="1" layout:height="112.40453183331931" layout:width="50.000000000000014"/>
+            </layout:boundingBox>
+          </layout:compartmentGlyph>
+        </layout:listOfCompartmentGlyphs>
+        <layout:listOfSpeciesGlyphs>
+          <layout:speciesGlyph layout:id="A_glyph_" layout:species="A" sboTerm="SBO:0000245">
+            <layout:boundingBox>
+              <layout:position layout:x="400" layout:y="266.66666666666663" layout:z="0"/>
+              <layout:dimensions layout:depth="1" layout:height="20" layout:width="40"/>
+            </layout:boundingBox>
+          </layout:speciesGlyph>
+          <layout:speciesGlyph layout:id="B_glyph_" layout:species="B" sboTerm="SBO:0000247">
+            <layout:boundingBox>
+              <layout:position layout:x="478.3713669723297" layout:y="292.13106741667366" layout:z="0"/>
+              <layout:dimensions layout:depth="1" layout:height="20" layout:width="40"/>
+            </layout:boundingBox>
+          </layout:speciesGlyph>
+          <layout:speciesGlyph layout:id="C_glyph_" layout:species="C" sboTerm="SBO:0000247">
+            <layout:boundingBox>
+              <layout:position layout:x="526.8075355060205" layout:y="358.79773408334034" layout:z="0"/>
+              <layout:dimensions layout:depth="1" layout:height="20" layout:width="40"/>
+            </layout:boundingBox>
+          </layout:speciesGlyph>
+          <layout:speciesGlyph layout:id="D_glyph_" layout:species="D" sboTerm="SBO:0000245">
+            <layout:boundingBox>
+              <layout:position layout:x="526.8075355060205" layout:y="441.20226591665966" layout:z="0"/>
+              <layout:dimensions layout:depth="1" layout:height="20" layout:width="40"/>
+            </layout:boundingBox>
+          </layout:speciesGlyph>
+          <layout:speciesGlyph layout:id="E_glyph_" layout:species="E" sboTerm="SBO:0000247">
+            <layout:boundingBox>
+              <layout:position layout:x="478.3713669723297" layout:y="507.86893258332634" layout:z="0"/>
+              <layout:dimensions layout:depth="1" layout:height="20" layout:width="40"/>
+            </layout:boundingBox>
+          </layout:speciesGlyph>
+          <layout:speciesGlyph layout:id="F_glyph_" layout:species="F" sboTerm="SBO:0000247">
+            <layout:boundingBox>
+              <layout:position layout:x="400" layout:y="533.3333333333334" layout:z="0"/>
+              <layout:dimensions layout:depth="1" layout:height="20" layout:width="40"/>
+            </layout:boundingBox>
+          </layout:speciesGlyph>
+          <layout:speciesGlyph layout:id="G_glyph_" layout:species="G" sboTerm="SBO:0000245">
+            <layout:boundingBox>
+              <layout:position layout:x="321.6286330276703" layout:y="507.86893258332634" layout:z="0"/>
+              <layout:dimensions layout:depth="1" layout:height="20" layout:width="40"/>
+            </layout:boundingBox>
+          </layout:speciesGlyph>
+          <layout:speciesGlyph layout:id="H_glyph_" layout:species="H" sboTerm="SBO:0000247">
+            <layout:boundingBox>
+              <layout:position layout:x="273.1924644939795" layout:y="441.20226591665966" layout:z="0"/>
+              <layout:dimensions layout:depth="1" layout:height="20" layout:width="40"/>
+            </layout:boundingBox>
+          </layout:speciesGlyph>
+          <layout:speciesGlyph layout:id="I_glyph_" layout:species="I" sboTerm="SBO:0000247">
+            <layout:boundingBox>
+              <layout:position layout:x="273.1924644939795" layout:y="358.79773408334034" layout:z="0"/>
+              <layout:dimensions layout:depth="1" layout:height="20" layout:width="40"/>
+            </layout:boundingBox>
+          </layout:speciesGlyph>
+          <layout:speciesGlyph layout:id="empty_glyph_" sboTerm="SBO:0000291">
+            <layout:boundingBox>
+              <layout:position layout:x="321.6286330276702" layout:y="292.13106741667366" layout:z="0"/>
+              <layout:dimensions layout:depth="1" layout:height="20" layout:width="40"/>
+            </layout:boundingBox>
+          </layout:speciesGlyph>
+        </layout:listOfSpeciesGlyphs>
+        <layout:listOfReactionGlyphs>
+          <layout:reactionGlyph layout:id="_4641e4aa_2fb4_47d5_beef_f7865441ba9a" layout:reaction="R1">
+            <layout:boundingBox>
+              <layout:position layout:x="474.4360806896183" layout:y="317.24245248926627" layout:z="0"/>
+              <layout:dimensions layout:depth="0" layout:height="10" layout:width="10"/>
+            </layout:boundingBox>
+            <layout:curve>
+              <layout:listOfCurveSegments>
+                <layout:curveSegment xsi:type="LineSegment">
+                  <layout:start layout:x="471.79595959204397" layout:y="315.79043345532034" layout:z="0.5"/>
+                  <layout:end layout:x="487.07620178719253" layout:y="328.69447152321214" layout:z="0.5"/>
+                </layout:curveSegment>
+              </layout:listOfCurveSegments>
+            </layout:curve>
+            <layout:listOfSpeciesReferenceGlyphs>
+              <layout:speciesReferenceGlyph layout:id="C_glyph__1" layout:role="product" layout:speciesGlyph="C_glyph_">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="CubicBezier">
+                      <layout:start layout:x="487.07620178719253" layout:y="328.69447152321214" layout:z="0.5"/>
+                      <layout:end layout:x="538.5806736487035" layout:y="363.1127763895116" layout:z="0.5"/>
+                      <layout:basePoint1 layout:x="497.00835921403905" layout:y="337.0820962673417" layout:z="0.7166666666666666"/>
+                      <layout:basePoint2 layout:x="527.8857532341913" layout:y="355.72233138753427" layout:z="0.4999999999999999"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+              <layout:speciesReferenceGlyph layout:id="A_glyph__1" layout:role="substrate" layout:speciesGlyph="A_glyph_">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="CubicBezier">
+                      <layout:start layout:x="471.79595959204397" layout:y="315.79043345532034" layout:z="0.5"/>
+                      <layout:end layout:x="430" layout:y="286.66666666666663" layout:z="0"/>
+                      <layout:basePoint1 layout:x="461.8638021651973" layout:y="307.4028087111905" layout:z="0.7166666666666666"/>
+                      <layout:basePoint2 layout:x="442.9999999999999" layout:y="299.6666666666665" layout:z="-0.65"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+              <layout:speciesReferenceGlyph layout:id="B_glyph__1" layout:role="substrate" layout:speciesGlyph="B_glyph_">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="CubicBezier">
+                      <layout:start layout:x="471.79595959204397" layout:y="315.79043345532034" layout:z="0.5"/>
+                      <layout:end layout:x="491.5163909165192" layout:y="309.41181622941707" layout:z="0.5"/>
+                      <layout:basePoint1 layout:x="470.251426909327" layout:y="297.470651284344" layout:z="0.2833333333333332"/>
+                      <layout:basePoint2 layout:x="482.6049220439654" layout:y="318.8767896859834" layout:z="0.4999999999999999"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+            </layout:listOfSpeciesReferenceGlyphs>
+          </layout:reactionGlyph>
+          <layout:reactionGlyph layout:id="_4037dff4_c70e_4431_a53b_75813a602854" layout:reaction="R2">
+            <layout:boundingBox>
+              <layout:position layout:x="450.14185839563527" layout:y="415.43273898766824" layout:z="0"/>
+              <layout:dimensions layout:depth="0" layout:height="10" layout:width="10"/>
+            </layout:boundingBox>
+            <layout:curve>
+              <layout:listOfCurveSegments>
+                <layout:curveSegment xsi:type="LineSegment">
+                  <layout:start layout:x="454.79282705575514" layout:y="410.43883198771164" layout:z="0"/>
+                  <layout:end layout:x="455.4908897355154" layout:y="430.4266459876248" layout:z="0.5"/>
+                </layout:curveSegment>
+              </layout:listOfCurveSegments>
+            </layout:curve>
+            <layout:listOfSpeciesReferenceGlyphs>
+              <layout:speciesReferenceGlyph layout:id="D_glyph__1" layout:role="modifier" layout:speciesGlyph="D_glyph_">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="CubicBezier">
+                      <layout:start layout:x="536.8075355060205" layout:y="441.20226591665966" layout:z="0"/>
+                      <layout:end layout:x="465.1357653955919" layout:y="420.0837076477881" layout:z="0"/>
+                      <layout:basePoint1 layout:x="523.8075355060205" layout:y="428.2022659166596" layout:z="-0.65"/>
+                      <layout:basePoint2 layout:x="491.1199235954791" layout:y="419.1762261640997" layout:z="-0.43333333333333335"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+              <layout:speciesReferenceGlyph layout:id="F_glyph__1" layout:role="product" layout:speciesGlyph="F_glyph_">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="CubicBezier">
+                      <layout:start layout:x="455.4908897355154" layout:y="430.4266459876248" layout:z="0.5"/>
+                      <layout:end layout:x="422.7491931892069" layout:y="533.7186603379363" layout:z="0.5"/>
+                      <layout:basePoint1 layout:x="455.9446304773594" layout:y="443.4187250875682" layout:z="0.9333333333333332"/>
+                      <layout:basePoint2 layout:x="426.3231443351758" layout:y="521.21958544392" layout:z="0.4999999999999999"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+              <layout:speciesReferenceGlyph layout:id="A_glyph__2" layout:role="substrate" layout:speciesGlyph="A_glyph_">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="CubicBezier">
+                      <layout:start layout:x="454.79282705575514" layout:y="410.43883198771164" layout:z="0"/>
+                      <layout:end layout:x="430" layout:y="286.66666666666663" layout:z="0"/>
+                      <layout:basePoint1 layout:x="454.3390863139109" layout:y="397.44675288776796" layout:z="-0.21666666666666667"/>
+                      <layout:basePoint2 layout:x="442.9999999999999" layout:y="299.6666666666665" layout:z="-0.65"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+            </layout:listOfSpeciesReferenceGlyphs>
+          </layout:reactionGlyph>
+          <layout:reactionGlyph layout:id="_2ba86b91_45fb_49ab_8a5c_0be0a09db021" layout:reaction="R3">
+            <layout:boundingBox>
+              <layout:position layout:x="438.7908513947403" layout:y="410.20226585616547" layout:z="0"/>
+              <layout:dimensions layout:depth="0" layout:height="10" layout:width="10"/>
+            </layout:boundingBox>
+            <layout:curve>
+              <layout:listOfCurveSegments>
+                <layout:curveSegment xsi:type="LineSegment">
+                  <layout:start layout:x="453.7427956812214" layout:y="414.2230800113049" layout:z="0.5"/>
+                  <layout:end layout:x="433.83890710825915" layout:y="416.18145170102605" layout:z="1"/>
+                </layout:curveSegment>
+              </layout:listOfCurveSegments>
+            </layout:curve>
+            <layout:listOfSpeciesReferenceGlyphs>
+              <layout:speciesReferenceGlyph layout:id="B_glyph__2" layout:role="product" layout:speciesGlyph="B_glyph_">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="CubicBezier">
+                      <layout:start layout:x="433.83890710825915" layout:y="416.18145170102605" layout:z="1"/>
+                      <layout:end layout:x="494.02423675804494" layout:y="311.1367577788865" layout:z="0.5"/>
+                      <layout:basePoint1 layout:x="419.62843793751483" layout:y="404.5168657269192" layout:z="1.5199999999999996"/>
+                      <layout:basePoint2 layout:x="488.3729674794745" layout:y="322.8441552497631" layout:z="0.4999999999999999"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+              <layout:speciesReferenceGlyph layout:id="G_glyph__1" layout:role="product" layout:speciesGlyph="G_glyph_">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="CubicBezier">
+                      <layout:start layout:x="433.83890710825915" layout:y="416.18145170102605" layout:z="1"/>
+                      <layout:end layout:x="351.6286330276703" layout:y="507.86893258332634" layout:z="0"/>
+                      <layout:basePoint1 layout:x="420.9013795358336" layout:y="417.4543932993447" layout:z="1.9099999999999997"/>
+                      <layout:basePoint2 layout:x="364.6286330276702" layout:y="494.8689325833262" layout:z="-0.65"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+              <layout:speciesReferenceGlyph layout:id="H_glyph__1" layout:role="product" layout:speciesGlyph="H_glyph_">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="CubicBezier">
+                      <layout:start layout:x="433.83890710825915" layout:y="416.18145170102605" layout:z="1"/>
+                      <layout:end layout:x="302.91843828591357" layout:y="448.8773070356013" layout:z="0.5"/>
+                      <layout:basePoint1 layout:x="420.9013795358336" layout:y="417.4543932993447" layout:z="1.9099999999999997"/>
+                      <layout:basePoint2 layout:x="315.56220421542776" layout:y="445.8548604902254" layout:z="0.4999999999999999"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+              <layout:speciesReferenceGlyph layout:id="C_glyph__2" layout:role="substrate" layout:speciesGlyph="C_glyph_">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="CubicBezier">
+                      <layout:start layout:x="453.7427956812214" layout:y="414.2230800113049" layout:z="0.5"/>
+                      <layout:end layout:x="537.6898785892204" layout:y="372.9048416236328" layout:z="0.5"/>
+                      <layout:basePoint1 layout:x="466.68032325364686" layout:y="412.950138412986" layout:z="0.7599999999999998"/>
+                      <layout:basePoint2 layout:x="525.8369245973802" layout:y="378.24408142601294" layout:z="0.4999999999999999"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+              <layout:speciesReferenceGlyph layout:id="D_glyph__2" layout:role="substrate" layout:speciesGlyph="D_glyph_">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="CubicBezier">
+                      <layout:start layout:x="453.7427956812214" layout:y="414.2230800113049" layout:z="0.5"/>
+                      <layout:end layout:x="536.8075355060205" layout:y="441.20226591665966" layout:z="0"/>
+                      <layout:basePoint1 layout:x="466.68032325364686" layout:y="412.950138412986" layout:z="0.7599999999999998"/>
+                      <layout:basePoint2 layout:x="523.8075355060205" layout:y="428.2022659166596" layout:z="-0.65"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+            </layout:listOfSpeciesReferenceGlyphs>
+          </layout:reactionGlyph>
+          <layout:reactionGlyph layout:id="_98713161_2be6_4f31_ae59_25511e2b2fd6" layout:reaction="R4">
+            <layout:boundingBox>
+              <layout:position layout:x="338.81194329538914" layout:y="459.9448844024854" layout:z="0"/>
+              <layout:dimensions layout:depth="0" layout:height="10" layout:width="10"/>
+            </layout:boundingBox>
+            <layout:curve>
+              <layout:listOfCurveSegments>
+                <layout:curveSegment xsi:type="LineSegment">
+                  <layout:start layout:x="350.6416647947616" layout:y="472.24932854567726" layout:z="0.5"/>
+                  <layout:end layout:x="336.98222179601674" layout:y="457.64044025929354" layout:z="1"/>
+                </layout:curveSegment>
+              </layout:listOfCurveSegments>
+            </layout:curve>
+            <layout:listOfSpeciesReferenceGlyphs>
+              <layout:speciesReferenceGlyph layout:id="G_glyph__2" layout:role="modifier" layout:speciesGlyph="G_glyph_">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="CubicBezier">
+                      <layout:start layout:x="351.6286330276703" layout:y="507.86893258332634" layout:z="0"/>
+                      <layout:end layout:x="336.5074991521973" layout:y="471.77460590185785" layout:z="0"/>
+                      <layout:basePoint1 layout:x="364.6286330276702" layout:y="494.8689325833262" layout:z="-0.65"/>
+                      <layout:basePoint2 layout:x="317.51594437989854" layout:y="489.5318818002263" layout:z="-0.9750000000000001"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+              <layout:speciesReferenceGlyph layout:id="H_glyph__2" layout:role="product" layout:speciesGlyph="H_glyph_">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="CubicBezier">
+                      <layout:start layout:x="336.98222179601674" layout:y="457.64044025929354" layout:z="1"/>
+                      <layout:end layout:x="302.8431304316608" layout:y="453.822313045869" layout:z="0.5"/>
+                      <layout:basePoint1 layout:x="328.1035838468326" layout:y="448.14466287314406" layout:z="1.8124999999999998"/>
+                      <layout:basePoint2 layout:x="315.38899615064645" layout:y="457.2283743138411" layout:z="0.4999999999999999"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+              <layout:speciesReferenceGlyph layout:id="I_glyph__1" layout:role="product" layout:speciesGlyph="I_glyph_">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="CubicBezier">
+                      <layout:start layout:x="336.98222179601674" layout:y="457.64044025929354" layout:z="1"/>
+                      <layout:end layout:x="297.85106137035905" layout:y="377.6463201366817" layout:z="0.5"/>
+                      <layout:basePoint1 layout:x="328.1035838468326" layout:y="448.14466287314406" layout:z="1.8124999999999998"/>
+                      <layout:basePoint2 layout:x="303.9072373096524" layout:y="389.14948200602544" layout:z="0.4999999999999999"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+              <layout:speciesReferenceGlyph layout:id="F_glyph__2" layout:role="substrate" layout:speciesGlyph="F_glyph_">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="CubicBezier">
+                      <layout:start layout:x="350.6416647947616" layout:y="472.24932854567726" layout:z="0.5"/>
+                      <layout:end layout:x="413.0302947556397" layout:y="536.1623355780181" layout:z="0.5"/>
+                      <layout:basePoint1 layout:x="359.5203027439457" layout:y="481.7451059318265" layout:z="0.6624999999999999"/>
+                      <layout:basePoint2 layout:x="403.96967793797126" layout:y="526.8400384961081" layout:z="0.4999999999999999"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+            </layout:listOfSpeciesReferenceGlyphs>
+          </layout:reactionGlyph>
+          <layout:reactionGlyph layout:id="c63e47e3_86a3_446e_9440_e434c85ad7d3" layout:reaction="EX1">
+            <layout:boundingBox>
+              <layout:position layout:x="344.1898111697849" layout:y="404.29422478735734" layout:z="0"/>
+              <layout:dimensions layout:depth="0" layout:height="10" layout:width="10"/>
+            </layout:boundingBox>
+            <layout:curve>
+              <layout:listOfCurveSegments>
+                <layout:curveSegment xsi:type="LineSegment">
+                  <layout:start layout:x="349.4371439635415" layout:y="419.291165643896" layout:z="0"/>
+                  <layout:end layout:x="348.94247837602836" layout:y="399.29728393081865" layout:z="0.5"/>
+                </layout:curveSegment>
+              </layout:listOfCurveSegments>
+            </layout:curve>
+            <layout:listOfSpeciesReferenceGlyphs>
+              <layout:speciesReferenceGlyph layout:id="empty_glyph__1" layout:role="product" layout:speciesGlyph="empty_glyph_">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="CubicBezier">
+                      <layout:start layout:x="348.94247837602836" layout:y="399.29728393081865" layout:z="0.5"/>
+                      <layout:end layout:x="342.3324595205357" layout:y="312.106268079715" layout:z="0.5"/>
+                      <layout:basePoint1 layout:x="348.62094574414476" layout:y="386.3012608173183" layout:z="0.825"/>
+                      <layout:basePoint2 layout:x="343.24743396126064" layout:y="325.0740289416687" layout:z="0.4999999999999999"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+              <layout:speciesReferenceGlyph layout:id="G_glyph__3" layout:role="substrate" layout:speciesGlyph="G_glyph_">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="CubicBezier">
+                      <layout:start layout:x="349.4371439635415" layout:y="419.291165643896" layout:z="0"/>
+                      <layout:end layout:x="351.6286330276703" layout:y="507.86893258332634" layout:z="0"/>
+                      <layout:basePoint1 layout:x="349.7586765954249" layout:y="432.28718875739617" layout:z="-0.325"/>
+                      <layout:basePoint2 layout:x="364.6286330276702" layout:y="494.8689325833262" layout:z="-0.65"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+            </layout:listOfSpeciesReferenceGlyphs>
+          </layout:reactionGlyph>
+        </layout:listOfReactionGlyphs>
+        <layout:listOfTextGlyphs>
+          <layout:textGlyph layout:graphicalObject="_92316df2_d22b_4b44_af26_74c082559170" layout:id="_796423e1_1146_4b81_8793_923c84632946" layout:originOfText="extracellular">
+            <layout:boundingBox>
+              <layout:position layout:x="395" layout:y="261.66666666666663" layout:z="-2"/>
+              <layout:dimensions layout:depth="1" layout:height="122.13106741667367" layout:width="176.80753550602049"/>
+            </layout:boundingBox>
+          </layout:textGlyph>
+          <layout:textGlyph layout:graphicalObject="_10a4c427_0db0_4b50_885b_61e256a5da58" layout:id="_70fa5f7c_e000_4103_94e0_de89999e6090" layout:originOfText="cytosol">
+            <layout:boundingBox>
+              <layout:position layout:x="316.6286330276703" layout:y="436.20226591665966" layout:z="-3"/>
+              <layout:dimensions layout:depth="1" layout:height="122.13106741667367" layout:width="255.1789024783502"/>
+            </layout:boundingBox>
+          </layout:textGlyph>
+          <layout:textGlyph layout:graphicalObject="_44634e92_9ba8_4b4b_86a8_b866ab4ca27e" layout:id="_6a6c8edb_af57_49db_bdf3_bbbed160b41a" layout:originOfText="vesicle">
+            <layout:boundingBox>
+              <layout:position layout:x="268.1924644939795" layout:y="353.79773408334034" layout:z="-1"/>
+              <layout:dimensions layout:depth="1" layout:height="112.40453183331931" layout:width="50.000000000000014"/>
+            </layout:boundingBox>
+          </layout:textGlyph>
+          <layout:textGlyph layout:graphicalObject="A_glyph_" layout:id="_02314a81_0917_479e_9b60_ce8d03e3f70c" layout:originOfText="A">
+            <layout:boundingBox>
+              <layout:position layout:x="400" layout:y="266.66666666666663" layout:z="0"/>
+              <layout:dimensions layout:depth="1" layout:height="20" layout:width="40"/>
+            </layout:boundingBox>
+          </layout:textGlyph>
+          <layout:textGlyph layout:graphicalObject="B_glyph_" layout:id="ce87d64c_f1bb_4269_8700_9c84955bd7d3" layout:originOfText="B">
+            <layout:boundingBox>
+              <layout:position layout:x="478.3713669723297" layout:y="292.13106741667366" layout:z="0"/>
+              <layout:dimensions layout:depth="1" layout:height="20" layout:width="40"/>
+            </layout:boundingBox>
+          </layout:textGlyph>
+          <layout:textGlyph layout:graphicalObject="C_glyph_" layout:id="_4b6232d3_bdc1_4e13_9453_d56f041c0995" layout:originOfText="C">
+            <layout:boundingBox>
+              <layout:position layout:x="526.8075355060205" layout:y="358.79773408334034" layout:z="0"/>
+              <layout:dimensions layout:depth="1" layout:height="20" layout:width="40"/>
+            </layout:boundingBox>
+          </layout:textGlyph>
+          <layout:textGlyph layout:graphicalObject="D_glyph_" layout:id="f420a3ec_3ea9_4f26_bfd7_692df42ec56f" layout:originOfText="D">
+            <layout:boundingBox>
+              <layout:position layout:x="526.8075355060205" layout:y="441.20226591665966" layout:z="0"/>
+              <layout:dimensions layout:depth="1" layout:height="20" layout:width="40"/>
+            </layout:boundingBox>
+          </layout:textGlyph>
+          <layout:textGlyph layout:graphicalObject="E_glyph_" layout:id="_2ea3e9a6_6019_4ab2_87fe_84fa40b8107a" layout:originOfText="E">
+            <layout:boundingBox>
+              <layout:position layout:x="478.3713669723297" layout:y="507.86893258332634" layout:z="0"/>
+              <layout:dimensions layout:depth="1" layout:height="20" layout:width="40"/>
+            </layout:boundingBox>
+          </layout:textGlyph>
+          <layout:textGlyph layout:graphicalObject="F_glyph_" layout:id="e6fda986_2962_43d5_9d30_b913e7c45641" layout:originOfText="F">
+            <layout:boundingBox>
+              <layout:position layout:x="400" layout:y="533.3333333333334" layout:z="0"/>
+              <layout:dimensions layout:depth="1" layout:height="20" layout:width="40"/>
+            </layout:boundingBox>
+          </layout:textGlyph>
+          <layout:textGlyph layout:graphicalObject="G_glyph_" layout:id="_44ac3580_3e29_446a_9940_43adc5a04e00" layout:originOfText="G">
+            <layout:boundingBox>
+              <layout:position layout:x="321.6286330276703" layout:y="507.86893258332634" layout:z="0"/>
+              <layout:dimensions layout:depth="1" layout:height="20" layout:width="40"/>
+            </layout:boundingBox>
+          </layout:textGlyph>
+          <layout:textGlyph layout:graphicalObject="H_glyph_" layout:id="_4f1e0a62_3293_47ab_b52b_bf9aed2d6baa" layout:originOfText="H">
+            <layout:boundingBox>
+              <layout:position layout:x="273.1924644939795" layout:y="441.20226591665966" layout:z="0"/>
+              <layout:dimensions layout:depth="1" layout:height="20" layout:width="40"/>
+            </layout:boundingBox>
+          </layout:textGlyph>
+          <layout:textGlyph layout:graphicalObject="I_glyph_" layout:id="e04b2718_4e0d_4710_aaf5_389bd840a832" layout:originOfText="I">
+            <layout:boundingBox>
+              <layout:position layout:x="273.1924644939795" layout:y="358.79773408334034" layout:z="0"/>
+              <layout:dimensions layout:depth="1" layout:height="20" layout:width="40"/>
+            </layout:boundingBox>
+          </layout:textGlyph>
+        </layout:listOfTextGlyphs>
+      </layout:layout>
+    </layout:listOfLayouts>
+    <listOfUnitDefinitions>
+      <unitDefinition id="volume">
+        <listOfUnits>
+          <unit exponent="1" kind="litre" multiplier="1" scale="0"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition id="substance">
+        <listOfUnits>
+          <unit exponent="1" kind="mole" multiplier="1" scale="0"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition id="time">
+        <listOfUnits>
+          <unit exponent="1" kind="second" multiplier="1" scale="0"/>
+        </listOfUnits>
+      </unitDefinition>
+    </listOfUnitDefinitions>
+    <listOfCompartments>
+      <compartment constant="true" id="extracellular" spatialDimensions="3" units="volume"/>
+      <compartment constant="true" id="cytosol" spatialDimensions="3" units="volume"/>
+      <compartment constant="true" id="vesicle" spatialDimensions="3" units="volume"/>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species boundaryCondition="false" compartment="extracellular" constant="false" hasOnlySubstanceUnits="false" id="A" name="A" sboTerm="SBO:0000245" substanceUnits="substance"/>
+      <species boundaryCondition="false" compartment="extracellular" constant="false" hasOnlySubstanceUnits="false" id="B" name="B" sboTerm="SBO:0000247" substanceUnits="substance"/>
+      <species boundaryCondition="false" compartment="extracellular" constant="false" hasOnlySubstanceUnits="false" id="C" name="C" sboTerm="SBO:0000247" substanceUnits="substance"/>
+      <species boundaryCondition="false" compartment="cytosol" constant="false" hasOnlySubstanceUnits="false" id="D" name="D" sboTerm="SBO:0000245" substanceUnits="substance"/>
+      <species boundaryCondition="false" compartment="cytosol" constant="false" hasOnlySubstanceUnits="false" id="E" name="E" sboTerm="SBO:0000247" substanceUnits="substance"/>
+      <species boundaryCondition="false" compartment="cytosol" constant="false" hasOnlySubstanceUnits="false" id="F" name="F" sboTerm="SBO:0000247" substanceUnits="substance"/>
+      <species boundaryCondition="false" compartment="cytosol" constant="false" hasOnlySubstanceUnits="false" id="G" name="G" sboTerm="SBO:0000245" substanceUnits="substance"/>
+      <species boundaryCondition="false" compartment="vesicle" constant="false" hasOnlySubstanceUnits="false" id="H" name="H" sboTerm="SBO:0000247" substanceUnits="substance"/>
+      <species boundaryCondition="false" compartment="vesicle" constant="false" hasOnlySubstanceUnits="false" id="I" name="I" sboTerm="SBO:0000247" substanceUnits="substance"/>
+    </listOfSpecies>
+    <listOfReactions>
+      <reaction fast="false" id="R1" reversible="false">
+        <listOfReactants>
+          <speciesReference constant="true" id="SR_R1_A" species="A" stoichiometry="1"/>
+          <speciesReference constant="true" id="SR_R1_B" species="B" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference constant="true" id="SR_R1_C" species="C" stoichiometry="1"/>
+        </listOfProducts>
+      </reaction>
+      <reaction fast="false" id="R2" reversible="false">
+        <listOfReactants>
+          <speciesReference constant="true" id="SR_R2_A" species="A" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference constant="true" id="SR_R2_F" species="F" stoichiometry="1"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference id="MSR_R2_D" species="D"/>
+        </listOfModifiers>
+      </reaction>
+      <reaction fast="false" id="R3" reversible="false">
+        <listOfReactants>
+          <speciesReference constant="true" id="SR_R3_C" species="C" stoichiometry="1"/>
+          <speciesReference constant="true" id="SR_R3_D" species="D" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference constant="true" id="SR_R3_B" species="B" stoichiometry="1"/>
+          <speciesReference constant="true" id="SR_R3_G" species="G" stoichiometry="1"/>
+          <speciesReference constant="true" id="SR_R3_H" species="H" stoichiometry="1"/>
+        </listOfProducts>
+      </reaction>
+      <reaction fast="false" id="R4" reversible="false">
+        <listOfReactants>
+          <speciesReference constant="true" id="SR_R4_F" species="F" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference constant="true" id="SR_R4_H" species="H" stoichiometry="1"/>
+          <speciesReference constant="true" id="SR_R4_I" species="I" stoichiometry="1"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference id="MSR_R4_G" sboTerm="SBO:0000172" species="G"/>
+        </listOfModifiers>
+      </reaction>
+      <reaction fast="false" id="EX1" reversible="true">
+        <listOfReactants>
+          <speciesReference constant="true" id="SR_EX1_G" species="G" stoichiometry="1"/>
+        </listOfReactants>
+      </reaction>
+    </listOfReactions>
+  </model>
+</sbml>


### PR DESCRIPTION
Implemented validation rules render-20201:render-23043 (i.e. missing the early rules render-10101:render-20103, also missing the recommendations render-21006/21007).

On the way, did some refactoring to the render-package. Some key refactorings:
 - dealing with incorrect attributes when reading: Added non-object-oriented helper-method `static void addToInvalidXMLUserObject` to XMLTools to register invalid attribute-values for later validation; and used it in the `readAttribute`-method
 - polygon's getChildAt can now handle the usual calls for notes/annotation (and is consistent with Polygon.getChildCount) -- this may need be translated to RenderCurve too, but RenderCurve did not cause problems here
 - Added UserObject-tracking in RenderParser, but for now just for RenderInformationBase (see respective TODO) -- this may need be added for the other Classes where subobjects are to be expected (cf. LayoutL3Parser)
 - Added `boolean isListOf___Empty()`-methods to complement the `boolean isSetListOf___()`-methods: `isListOf___Empty` will return `true` iff the list is not null, but empty (which is usually forbidden by the validation-rules). Thereby, the API as stood before does not change (`isSetListOf___` still behave the same).

The sbml-test-files were adapted where they (incorrectly?) made use of <g ... /> instead of <render:g ... />.