### PR TITLE
Fix GeneProduct cloning to copy required label and associatedSpecies

### DIFF
--- a/extensions/fbc/src/org/sbml/jsbml/ext/fbc/GeneProduct.java
+++ b/extensions/fbc/src/org/sbml/jsbml/ext/fbc/GeneProduct.java
@@ -112,12 +112,22 @@ public class GeneProduct extends AbstractNamedSBase implements UniqueNamedSBase 
   }
 
   /**
-   * Creates a new {@link GeneProduct} instance.
+   * Creates a new {@link GeneProduct} instance by copying all fields.
    * 
    * @param nsb the instance to clone
    */
   public GeneProduct(GeneProduct nsb) {
     super(nsb);
+
+    // copy GeneProduct-specific fields
+    if (nsb.isSetLabel()) {
+      // use the setter to keep property-change semantics consistent
+      setLabel(nsb.getLabel());
+    }
+
+    if (nsb.isSetAssociatedSpecies()) {
+      setAssociatedSpecies(nsb.getAssociatedSpecies());
+    }
   }
 
   /**


### PR DESCRIPTION
### Summary

This PR fixes [sbmlteam/jsbml#252](https://github.com/sbmlteam/jsbml/issues/252).

Previously, the `GeneProduct(GeneProduct nsb)` copy constructor only called the
super-constructor and did not copy the `label` (required) or `associatedSpecies`
fields. Since `clone()` is implemented as:

```java
@Override
public GeneProduct clone() {
  return new GeneProduct(this);
}
```
cloning a GeneProduct would result in a cloned instance missing these fields,
potentially producing invalid SBML.

The copy constructor is now:
```java
public GeneProduct(GeneProduct nsb) {
  super(nsb);

  if (nsb.isSetLabel()) {
    setLabel(nsb.getLabel());
  }

  if (nsb.isSetAssociatedSpecies()) {
    setAssociatedSpecies(nsb.getAssociatedSpecies());
  }
}
```

so that both label and associatedSpecies are preserved when cloning.

Verification
Local compilation with Maven (core + fbc) succeeds using Java 11.
Cloning a GeneProduct now yields an equal instance with the same label
and associatedSpecies.

Fixes sbmlteam/jsbml#252