### PR TITLE
Fix javadoc broken logo

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -499,7 +499,7 @@
             header="&lt;script src=&quot;http://alexgorbatchev.com/pub/sh/current/scripts/shCore.js&quot; type=&quot;text/javascript&quot;&gt;&lt;/script&gt;
                 &lt;script src=&quot;http://alexgorbatchev.com/pub/sh/current/scripts/shBrushJava.js&quot; type=&quot;text/javascript&quot;&gt;&lt;/script&gt;
                 &lt;script src=&quot;http://alexgorbatchev.com/pub/sh/current/scripts/shBrushXML.js&quot; type=&quot;text/javascript&quot;&gt;&lt;/script&gt;
-                &lt;img height=&quot;40&quot; src=&quot;http://sbml.org/images/7/79/xJsbml-logo-54px.png.pagespeed.ic.am7oEUtfpP.png&quot; title=&quot;JSBML&quot; alt=&quot;JSBML&quot;/&gt;"
+                &lt;img height=&quot;40&quot; src=&quot;https://github.com/sbmlteam/jsbml/blob/master/doc/common/logo/JSBML_shaddow_small.png?raw=true&quot; title=&quot;JSBML&quot; alt=&quot;JSBML&quot;/&gt;"
             footer="&lt;script type=&quot;text/javascript&quot;&gt;
                 SyntaxHighlighter.defaults[&quot;auto-links&quot;] = false;
                 SyntaxHighlighter.defaults[&quot;tab-size&quot;] = 2;

--- a/overview.html
+++ b/overview.html
@@ -19,6 +19,6 @@
 -->
 <body>
 <p> JSBML is a community-driven project to create a free, open-source, pure Java library for reading, writing, and manipulating SBML files and data streams. It is an alternative to the mixed Java/native code-based interface provided in <a href="http://sbml.org/Software/libSBML">libSBML</a>. The JSBML project's aim is to provide an SBML parser and programming library that maps all SBML elements to a flexible and extended type hierarchy. Where possible, JSBML strives to attain 100% API compatibility with the libSBML Java API, to facilitate a switch from one library to the other.
-<p> The user guide can be found at the <a href = "http://sbml.org/Special/Software/JSBML/latest-stable/doc/user_guide/User_Guide.pdf">JSBML User Guide</a> webpage.
-<p><img src = "http://sbml.org/images/7/79/xJsbml-logo-54px.png.pagespeed.ic.am7oEUtfpP.png">
+<p> The user guide can be found at the <a href="http://sbml.org/Special/Software/JSBML/latest-stable/doc/user_guide/User_Guide.pdf">JSBML User Guide</a> webpage.
+  <p><img height="50px" src="https://github.com/sbmlteam/jsbml/blob/master/doc/common/logo/JSBML_shaddow_small.png?raw=true">
 </body>

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -137,7 +137,7 @@ Navigation bar styles
     padding:0;
     width:100%;
     clear:right;
-    height:2.8em;
+    height:4em;
     padding-top:10px;
     overflow:hidden;
 }


### PR DESCRIPTION
This replaces the links to logo images to ones that are a little more stable.