### PR TITLE
Fixed issue with unit derivation

### DIFF
--- a/core/src/org/sbml/jsbml/Unit.java
+++ b/core/src/org/sbml/jsbml/Unit.java
@@ -1069,29 +1069,22 @@ public class Unit extends AbstractSBase implements UniqueSId {
       unit2.setKind(Kind.LITRE);
     }
 
+    kind1 = unit1.getKind();
+    kind2 = unit2.getKind();
+
 
     // If one of the units are invalid then an invalid unit is returned with the parameters
     // of
-    if(unit1.getKind().equals(Kind.INVALID) || unit2.getKind().equals(Kind.INVALID)) {
+    if(kind1.equals(Kind.INVALID) || kind2.equals(Kind.INVALID)) {
 
-      // The resulting units is always invalid
+      // The resulting unit is always invalid
       unit1.setKind(Kind.INVALID);
-
-      if (!unit2.getKind().equals(Kind.INVALID)) {
-        if (unit2.isSetOffset) {
-          unit1.setOffset(unit2.getOffset());
-        }
-        unit1.setMultiplier(unit2.getMultiplier());
-        unit1.setScale(unit2.getScale());
-        unit1.setExponent(unit2.getExponent());
-      }
-
-      return;
     }
-
-    // If units are not invalid but not of same kind don't merge
-    if(!unit1.getKind().equals(unit2.getKind())) {
-      return;
+    // If neither unit is invalid but units are not of same kind don't merge
+    else if(!kind1.equals(kind2) && !(kind1.equals(Kind.DIMENSIONLESS) || kind2.equals(Kind.DIMENSIONLESS))) {
+      throw new IllegalArgumentException(MessageFormat.format(
+              "Cannot merge units with different kind properties {0} and {1}. Units can only be merged if both have the same kind attribute or if one of them is dimensionless or invalid.",
+              unit1.getKind(), unit2.getKind()));
     }
 
 

--- a/core/src/org/sbml/jsbml/math/compiler/UnitsCompiler.java
+++ b/core/src/org/sbml/jsbml/math/compiler/UnitsCompiler.java
@@ -1153,7 +1153,7 @@ public class UnitsCompiler implements ASTNode2Compiler {
       }
     }
     ASTNode2Value<Double> value = new ASTNode2Value<Double>(ud, this);
-    value.setValue(Double.valueOf(Math.pow(radiant.toDouble(), 1d / rootExponent)));
+    value.setValue(Maths.root(radiant.toDouble(), rootExponent));
     return value;
   }
 

--- a/core/src/org/sbml/jsbml/util/Maths.java
+++ b/core/src/org/sbml/jsbml/util/Maths.java
@@ -290,27 +290,29 @@ public class Maths {
 
   /**
    * Computes the rootExponent-th root of the radiant
+   *
+   * This method originally always used {@link Math#pow(double, double)} with 1/root exponent (if root exponent != 0)
+   * It was changed mainly to obtain more precise results for root exponents of 2 and 3 with their respective methods
+   * in {@link Math} but it also improved runtime if the rootExponent is either 1, 2 or 3.
    * 
    * @param radiant the radiant
    * @param rootExponent the exponent
    * @return the rootExponent-th root of the radiant
    */
   public static final double root(double radiant, double rootExponent) {
+
     if (rootExponent == 0d) {
       throw new ArithmeticException("Root exponent must not be zero.");
     }
-    else if(rootExponent == 1d) {
+
+    if (rootExponent == 1d) {
       return radiant;
-    }
-    else if(rootExponent == 2d) {
+    } else if (rootExponent == 2d) {
       return Math.sqrt(radiant);
-    }
-    else if(rootExponent == 3d) {
+    } else if (rootExponent == 3d) {
       return Math.cbrt(radiant);
     }
-    else {
-      return Math.pow(radiant, 1d / rootExponent);
-    }
+    return Math.pow(radiant, 1d / rootExponent);
   }
 
   /**

--- a/core/src/org/sbml/jsbml/util/Maths.java
+++ b/core/src/org/sbml/jsbml/util/Maths.java
@@ -296,10 +296,21 @@ public class Maths {
    * @return the rootExponent-th root of the radiant
    */
   public static final double root(double radiant, double rootExponent) {
-    if (rootExponent != 0) {
-      return Math.pow(radiant, 1 / rootExponent);
+    if (rootExponent == 0d) {
+      throw new ArithmeticException("Root exponent must not be zero.");
     }
-    throw new ArithmeticException("Root exponent must not be zero.");
+    else if(rootExponent == 1d) {
+      return radiant;
+    }
+    else if(rootExponent == 2d) {
+      return Math.sqrt(radiant);
+    }
+    else if(rootExponent == 3d) {
+      return Math.cbrt(radiant);
+    }
+    else {
+      return Math.pow(radiant, 1d / rootExponent);
+    }
   }
 
   /**

--- a/core/src/org/sbml/jsbml/util/compilers/UnitsCompiler.java
+++ b/core/src/org/sbml/jsbml/util/compilers/UnitsCompiler.java
@@ -1362,7 +1362,7 @@ public class UnitsCompiler implements ASTNodeCompiler {
 
     }
     ASTNodeValue value = new ASTNodeValue(ud, this);
-    value.setValue(Double.valueOf(Math.pow(radiant.toDouble(), 1d / rootExponent)));
+    value.setValue(Double.valueOf(Maths.root(radiant.toDouble(), rootExponent)));
     return value;
   }
 

--- a/core/test/org/sbml/jsbml/test/sbml/TestUnitMerging.java
+++ b/core/test/org/sbml/jsbml/test/sbml/TestUnitMerging.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
 import org.sbml.jsbml.*;
+import org.sbml.jsbml.util.Maths;
 
 import java.util.Locale;
 
@@ -42,19 +43,18 @@ public class TestUnitMerging {
 
     @Test
     public void testTwoEmptyUnits() {
-        Unit u1 = new Unit();
-        Unit u2 = new Unit();
-        Unit expUnit = new Unit();
+        Unit u1 = new Unit(levelNormal, versionNormal);
+        Unit u2 = new Unit(levelNormal, versionNormal);
+        Unit expUnit = new Unit(0, Unit.Kind.INVALID, 2, levelNormal, versionNormal);
         Unit.merge(u1, u2);
         assertEquals(expUnit, u1);
     }
 
     @Test
     public void testOneEmptyUnit() {
-        Unit u1 = new Unit(8, -3, Unit.Kind.LITER, 1, levelNormal, versionNormal);
-        Unit u2 = new Unit();
-        Unit expUnit = u1.clone();
-        expUnit.setKind(Unit.Kind.INVALID);
+        Unit u1 = new Unit(4, 0, Unit.Kind.LITER, 1, levelNormal, versionNormal);
+        Unit u2 = new Unit(levelNormal, versionNormal);
+        Unit expUnit = new Unit(2, 0, Unit.Kind.INVALID, 2, levelNormal, versionNormal);
         Unit.merge(u1, u2);
         assertEquals(expUnit, u1);
     }
@@ -77,9 +77,9 @@ public class TestUnitMerging {
      */
     @Test
     public void testOneDimensionless() {
-        Unit u1 = new Unit(1, -3, Unit.Kind.GRAM, 1, levelNormal, versionNormal);
+        Unit u1 = new Unit(1, -2, Unit.Kind.GRAM, 1, levelNormal, versionNormal);
         Unit u2 = new Unit(1, 2, Unit.Kind.DIMENSIONLESS, 1, levelNormal, versionNormal);
-        Unit expUnit = u1.clone();
+        Unit expUnit = new Unit(1, 0, Unit.Kind.GRAM, 2, levelNormal, versionNormal);
         Unit.merge(u1, u2);
         assertEquals(expUnit, u1);
     }
@@ -99,13 +99,12 @@ public class TestUnitMerging {
     /**
      * Tests {@link Unit#merge(Unit, Unit)} with two valid non-dimensionless units of different kind.
      */
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testUnequivalentUnits() {
         Unit u1 = new Unit(1, -7, Unit.Kind.GRAM, 1, levelNormal, versionNormal);
         Unit u2 = new Unit(1, 2, Unit.Kind.LITRE, 1, levelNormal, versionNormal);
         Unit expUnit = u1.clone();
         Unit.merge(u1, u2);
-        assertEquals(expUnit, u1);
     }
 
     /**
@@ -127,9 +126,9 @@ public class TestUnitMerging {
      */
     @Test
     public void testWithOneInvalidUnit() {
-        Unit u1 = new Unit(2, 3, Unit.Kind.INVALID, 1, levelNormal, versionNormal);
+        Unit u1 = new Unit(3, 1, Unit.Kind.INVALID, 1, levelNormal, versionNormal);
         Unit u2 = new Unit(3, 2, Unit.Kind.METRE, -1, levelNormal, versionNormal);
-        Unit expUnit = new Unit(3, 2, Unit.Kind.INVALID, -1, levelNormal, versionNormal);
+        Unit expUnit = new Unit(0.1, 0, Unit.Kind.INVALID, 0, levelNormal, versionNormal);
         Unit.merge(u1, u2);
         assertEquals(expUnit, u1);
     }

--- a/core/test/org/sbml/jsbml/test/sbml/TestUnitMerging.java
+++ b/core/test/org/sbml/jsbml/test/sbml/TestUnitMerging.java
@@ -1,0 +1,137 @@
+package org.sbml.jsbml.test.sbml;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.sbml.jsbml.*;
+
+import java.util.Locale;
+
+/**
+ * Testing methods for {@link Unit#merge(Unit, Unit)}.
+ */
+public class TestUnitMerging {
+
+    /**
+     * General SBML level for which Units are defined.
+     */
+    private static final int levelNormal = 3;
+
+    /**
+     * General SBML version for which Units are defined.
+     */
+    private static final int versionNormal = 2;
+
+    /**
+     * SBML level for offset tests for which Units are defined.
+     * Needed because offsets are only defined in version 2 level 1
+     */
+    private static final int levelOffset = 2;
+
+    /**
+     * SBML version for offset tests for which Units are defined.
+     * Needed because offsets are only defined in version 2 level 1
+     */
+    private static final int versionOffset = 1;
+
+    @Before
+    public void setUp() {
+        Locale.setDefault(Locale.ENGLISH);
+    }
+
+    @Test
+    public void testTwoEmptyUnits() {
+        Unit u1 = new Unit();
+        Unit u2 = new Unit();
+        Unit expUnit = new Unit();
+        Unit.merge(u1, u2);
+        assertEquals(expUnit, u1);
+    }
+
+    @Test
+    public void testOneEmptyUnit() {
+        Unit u1 = new Unit(8, -3, Unit.Kind.LITER, 1, levelNormal, versionNormal);
+        Unit u2 = new Unit();
+        Unit expUnit = u1.clone();
+        expUnit.setKind(Unit.Kind.INVALID);
+        Unit.merge(u1, u2);
+        assertEquals(expUnit, u1);
+    }
+
+    /**
+     * Tests {@link Unit#merge(Unit, Unit)} with two valid non-dimensionless units of same kind.
+     * Additionally also test if conversion from deprecated {@link Unit.Kind#LITER} to {@link Unit.Kind#LITRE} works.
+     */
+    @Test
+    public void testNoneDimensionless() {
+        Unit u1 = new Unit(8, -4, Unit.Kind.LITER, 1, levelNormal, versionNormal);
+        Unit u2 = new Unit(2, 2, Unit.Kind.LITER, 1, levelNormal, versionNormal);
+        Unit expUnit = new Unit(0.4, 0, Unit.Kind.LITRE, 2,levelNormal, versionNormal);
+        Unit.merge(u1, u2);
+        assertEquals(expUnit, u1);
+    }
+
+    /**
+     * Tests {@link Unit#merge(Unit, Unit)} with one valid non-dimensionless unit and one dimensionless units.
+     */
+    @Test
+    public void testOneDimensionless() {
+        Unit u1 = new Unit(1, -3, Unit.Kind.GRAM, 1, levelNormal, versionNormal);
+        Unit u2 = new Unit(1, 2, Unit.Kind.DIMENSIONLESS, 1, levelNormal, versionNormal);
+        Unit expUnit = u1.clone();
+        Unit.merge(u1, u2);
+        assertEquals(expUnit, u1);
+    }
+
+    /**
+     * Test {@link Unit#merge(Unit, Unit)} with two dimensionless units.
+     */
+    @Test
+    public void testTwoDimensionless() {
+        Unit u1 = new Unit(2, 0, Unit.Kind.DIMENSIONLESS, 1, levelNormal, versionNormal);
+        Unit u2 = new Unit(8, 0, Unit.Kind.DIMENSIONLESS, 1, levelNormal, versionNormal);
+        Unit expUnit = new Unit( 4,0, Unit.Kind.DIMENSIONLESS, 2, levelNormal, versionNormal);
+        Unit.merge(u1, u2);
+        assertEquals(expUnit, u1);
+    }
+
+    /**
+     * Tests {@link Unit#merge(Unit, Unit)} with two valid non-dimensionless units of different kind.
+     */
+    @Test
+    public void testUnequivalentUnits() {
+        Unit u1 = new Unit(1, -7, Unit.Kind.GRAM, 1, levelNormal, versionNormal);
+        Unit u2 = new Unit(1, 2, Unit.Kind.LITRE, 1, levelNormal, versionNormal);
+        Unit expUnit = u1.clone();
+        Unit.merge(u1, u2);
+        assertEquals(expUnit, u1);
+    }
+
+    /**
+     * Tests {@link Unit#merge(Unit, Unit)} with two valid non-dimensionless units of same kind with offset (deprecated feature).
+     * Additionally also test if conversion from deprecated {@link Unit.Kind#METER} to {@link Unit.Kind#METRE} works.
+     */
+    @Test
+    public void testUnitWithOffset() {
+        Unit u1 = new Unit(2, 3, Unit.Kind.METER, 1, levelOffset, versionOffset);
+        u1.setOffset(1000);
+        Unit u2 = new Unit(3, 2, Unit.Kind.METER, -1, levelOffset, versionOffset);
+        Unit expUnit = new Unit(10, 0, Unit.Kind.METRE, 0, levelOffset, versionOffset);
+        Unit.merge(u1, u2);
+        assertEquals(expUnit, u1);
+    }
+
+    /**
+     * Tests {@link Unit#merge(Unit, Unit)} with one valid non-dimensionless and one invalid unit
+     */
+    @Test
+    public void testWithOneInvalidUnit() {
+        Unit u1 = new Unit(2, 3, Unit.Kind.INVALID, 1, levelNormal, versionNormal);
+        Unit u2 = new Unit(3, 2, Unit.Kind.METRE, -1, levelNormal, versionNormal);
+        Unit expUnit = new Unit(3, 2, Unit.Kind.INVALID, -1, levelNormal, versionNormal);
+        Unit.merge(u1, u2);
+        assertEquals(expUnit, u1);
+    }
+
+}

--- a/core/test/org/sbml/jsbml/test/sbml/TestUnitSimplification.java
+++ b/core/test/org/sbml/jsbml/test/sbml/TestUnitSimplification.java
@@ -20,15 +20,15 @@
  */
 package org.sbml.jsbml.test.sbml;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Locale;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.sbml.jsbml.Unit;
+import org.sbml.jsbml.*;
 import org.sbml.jsbml.Unit.Kind;
-import org.sbml.jsbml.UnitDefinition;
+import org.sbml.jsbml.util.ModelBuilder;
 
 
 /**
@@ -42,37 +42,83 @@ public class TestUnitSimplification {
    */
   private static final int level = 3;
   /**
-   * 
+   * SBML version used in {}
    */
-  private static final int version = 1;
+  private static final int version = 2;
+
   /**
-   * mole per litre
+   * Mol per litre
    */
-  private UnitDefinition ud1;
+  UnitDefinition molPerL_ud;
+  UnitDefinition molPerL_ud2;
   /**
-   * micro litre
+   * Litre per mole
    */
-  private UnitDefinition ud2;
+  UnitDefinition lPerMol_ud;
   /**
-   * hours
+   * Micro litre
    */
-  private UnitDefinition ud3;
+  UnitDefinition muL_ud;
   /**
-   * minutes
+   * Hour
    */
-  private UnitDefinition ud4;
+  UnitDefinition h_ud;
   /**
-   * micro mole
+   * Dimensionless
    */
-  private UnitDefinition ud5;
+  UnitDefinition dimless_ud;
   /**
-   * milli litre
+   * Invalid
    */
-  private UnitDefinition ud6;
+  UnitDefinition invalid_ud;
   /**
-   * seconds
+   * Empty
    */
-  private UnitDefinition ud7;
+  UnitDefinition empty_ud;
+  /**
+   * Containing dimensionless unit
+   */
+  UnitDefinition contDimless_ud;
+  /**
+   * Only dimensionless units
+   */
+  UnitDefinition mulDimless_ud;
+  /**
+   * Containing one invalid
+   */
+  UnitDefinition oneInvalid_ud;
+  /**
+   * Containing two times the same kind of unit (minute)
+   */
+  UnitDefinition twoNormalSame_ud;
+  /**
+   * Containing two times the different kind of unit
+   */
+  UnitDefinition twoNormalDiff_ud;
+  /**
+   * Containing three units of the same kind (litre)
+   */
+  UnitDefinition threeNormalSame_ud;
+  /**
+   * Containing three different kinds of units
+   */
+  UnitDefinition threeNormalDiff_ud;
+  /**
+   * Containing two same and one different unit
+   */
+  UnitDefinition twoSameOneDiff_ud;
+  /**
+   *
+   * First complex unit definition with more than three units:
+   * (0.45 * min * l * mol * s^2 * l) / l
+   *
+   */
+  UnitDefinition complex_ud1;
+  /**
+   * Second complex unit definition with more than three units:
+   * (6.75 * h * μmol * μl^3*l) / (mol*ml^2*l)
+   */
+  UnitDefinition complex_ud2;
 
   /**
    * @throws java.lang.Exception
@@ -81,69 +127,351 @@ public class TestUnitSimplification {
   public void setUp() throws Exception {
     Locale.setDefault(Locale.ENGLISH);
 
-    ud1 = new UnitDefinition("ud1", level, version);
-    ud2 = new UnitDefinition("ud2", level, version);
-    ud3 = new UnitDefinition("ud3", level, version);
-    ud4 = new UnitDefinition("ud4", level, version);
-    ud5 = new UnitDefinition("ud5", level, version);
-    ud6 = new UnitDefinition("ud6", level, version);
-    ud7 = new UnitDefinition("ud7", level, version);
+    // Definition of general Units
 
-    // mole per litre
-    ud1.addUnit(Kind.MOLE);
-    ud1.addUnit(new Unit(1d, 0, Kind.LITRE, -1d, level, version));
+    // mol
+    Unit mol = new Unit(1d, 0, Kind.MOLE, 1d, level, version);
+    // 1 / mol
+    Unit invMole = mol.clone();
+    invMole.setExponent(-1d);
+    // litre
+    Unit litre = new Unit(1d, 0, Kind.LITRE, 1d, level, version);
+    // 1 / l
+    Unit invLitre = litre.clone();
+    invLitre.setExponent(-1d);
+    // micro litre
+    Unit muL = new Unit(1d, -6, Kind.LITRE, 1d, level, version);
+    // hour
+    Unit h = new Unit(3600d, 0, Kind.SECOND, 1d, level, version);
+    // minutes
+    Unit min = new Unit(60d, 0, Kind.SECOND, 1d, level, version);
+    // micro mol
+    Unit muMol = new Unit(1d, -6, Kind.MOLE, 1d, level, version);
+    // milli litre
+    Unit ml = new Unit(1d, -3, Kind.LITRE, 1d, level, version);
+    // seconds
+    Unit s = new Unit(1d, 0, Kind.SECOND, 1d, level, version);
+    // 4*dimensionless
+    Unit dimless4 = new Unit(4d, 0, Kind.DIMENSIONLESS, 1d, level, version);
+    // 0.45*dimensionless
+    Unit dimless045 = new Unit(0.45,0, Kind.DIMENSIONLESS, 1d, level, version);
+    // 6.75*dimensionless
+    Unit dimless675 = new Unit(6.75, 0, Kind.DIMENSIONLESS, 1d, level, version);
+    // invalid
+    Unit invalid = new Unit(5d, 5, Kind.INVALID, 1d, level, version);
+    // seconds squared
+    Unit sSquared = s.clone();
+    sSquared.setExponent(2d);
+    // mu litre cubed
+    Unit muLitreCubed = muL.clone();
+    muLitreCubed.setExponent(3d);
+    // 1 / ml^2
+    Unit invMilliLitreSquared = ml.clone();
+    invMilliLitreSquared.setExponent(-2d);
+
+
+    //Setting values of Unit Definitions later used in testing
+
+    UnitDefinition baseUD = new UnitDefinition();
+    baseUD.setLevel(level);
+    baseUD.setVersion(version);
+
+    // mol per l
+    molPerL_ud = baseUD.clone();
+    molPerL_ud.addUnit(mol.clone());
+    molPerL_ud.addUnit(invLitre.clone());
+
+    // mol per l
+    molPerL_ud2 = baseUD.clone();
+    molPerL_ud2.addUnit(invLitre.clone());
+    molPerL_ud2.addUnit(mol.clone());
 
     // micro litre
-    ud2.addUnit(new Unit(1d, -6, Kind.LITRE, 1d, level, version));
+    muL_ud = baseUD.clone();
+    muL_ud.addUnit(muL.clone());
 
-    // hours
-    ud3.addUnit(new Unit(3600d, 0, Kind.SECOND, 1d, level, version));
+    // dimensionless
+    dimless_ud = baseUD.clone();
+    dimless_ud.addUnit(dimless4.clone());
 
-    // minutes
-    ud4.addUnit(new Unit(60d, 0, Kind.SECOND, 1d, level, version));
+    // invalid
+    invalid_ud = baseUD.clone();
+    invalid_ud.addUnit(invalid.clone());
 
-    // micro mole
-    ud5.addUnit(new Unit(1d, -6, Kind.MOLE, 1d, level, version));
+    // l / mol
+    lPerMol_ud = baseUD.clone();
+    lPerMol_ud.addUnit(litre.clone());
+    lPerMol_ud.addUnit(invMole.clone());
 
-    // milli litre
-    ud6.addUnit(new Unit(1d, -3, Kind.LITRE, 1d, level, version));
+    // hour
+    h_ud = baseUD.clone();
+    h_ud.addUnit(h.clone());
 
-    // seconds
-    ud7.addUnit(new Unit(1d, 0, Kind.SECOND, 1d, level, version));
+    //empty
+    empty_ud = baseUD.clone();
+
+    // containing one dimensionless
+    contDimless_ud = baseUD.clone();
+    contDimless_ud.addUnit(dimless4.clone());
+    contDimless_ud.addUnit(min.clone());
+
+    // multiple dimensionless
+    mulDimless_ud = baseUD.clone();
+    mulDimless_ud.addUnit(dimless4.clone());
+    mulDimless_ud.addUnit(dimless4.clone());
+
+    // containing one invalid unit
+    oneInvalid_ud = baseUD.clone();
+    oneInvalid_ud.addUnit(h.clone());
+    oneInvalid_ud.addUnit(invalid.clone());
+
+    // containing two times same kind of unit (minute)
+    twoNormalSame_ud = baseUD.clone();
+    twoNormalSame_ud.addUnit(min.clone());
+    twoNormalSame_ud.addUnit(min.clone());
+
+    // containing two different kind of units
+    twoNormalDiff_ud = baseUD.clone();
+    twoNormalDiff_ud.addUnit(min.clone());
+    twoNormalDiff_ud.addUnit(invLitre.clone());
+
+    // containing three times same unit (litre)
+    threeNormalSame_ud = baseUD.clone();
+    threeNormalSame_ud.addUnit(litre.clone());
+    threeNormalSame_ud.addUnit(invLitre.clone());
+    threeNormalSame_ud.addUnit(litre.clone());
+
+    // containing three times a different unit
+    threeNormalDiff_ud = baseUD.clone();
+    threeNormalDiff_ud.addUnit(litre.clone());
+    threeNormalDiff_ud.addUnit(min.clone());
+    threeNormalDiff_ud.addUnit(muMol.clone());
+
+    // containing two times the same unit (minute) and one different unit
+    twoSameOneDiff_ud = baseUD.clone();
+    twoSameOneDiff_ud.addUnit(muL.clone());
+    twoSameOneDiff_ud.addUnit(min.clone());
+    twoSameOneDiff_ud.addUnit(litre.clone());
+
+    // first complex unit definition with more than 3 units
+    complex_ud1 = baseUD.clone();
+    complex_ud1.addUnit(min.clone());
+    complex_ud1.addUnit(litre.clone());
+    complex_ud1.addUnit(mol.clone());
+    complex_ud1.addUnit(invLitre.clone());
+    complex_ud1.addUnit(sSquared.clone());
+    complex_ud1.addUnit(litre.clone());
+    complex_ud1.addUnit(dimless045);
+
+    // second complex unit definition with more than 3 units
+    complex_ud2 = baseUD.clone();
+    complex_ud2.addUnit(h.clone());
+    complex_ud2.addUnit(muMol.clone());
+    complex_ud2.addUnit(muLitreCubed.clone());
+    complex_ud2.addUnit(invMole.clone());
+    complex_ud2.addUnit(invMilliLitreSquared.clone());
+    complex_ud2.addUnit(invLitre.clone());
+    complex_ud2.addUnit(litre.clone());
+    complex_ud2.addUnit(dimless675.clone());
   }
+
+  @Test
+  public void test_specfic_law() {
+    SBMLReader r = new SBMLReader();
+    SBMLDocument sbmlDoc = null;
+    try {
+      sbmlDoc = r.readSBML("/home/eikept/Documents/Studium/HiWi/git_repos/SBMLsqueezer/core/src/test/resources/additional_xml_files/limax_pkpd_39.xml");
+    }
+    catch (Exception e) {
+      System.out.println("Couldn't read model file.");;
+    }
+    Model model = sbmlDoc.getModel();
+    ListOf<Rule> lor = model.getListOfRules();
+    AssignmentRule ar = (AssignmentRule) lor.get(lor.size()-1);
+    UnitDefinition ud = ar.getDerivedUnitDefinition();
+
+    System.out.println("Assignment Rule: " + ar.getMath().toFormula());
+    System.out.println("Final Unit: " + UnitDefinition.printUnits(ud, true));
+  }
+
+
+
+  //////////////////////
+  // divideBy testing
+  //////////////////////
+
+  /**
+   * Testing {@link UnitDefinition#divideBy(UnitDefinition)} with two simple valid, non-dimensionless unit definitions.
+   */
+  @Test
+  public void testDivideByInGeneralSimple() { ;
+    assertEquals("mol*ml^(-2)", UnitDefinition.printUnits(molPerL_ud.clone().divideBy(muL_ud), true));
+  }
+
+  /**
+   * Testing {@link UnitDefinition#divideBy(UnitDefinition)} with one complex and one simple valid, non-dimensionless
+   * unit definition.
+   */
+  @Test
+  public void testDivideByInGeneralComplex() { ;
+    assertEquals("(3*s)^3*l^2", UnitDefinition.printUnits(complex_ud1.clone().divideBy(molPerL_ud), true));
+  }
+
+  /**
+   * Testing {@link UnitDefinition#divideBy(UnitDefinition)} with two valid, non-dimensionless unit definitions
+   * which cancel out.
+   */
+  @Test
+  public void testDivideByWhenUnitsCancelOut() {
+    assertEquals("dimensionless", UnitDefinition.printUnits(molPerL_ud.clone().divideBy(molPerL_ud), true));
+  }
+
+  /**
+   * Testing {@link UnitDefinition#divideBy(UnitDefinition)} with one valid, non-dimensionless and one dimensionless
+   * unit definition.
+   */
+  @Test
+  public void testDivideByDimlessUnit() {
+    assertEquals("mol*(4*l)^(-1)", UnitDefinition.printUnits(molPerL_ud.clone().divideBy(dimless_ud), true));
+  }
+
+  @Test
+  public void testDivideDimlessByDimless() {
+    assertEquals("dimensionless", UnitDefinition.printUnits(dimless_ud.clone().divideBy(dimless_ud), true));
+  }
+
+  /**
+   * Testing {@link UnitDefinition#divideBy(UnitDefinition)} with one invalid unit definition.
+   */
+  @Test
+  public void testDivideByInvalidUnit() {
+    assertEquals("invalid", UnitDefinition.printUnits(molPerL_ud.clone().divideBy(invalid_ud), true));
+  }
+
+
+  ////////////////////////////
+  // multiplyWith testing
+  //////////////////////////
 
 
   /**
-   * Test method for {@link UnitDefinition#divideBy(UnitDefinition)}.
+   * Testing {@link UnitDefinition#multiplyWith(UnitDefinition)} with two simpple valid, non-dimensionless unit definitions.
    */
   @Test
-  public void testDivideBy() {
-    assertTrue(UnitDefinition.printUnits(ud1.clone().divideBy(ud1), true).equals("dimensionless*dimensionless"));
-    assertTrue(UnitDefinition.printUnits(ud1.clone().divideBy(ud2), true).equals("mol*ml^(-2)"));
-    assertTrue(UnitDefinition.printUnits(ud1.clone().divideBy(ud3), true).equals("mol*l^(-1)*(3600*s)^(-1)"));
+  public void testMultiplyWithInGeneralSimple() {
+   assertEquals("mol^2*l^(-2)", UnitDefinition.printUnits(molPerL_ud.clone().multiplyWith(molPerL_ud), true));
   }
+
+  /**
+   * Testing {@link UnitDefinition#multiplyWith(UnitDefinition)} with one complex and one simple valid, non-dimensionless
+   * unit definition.
+   */
+  @Test
+  public void testMultiplyWithInGeneralComplex() { ;
+    assertEquals("(3*s)^3*mol^2", UnitDefinition.printUnits(complex_ud1.clone().multiplyWith(molPerL_ud), true));
+  }
+
+  /**
+   * Testing {@link UnitDefinition#multiplyWith(UnitDefinition)} with two valid, non-dimensionless unit definitions
+   * which cancel out.
+   */
+  @Test
+  public void testMultiplyWithWhenUnitsCancelOut() {
+    assertEquals("dimensionless", UnitDefinition.printUnits(molPerL_ud.clone().multiplyWith(lPerMol_ud), true));
+  }
+
+  /**
+   * Testing {@link UnitDefinition#multiplyWith(UnitDefinition)} with one valid, non-dimensionless and one dimensionless
+   * unit definition.
+   */
+  @Test
+  public void testMultiplyWithDimlessUnit() {
+    assertEquals("4*mol*l^(-1)", UnitDefinition.printUnits(molPerL_ud.clone().multiplyWith(dimless_ud), true));
+  }
+
+  /**
+   * Testing {@link UnitDefinition#multiplyWith(UnitDefinition)} with two dimensionless unit definitions.
+   */
+  @Test
+  public void testMultiplyDimlessWithDimless() {
+    assertEquals("16*dimensionless", UnitDefinition.printUnits(dimless_ud.clone().multiplyWith(dimless_ud), true));
+  }
+
+  /**
+   * Testing {@link UnitDefinition#multiplyWith(UnitDefinition)} with one invalid unit definition.
+   */
+  @Test
+  public void testMultiplyWithInvalidUnit() {
+    assertEquals("mol*5*10^5*invalid*l^(-1)", UnitDefinition.printUnits(molPerL_ud.clone().multiplyWith(invalid_ud), true));
+  }
+
+
+  ////////////////////////////
+  // raiseByThePowerOf testing
+  ////////////////////////////
 
 
   /**
-   * Test method for {@link UnitDefinition#multiplyWith(UnitDefinition)}.
+   * Testing {@link UnitDefinition#raiseByThePowerOf(double)} with 0 as exponent.
    */
   @Test
-  public void testMultiplyWith() {
-    assertTrue(UnitDefinition.printUnits(ud1.clone().multiplyWith(ud1), true).equals("mol^2*l^(-2)"));
-    assertTrue(UnitDefinition.printUnits(ud1.clone().multiplyWith(ud2), true).equals("mol*10^(-6)*dimensionless"));
-    assertTrue(UnitDefinition.printUnits(ud1.clone().multiplyWith(ud3), true).equals("mol*l^(-1)*3600*s"));
+  public void testRaiseByThePowerOfZero() {
+    assertEquals("", UnitDefinition.printUnits(complex_ud1.clone().raiseByThePowerOf(0d), true));
   }
-
 
   /**
-   * Test method for {@link UnitDefinition#raiseByThePowerOf(double)}.
+   * Testing {@link UnitDefinition#raiseByThePowerOf(double)} with positive integer as exponent.
    */
   @Test
-  public void testRaiseByThePowerOf() {
-    assertTrue(UnitDefinition.printUnits(ud1.clone().raiseByThePowerOf(3d), true).equals("mol^3*l^(-3)"));
-    assertTrue(UnitDefinition.printUnits(ud2.clone().raiseByThePowerOf(-2d), true).equals("\u03BCl^(-2)"));
-    assertTrue(UnitDefinition.printUnits(ud3.clone().raiseByThePowerOf(3.4d), true).equals("(3600*s)^3.4"));
+  public void testRaiseByThePowerOfPositiveInt() {
+    assertEquals("mol^3*l^(-3)", UnitDefinition.printUnits(molPerL_ud.clone().raiseByThePowerOf(3d), true));
   }
+
+  /**
+   * Testing {@link UnitDefinition#raiseByThePowerOf(double)} with negative integer as exponent.
+   */
+  @Test
+  public void testRaiseByThePowerOfNegativeInt() {
+    assertEquals("\u03BCl^(-2)", UnitDefinition.printUnits(muL_ud.clone().raiseByThePowerOf(-2d), true));
+  }
+
+  /**
+   * Testing {@link UnitDefinition#raiseByThePowerOf(double)} with rational number as exponent.
+   */
+  @Test
+  public void testRaiseByThePowerOfReal() {
+    assertEquals("(3600*s)^3.4", UnitDefinition.printUnits(h_ud.clone().raiseByThePowerOf(3.4d), true));
+  }
+
+  /**
+   * Testing {@link UnitDefinition#raiseByThePowerOf(double)} with (positive) infinity as exponent.
+   */
+  @Test
+  public void testRaiseByThePowerOfInfinity() {
+    assertEquals("μl^INF", UnitDefinition.printUnits(muL_ud.clone().raiseByThePowerOf(Double.POSITIVE_INFINITY), true));
+  }
+
+  /**
+   * Testing {@link UnitDefinition#raiseByThePowerOf(double)} with invalid unit definition as base.
+   */
+  @Test
+  public void testRaiseInvalidByThePowerOf() {
+    assertEquals("invalid", UnitDefinition.printUnits(invalid_ud.clone().raiseByThePowerOf(3.4d), true));
+  }
+
+  /**
+   * Testing {@link UnitDefinition#raiseByThePowerOf(double)} with dimensionless unit definition as base
+   */
+  @Test
+  public void testRaiseDimensionlessByThePowerOf() {
+    assertEquals("(4*dimensionless)^3", UnitDefinition.printUnits(dimless_ud.clone().raiseByThePowerOf(3d), true));
+  }
+
+
+
+  ////////////////////////////
+  // removeMutliplier testing
+  ////////////////////////////
 
   /**
    * Test method for {@link Unit#removeMultiplier()}.
@@ -157,68 +485,165 @@ public class TestUnitSimplification {
     double exp = 1d;
     uuu.addUnit(new Unit(multiplier + noise, scale, Kind.JOULE, exp, level, version));
     uuu.getUnit(0).removeMultiplier();
-    assertTrue(UnitDefinition.printUnits(uuu, true).equals("kJ"));
+    assertEquals("kJ", UnitDefinition.printUnits(uuu, true));
+  }
+
+  ////////////////////////////
+  // simplify testing
+  ////////////////////////////
+
+  /**
+   * Testing {@link UnitDefinition#simplify()} with empty unit definition
+   */
+  @Test
+  public void testSimplifyEmptyUD() {
+    assertEquals("", UnitDefinition.printUnits(empty_ud.simplify(), true));
   }
 
   /**
-   * Test method for {@link UnitDefinition#simplify()}.
+   * Testing {@link UnitDefinition#simplify()} with unit definition containing one valid non-dimensionless unit
    */
   @Test
-  public void testSimplify() {
-    // TODO: add more test cases!
-    UnitDefinition udef = ud1.clone().divideBy(ud1).simplify();
-    printTask('/', ud1, ud1, udef);
-    assertTrue(UnitDefinition.printUnits(udef, true).equals("dimensionless"));
-
-    udef = ud1.clone().divideBy(ud2).simplify();
-    printTask('/', ud1, ud2, udef);
-    assertTrue(UnitDefinition.printUnits(udef, true).equals("ml^(-2)*mol"));
-
-    udef = ud1.clone().multiplyWith(ud2).simplify();
-    printTask('*', ud1, ud2, udef);
-    assertTrue(UnitDefinition.printUnits(udef, true).equals("\u03BCmol"));
-
-    udef = ud1.clone().multiplyWith(ud2);
-    udef = udef.simplify();
-    udef = udef.divideBy(ud3);
-    System.out.println(c(ud1) + '*' + c(ud2) + '/' + c(ud3) + " = " + c(udef));
-    assertTrue(UnitDefinition.printUnits(udef, true).equals("\u03BCmol*(3600*s)^(-1)"));
-
-    udef = ud3.clone().divideBy(ud4).simplify();
-    printTask('/', ud3, ud4, udef);
-    assertTrue(UnitDefinition.printUnits(udef, true).equals("60*dimensionless"));
-
-    UnitDefinition u1 = new UnitDefinition(level, version);
-    u1.addUnit(new Unit(1d, -3, Unit.Kind.JOULE, 1d, level, version));
-    u1.addUnit(new Unit(1d, -3, Unit.Kind.MOLE, 1d, level, version));
-
-    UnitDefinition u2 = new UnitDefinition(level, version);
-    u2.addUnit(new Unit(1d, 0, Unit.Kind.JOULE, 5d, level, version));
-    u2.addUnit(new Unit(1d, 0, Unit.Kind.MOLE, 5d, level, version));
-
-    udef = u1.clone().divideBy(u2).simplify();
-    printTask('/', u1, u2, udef);
-    double pow = Math.pow(10, 3d/4d);
-    assertTrue(UnitDefinition.printUnits(udef, true).equals('('+ Double.toString(pow) +"*J)^(-4)*(" + Double.toString(pow) + "*mol)^(-4)"));
-
-    UnitDefinition u3 = new UnitDefinition(level, version);
-    u3.addUnit(new Unit(1d, 0, Kind.MOLE, -4d, level, version));
-    u3.addUnit(new Unit(1d, 0, Kind.SECOND, -1d, level, version));
-    udef = ud5.clone().multiplyWith(u3).simplify();
-    printTask('*', ud5, u3, udef);
-    assertTrue(UnitDefinition.printUnits(udef, true).equals("hmol^(-3)*s^(-1)"));
-
-    u1 = ud5.clone().raiseByThePowerOf(5d);
-    u1 = u1.divideBy(ud6.clone().raiseByThePowerOf(5d));
-    u2 = ud5.clone().raiseByThePowerOf(-4d);
-    u2 = u2.multiplyWith(ud6.clone().raiseByThePowerOf(5d));
-    u2 = u2.divideBy(ud7.clone());
-    udef = u1.clone();
-    udef = udef.multiplyWith(u2);
-    udef.simplify();
-    printTask('*', u1, u2, udef);
-    assertTrue(UnitDefinition.printUnits(udef, true).equals("\u03BCmol*s^(-1)"));
+  public void testSimplifyOneUnitUD() {
+    assertEquals("μl", UnitDefinition.printUnits(muL_ud.simplify(), true));
   }
+
+  /**
+   * Testing {@link UnitDefinition#simplify()} with unit definition containing single invalid unit
+   */
+  @Test
+  public void testSimplifyOnlyInvalidUD() {
+    assertEquals("5*10^5*invalid", UnitDefinition.printUnits(invalid_ud.simplify(), true));
+  }
+
+  /**
+   * Testing {@link UnitDefinition#simplify()} with unit definition containing two units:
+   *  - valid non-dimensionless unit
+   *  - valid dimensionless unit
+   */
+  @Test
+  public void testSimplifyOneDimlessOneNormalUD() {
+    assertEquals("240*s", UnitDefinition.printUnits(contDimless_ud.simplify(), true));
+  }
+
+  /**
+   * Testing {@link UnitDefinition#simplify()} with unit definition containing two valid dimensionless units:
+   */
+  @Test
+  public void testSimplifyOnlyDimlessUD() {
+    assertEquals("16*dimensionless", UnitDefinition.printUnits(mulDimless_ud.simplify(), true));
+  }
+
+  /**
+   * Testing {@link UnitDefinition#simplify()} with unit definition containing units:
+   * - invalid unit
+   * - valid non-dimensionless unit
+   */
+  @Test
+  public void testSimplifyOneInvalidOneNormalUD() {
+    assertEquals("3600*s*5*10^5*invalid", UnitDefinition.printUnits(oneInvalid_ud.simplify(), true));
+  }
+
+  /**
+   * Testing {@link UnitDefinition#simplify()} with unit definition containing two valid non-dimensionless
+   * units of the same kind
+   */
+  @Test
+  public void testSimplifyTwoNormalSameUD() {
+    assertEquals("(60*s)^2", UnitDefinition.printUnits(twoNormalSame_ud.simplify(), true));
+  }
+
+  /**
+   * Testing {@link UnitDefinition#simplify()} with unit definition containing two valid non-dimensionless
+   * units of different kind
+   */
+  @Test
+  public void testSimplifyTwoNormalDiffUD() {
+    assertEquals("60*s*l^(-1)", UnitDefinition.printUnits(twoNormalDiff_ud.simplify(), true));
+  }
+
+  /**
+   * Testing {@link UnitDefinition#simplify()} with unit definition containing three valid non-dimensionless
+   * units of the same kind
+   */
+  @Test
+  public void testSimplifyThreeNormalSameUD() {
+    assertEquals("l", UnitDefinition.printUnits(threeNormalSame_ud.simplify(), true));
+  }
+
+  /**
+   * Testing {@link UnitDefinition#simplify()} with unit definition containing three valid non-dimensionless
+   * units, two of which are of the same kind.
+   */
+  @Test
+  public void testSimplifyTwoSameUD() {
+    assertEquals("ml^2*60*s", UnitDefinition.printUnits(twoSameOneDiff_ud.simplify(), true));
+  }
+
+  /**
+   * Testing {@link UnitDefinition#simplify()} with unit definition containing three valid non-dimensionless
+   * units of different kind
+   */
+  @Test
+  public void testSimplifyThreeNormalDiffUD() {
+    assertEquals("l*60*s*μmol", UnitDefinition.printUnits(threeNormalDiff_ud.simplify(), true));
+  }
+
+  /**
+   * Testing {@link UnitDefinition#simplify()} with unit definition containing more than 3 valid units of a
+   * variety of kind ({@link TestUnitSimplification#complex_ud1})
+   */
+  @Test
+  public void testSimplifyComplexUD1() {
+    assertEquals("(3*s)^3*l*mol", UnitDefinition.printUnits(complex_ud1.simplify(), true));
+  }
+
+  /**
+   * Testing {@link UnitDefinition#simplify()} with unit definition containing more than 3 valid units of a
+   * variety of kind ({@link TestUnitSimplification#complex_ud2})
+   */
+  @Test
+  public void testSimplifyComplexUD2() {
+    assertEquals("0.0243*s*pl", UnitDefinition.printUnits(complex_ud2.simplify(), true));
+  }
+
+  /**
+   * Test {@link UnitDefinition#simplify()} of product of the more complex unit definitions defined above
+   * ({@link TestUnitSimplification#complex_ud1} & {@link TestUnitSimplification#complex_ud2})
+   */
+  @Test
+  public void testSimplifyMultipliedComplexUDs() {
+    assertEquals("(0.9*s)^4*μl^2*mol", UnitDefinition.printUnits((complex_ud1.clone().simplify().multiplyWith(complex_ud2.clone().simplify())), true));
+  }
+
+  /**
+   * Test {@link UnitDefinition#simplify()} of quotient of the more complex unit definitions defined above
+   * ({@link TestUnitSimplification#complex_ud1} & {@link TestUnitSimplification#complex_ud2})
+   */
+  @Test
+  public void testSimplifyDividedComplexUDs() {
+    assertEquals("(3.3333333333333336E7*s)^2*mol", UnitDefinition.printUnits(complex_ud1.clone().simplify().divideBy(complex_ud2.clone().simplify()), true));
+  }
+  /**
+   * Test {@link UnitDefinition#simplify()} with {@link TestUnitSimplification#complex_ud1} raised by the power of 3
+   */
+  @Test
+  public void testSimplifyComplexUDToPowerOf() {
+    assertEquals( "(3*s)^9*l^3*mol^3", UnitDefinition.printUnits(complex_ud1.clone().raiseByThePowerOf(3d).simplify(), true));
+  }
+
+  /**
+   * Test {@link UnitDefinition#simplify()} with unit definition containing multiple dimensionless units raised by the power of 3
+   */
+  @Test
+  public void testSimplifyMultiDimensionlessUDToPowerOf() {
+    assertEquals("4096*dimensionless", UnitDefinition.printUnits(mulDimless_ud.clone().raiseByThePowerOf(3d).simplify(), true));
+  }
+
+
+  ////////////////////////////
+  // utility methods
+  ////////////////////////////
 
   /**
    * Convenient helper method.


### PR DESCRIPTION
**Issue:**

The issue was that units were not always derived correctly as there were issues in the `simplify()` and `merge()` methods  in the classes `UnitDefinition` and  `Unit` respectively. 


**Main Changes:**

- Methods `simplify()` and `merge()`  were rewritten as to fix aforementioned issue with the unit derivation where this implementation was largely based on the corresponding methods in LibSBML (C++).
- As there are structural differences between the `simplify()` and `merge()` methods in JSBML and LibSBML the methods `multiplyWith()` and `divideBy()` in `UnitDefinition` had to be changed appropriately.
- `testUnitSimplification()` was modified to test more extensively and  new test method `testUnitMerging()` was added to test the `merge()` method individually. 

**Other Changes:**

- The `root()` method from `Maths` was extended as to return just the radiant if the root exponent is 1 and to use the square/cubic root methods from the regular java `Math` class for root exponents of 2/3 respectively instead of always using `pow()` from `Math`. This leads to better results should the root exponent be 2 or 3. Additionally, where applicable, calls of `Math.pow()` were replaced with `Maths.root()` at various places in the code.

**Remaining Issues:**

Because of inaccuracies in the calculation with floating point numbers some multipliers will be slightly incorrect when the unit is derived. 