### PR TITLE
Handle empty lambda expressions in UnitsCompiler (fix #248)

### DIFF
--- a/core/src/org/sbml/jsbml/math/compiler/UnitsCompiler.java
+++ b/core/src/org/sbml/jsbml/math/compiler/UnitsCompiler.java
@@ -727,12 +727,23 @@ public class UnitsCompiler implements ASTNode2Compiler {
   @Override
   // TODO: Specify generic type T i.e. ASTNode2Value<?>
   public <T> ASTNode2Value<?> lambda(List<ASTNode2> values) throws SBMLException {
-    for (int i = 0; i < values.size() - 1; i++) {
-      namesToUnits.put(values.get(i).toString(),
-        values.get(i).compile(this));
+    // When the lambda node is first constructed, its child list may be empty;
+    // in that case, there is no body and no arguments yet, so we cannot derive
+    // any meaningful units. Returning an invalid unit definition here avoids
+    // out-of-bounds exceptions while signalling "units unknown".
+    if (values == null || values.isEmpty()) {
+      return invalid();
     }
-    return new ASTNode2Value(values.get(values.size() - 1).compile(this)
-      .getUnits(), this);
+
+    // For a fully-formed lambda expression, all but the last child are
+    // arguments; the last child is the body whose units we want to derive.
+    for (int i = 0; i < values.size() - 1; i++) {
+      namesToUnits.put(values.get(i).toString(), values.get(i).compile(this));
+    }
+
+    return new ASTNode2Value(
+        values.get(values.size() - 1).compile(this).getUnits(),
+        this);
   }
 
   /* (non-Javadoc)

--- a/core/test/org/sbml/jsbml/math/compiler/UnitsCompilerLambdaTest.java
+++ b/core/test/org/sbml/jsbml/math/compiler/UnitsCompilerLambdaTest.java
@@ -1,0 +1,37 @@
+package org.sbml.jsbml.math.compiler;
+
+import static org.junit.Assert.*;
+
+import java.util.Collections;
+
+import org.junit.Test;
+import org.sbml.jsbml.math.ASTNode2;
+// no import needed for ASTNode2Value since we are in the same package
+// or, if you prefer, you could import:
+// import org.sbml.jsbml.math.compiler.ASTNode2Value;
+
+/**
+ * Regression tests for lambda handling in {@link UnitsCompiler}.
+ */
+public class UnitsCompilerLambdaTest {
+
+  /**
+   * Issue #248: Deriving units for a lambda expression while its child list
+   * is still empty must not cause an IndexOutOfBoundsException.
+   */
+  @Test
+  public void testLambdaWithNoChildrenDoesNotThrow() throws Exception {
+    UnitsCompiler compiler = new UnitsCompiler(3, 1); // arbitrary level/version
+
+    ASTNode2Value<?> result = null;
+    try {
+      result = compiler.lambda(Collections.<ASTNode2>emptyList());
+    } catch (IndexOutOfBoundsException ex) {
+      fail("lambda() must not throw IndexOutOfBoundsException when values list is empty: " + ex);
+    }
+
+    assertNotNull("lambda() should return a non-null ASTNode2Value", result);
+    assertTrue("lambda() with no children should return invalid units",
+               result.getUnits().isInvalid());
+  }
+}


### PR DESCRIPTION
Fixes #248.

Deriving units for a lambda expression while its child list is still empty
(e.g., immediately after the lambda node is constructed, before `addChild()`
has been called) could cause an `IndexOutOfBoundsException` in
`UnitsCompiler.lambda(List<ASTNode2>)`.

Previously, `lambda(...)` always did:

```java
values.get(values.size() - 1)
```
without checking whether values was empty, so an empty child list led to a
call to `values.get(-1)`.

Changes

1. Updated UnitsCompiler.lambda(List<ASTNode2> values) to guard against an empty list:

    - If `values` is `null` or empty, the method now returns `invalid()`, i.e., an `ASTNode2Value` whose `UnitDefinition` is marked as `INVALID`. This avoids out-of-bounds access while signalling that units for a bare lambda expression (without arguments/body yet) are unknown at that time.

2. For non-empty `values`, behaviour is unchanged:

    - All but the last child are treated as arguments and stored in `namesToUnits`.

    - The units of the last child (the body) are used as the lambda’s result units.

Tests

1. Added UnitsCompilerLambdaTest under `core/test/org/sbml/jsbml/math/compiler`:

    - `testLambdaWithNoChildrenDoesNotThrow()`:

        - Calls new `UnitsCompiler(3, 1).lambda(Collections.<ASTNode2>emptyList())`.

        - Asserts that no `IndexOutOfBoundsException` is thrown.

        - Asserts that the returned units are marked as invalid.

2. Ran:

```Bash
mvn -pl core -Dtest=UnitsCompilerLambdaTest test
mvn -pl core test
```
Both complete with `BUILD SUCCESS` on Java 11.
