### PR TITLE
Fix for issue #207: building javadoc

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -515,6 +515,13 @@
 			<tag name="jsbml.warning" />
 			<tag name="doc.note" description="Documentation note" />
 			<tag name="date" description="Last modified:" />
+			<arg value="--allow-script-in-comments"/>
+			<arg value="-J-Xms4096m"/>
+			<arg value="-J-Xmx4096m"/>
+			<arg value="-Xmaxerrs"/>
+			<arg value="10000"/>
+			<arg value="-Xmaxwarns"/>
+			<arg value="10000"/>
 		</javadoc>
 
 		<!--<property name="icon.file.src" value="${basedir}/core/doc/common/logo/JSBML.png"/>-->


### PR DESCRIPTION
This adds options to the invocation of javadoc so that it no longer
fails, at least on my system and using ant 1.10.7 and Java 8.

Attached is a log of the build after these changes are made.
[javadoc.log](https://github.com/sbmlteam/jsbml/files/4448066/javadoc.log)
