### PR TITLE
Fixed a bug that can cause an OutOfBoundsException if debugging is enabled.

### DIFF
--- a/core/src/org/sbml/jsbml/ASTNode.java
+++ b/core/src/org/sbml/jsbml/ASTNode.java
@@ -1821,10 +1821,19 @@ public class ASTNode extends AbstractTreeNode {
    *            the node to add as child.
    */
   public void addChild(ASTNode child) {
+    /*
+    This code for debugging was commented out because it can cause an OutOfBoundsException during
+    the parsing of a model if it contains a lambda element. The reason for this is that
+    in astNodeToTree units are derived for the node and for lambda nodes the children
+    are necessary for this derivation. The children are not yet present however as addChild()
+    is responsible for adding them.
+     */
+    /*
     if (isDebugEnabled) {
       logger.debug(" adding child current node: \n" + astNodeToTree(this, "", ""));
       logger.debug(" adding child: \n" + astNodeToTree(child, "", ""));
     }
+     */
     listOfNodes.add(child);
     setParentSBMLObject(child, parentSBMLObject, 0);
     child.setParent(this);


### PR DESCRIPTION
**Description of Issue**

If debugging is activated in log4j and a model is read that contains a lambda element an OutOfBoundsException is thrown. The reason behind this is that during debugging a tree is drawn for each node in the model when addChild() is called on this node that also displays the unit of the node. To display the unit, the unit needs to be derived first and for lambda nodes, all children are required for this derivation. These children however are not yet present as they're being added by the addChild() method itself.

**Fix**
The code fragment that draws this tree, if debugging is enabled, was commented out.