### PR TITLE
Make CobraUtil.parseCobraNotes robust to generic HTML notes

### DIFF
--- a/core/test/org/sbml/jsbml/util/CobraUtilTest.java
+++ b/core/test/org/sbml/jsbml/util/CobraUtilTest.java
@@ -12,22 +12,39 @@ import org.sbml.jsbml.Parameter;
 public class CobraUtilTest {
 
   @Test
-  public void testParseCobraNotesRecognizesKnownKeys() throws XMLStreamException {
+  public void testParseCobraNotesRecognizesSimpleKeys() throws XMLStreamException {
     Parameter p = new Parameter(3, 1);
     p.setId("p");
 
-    // Simple COBRA-style notes using known keys
+    // Simple COBRA-style notes using keys without spaces
     p.appendNotes("<body xmlns=\"http://www.w3.org/1999/xhtml\">"
         + "<p>FORMULA: H4N</p>"
         + "<p>CHARGE: 1</p>"
-        + "<p>EC Number: 123</p>"
+        + "<p>GENE_ASSOCIATION: 1594.1</p>"
         + "</body>");
 
     Properties props = CobraUtil.parseCobraNotes(p);
 
     assertEquals("H4N", props.getProperty("FORMULA"));
     assertEquals("1", props.getProperty("CHARGE"));
-    assertEquals("123", props.getProperty("EC Number"));
+    assertEquals("1594.1", props.getProperty("GENE_ASSOCIATION"));
+  }
+
+  @Test
+  public void testParseCobraNotesIgnoresKeysWithSpaces() throws XMLStreamException {
+    Parameter p = new Parameter(3, 1);
+    p.setId("p");
+
+    // Keys with spaces before the colon should be ignored by the generic rule
+    p.appendNotes("<body xmlns=\"http://www.w3.org/1999/xhtml\">"
+        + "<p>EC Number: 123</p>"
+        + "<p>Confidence Level: 4</p>"
+        + "</body>");
+
+    Properties props = CobraUtil.parseCobraNotes(p);
+
+    assertNull("Keys with spaces should be ignored", props.getProperty("EC Number"));
+    assertNull("Keys with spaces should be ignored", props.getProperty("Confidence Level"));
   }
 
   @Test


### PR DESCRIPTION
Fixes #269.

`CobraUtil.parseCobraNotes(SBase)` previously treated any `<p>` element
containing a colon as a `KEY: VALUE` pair, which produced false-positive
COBRA properties when notes contained generic HTML text with `:`.

**Changes**

- Updated `parseCobraNotes` to a generic, pattern-based approach similar
  to the implementation used in cy3sbml:
  - Requires exactly one colon in the `<p>` content.
  - Splits at the first colon into `key` and `value`.
  - Rejects keys containing whitespace (so that free-text sentences are
    not interpreted as keys).
- This keeps the parser generic and does not restrict which COBRA keys
  can be used, while avoiding false positives from arbitrary HTML notes.

**Testing**

- `CobraUtilTest`:
  - `testParseCobraNotesRecognizesSimpleKeys`: verifies that
    COBRA-style keys without spaces (e.g., `FORMULA`, `GENE_ASSOCIATION`)
    are parsed as before.
  - `testParseCobraNotesIgnoresKeysWithSpaces`: verifies that keys with
    whitespace (e.g., `EC Number`) are ignored by the generic rule.
  - `testParseCobraNotesIgnoresGenericHtmlSentences`: verifies that
    generic HTML sentences containing `:` do not produce any properties.

Ran:

```bash
mvn -pl core -Dtest=CobraUtilTest test
```
which completes with BUILD SUCCESS (Java 11)