### PR TITLE
createRenderCubicBezier should return RenderCubicBezier type

### DIFF
--- a/extensions/render/src/org/sbml/jsbml/ext/render/Polygon.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/Polygon.java
@@ -268,8 +268,8 @@ public class Polygon extends GraphicalPrimitive2D implements ICurve {
    * 
    * @return a new {@link RenderCubicBezier} instance
    */
-  public RenderPoint createRenderCubicBezier() {
-    RenderPoint element = new RenderCubicBezier();
+  public RenderCubicBezier createRenderCubicBezier() {
+    RenderCubicBezier element = new RenderCubicBezier();
     addElement(element);
     return element;
   }


### PR DESCRIPTION
One minor in Polygon class from render extension. The return type of `createRenderCubicBezier` method should be `RenderCubicBezier`, so there is no need to cast later on.