### PR TITLE
Updated vulnerable dependency

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -86,7 +86,7 @@
     <dependency>
       <groupId>com.fasterxml.woodstox</groupId>
       <artifactId>woodstox-core</artifactId>
-      <version>5.0.1</version>
+      <version>5.4.0</version>
     </dependency>
     <dependency>
       <groupId>org.w3c.jigsaw</groupId>


### PR DESCRIPTION
Bumped com.fasterxml.woodstox from 5.0.1 to version 5.4.0