### PR TITLE
Fix NullPointerException in AbstractTreeNode used by ASTNode clone

### DIFF
--- a/core/src/org/sbml/jsbml/AbstractTreeNode.java
+++ b/core/src/org/sbml/jsbml/AbstractTreeNode.java
@@ -167,9 +167,10 @@ public abstract class AbstractTreeNode implements TreeNodeWithChangeSupport {
       AbstractTreeNode anode = (AbstractTreeNode) node;
       // Do not clone listeners!
       //   this.listOfListeners.addAll(anode.listOfListeners);
-      if (anode.isSetUserObjects()) {
-        userObjects = new HashMap<Object, Object>();
-        userObjects.putAll(anode.userObjects);
+      // Copy userObjects if present. We must not rely on isSetUserObjects(),
+      // because subclasses may override it with different semantics.
+      if (anode.userObjects != null && !anode.userObjects.isEmpty()) {
+        userObjects = new HashMap<Object, Object>(anode.userObjects);
       }
       
       // TODO - add this for all objects when we start using the checkAttribute method for other classes than Compartment.


### PR DESCRIPTION
This PR fixes a `NullPointerException` that could occur when cloning `AbstractTreeNode` (and thus `ASTNode`) when `userObjects` is null.

Previously, the copy constructor in `AbstractTreeNode` did:

if (anode.isSetUserObjects()) {
  userObjects = new HashMap<Object, Object>();
  userObjects.putAll(anode.userObjects);
}

If a subclass overrides isSetUserObjects() (e.g. ASTNode) and returns true even when the underlying userObjects map is still null, putAll throws an NPE.

The constructor is now changed to check the field directly:


if (anode.userObjects != null && !anode.userObjects.isEmpty()) {
  userObjects = new HashMap<Object, Object>(anode.userObjects);
}



This makes the clone logic robust to such overrides.
I verified the fix by:

Building JSBML and running its tests locally.
Building SBSCL 2.1.1 against this JSBML snapshot.
Running the SBMLTestSuite wrapper used in draeger-lab/SBSCL#74 without encountering the previous NPE in ASTNode.clone.
Related issues:

Fixes sbmlteam/jsbml#258
Related to draeger-lab/SBSCL#74
