### PR TITLE
Document offline validation as the default and add test (#246)

### DIFF
--- a/core/src/org/sbml/jsbml/SBMLDocument.java
+++ b/core/src/org/sbml/jsbml/SBMLDocument.java
@@ -336,9 +336,9 @@ public class SBMLDocument extends AbstractSBase {
    * flag in the individual SBMLError objects returned by
    * {@link SBMLDocument#getError(int)} to determine the nature of the failures.
    * 
-   * <p>The offline validator is not yet as complete as the online one so it is not
-   * currently used by default when calling {@link #checkConsistency()} but it might be
-   * in future versions. To get an up to date status, please check the page 
+   * <p>The offline validator was initially less complete than the online one but
+   * has evolved and is now used by default when calling {@link #checkConsistency()}.
+   * The online validator remains available via {@link #checkConsistencyOnline()}. 
    * <a href="https://github.com/sbmlteam/jsbml/wiki/Offline-validator-status">Offline-validator-status</a>.</p>
    * 
    * @return the number of errors found
@@ -580,9 +580,11 @@ public class SBMLDocument extends AbstractSBase {
 
   /**
    * Validates the {@link SBMLDocument}.
-   * 
-   * <p> The validation is currently performed using the
-   * SBML.org online validator (http://sbml.org/validator/).</p>
+   *
+   * <p>The validation is currently performed using the JSBML internal
+   * offline validator, see {@link #checkConsistencyOffline()}. The SBML.org
+   * online validator (http://sbml.org/validator/) is still available via
+   * {@link #checkConsistencyOnline()}.</p>
    * 
    * <p>
    * You can control the consistency checks that are performed when

--- a/core/test/org/sbml/jsbml/test/SBMLDocumentValidationModeTest.java
+++ b/core/test/org/sbml/jsbml/test/SBMLDocumentValidationModeTest.java
@@ -1,0 +1,69 @@
+/*
+ * ----------------------------------------------------------------------------
+ * This file is part of JSBML. Please visit <http://sbml.org/Software/JSBML>
+ * for the latest version of JSBML and more information about SBML.
+ *
+ * Copyright (C) 2009-2022 jointly by the following organizations:
+ * 1. The University of Tuebingen, Germany
+ * 2. EMBL European Bioinformatics Institute (EBML-EBI), Hinxton, UK
+ * 3. The California Institute of Technology, Pasadena, CA, USA
+ * 4. The University of California, San Diego, La Jolla, CA, USA
+ * 5. The Babraham Institute, Cambridge, UK
+ * 
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation. A copy of the license agreement is provided
+ * in the file named "LICENSE.txt" included with this software distribution
+ * and also available online as <http://sbml.org/Software/JSBML/License>.
+ * ----------------------------------------------------------------------------
+ */
+
+package org.sbml.jsbml.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.sbml.jsbml.SBMLDocument;
+
+/**
+ * Tests that {@link SBMLDocument#checkConsistency()} uses the offline
+ * validator by default.
+ */
+public class SBMLDocumentValidationModeTest {
+
+  /**
+   * Small test subclass of {@link SBMLDocument} that records whether the
+   * offline or online validation methods are called.
+   */
+  private static class TestDocument extends SBMLDocument {
+
+    boolean offlineCalled = false;
+    boolean onlineCalled = false;
+
+    @Override
+    public int checkConsistencyOffline() {
+      offlineCalled = true;
+      // return a distinctive value so we can verify it is propagated
+      return 7;
+    }
+
+    @Override
+    public int checkConsistencyOnline() {
+      onlineCalled = true;
+      return 13;
+    }
+  }
+
+  @Test
+  public void checkConsistencyUsesOfflineValidatorByDefault() {
+    TestDocument doc = new TestDocument();
+
+    int result = doc.checkConsistency();
+
+    assertTrue("Offline validator should be used by default.", doc.offlineCalled);
+    assertFalse("Online validator should not be used when calling checkConsistency().", doc.onlineCalled);
+    assertEquals("checkConsistency() should return the offline validator result.", 7, result);
+  }
+}


### PR DESCRIPTION
This PR addresses sbmlteam/jsbml#246.

## Summary

`SBMLDocument.checkConsistency()` already delegates to `checkConsistencyOffline()`, so offline validation is effectively the default. However, the Javadoc still claimed that validation was "currently performed using the SBML.org online validator". This PR:

* updates the documentation to match the actual behaviour, and
* adds a small regression test to ensure `checkConsistency()` continues to use the offline validator.

## Changes

1. **Javadoc updates in `SBMLDocument`**
   * `core/src/org/sbml/jsbml/SBMLDocument.java`
     * `checkConsistencyOffline()` Javadoc now explains that the offline validator is used by default when calling `checkConsistency()`, and points to `checkConsistencyOnline()` as the alternative.
     * `checkConsistency()` Javadoc is updated to state that validation is performed using the JSBML internal offline validator, with the SBML.org online validator still available via `checkConsistencyOnline()`.

   > Note: No executable code was changed; only comments/Javadoc were modified.  
   > The method remains:
   > ```java
   > public int checkConsistency() {
   >   return checkConsistencyOffline();
   > }
   > ```

2. **New unit test**

   * Added `core/test/org/sbml/jsbml/test/SBMLDocumentValidationModeTest.java`
   * The test creates a small `TestDocument` subclass of `SBMLDocument` that overrides:
     * `checkConsistencyOffline()` and
     * `checkConsistencyOnline()`
     and records which one is called.
   * The test `checkConsistencyUsesOfflineValidatorByDefault()` asserts that:
     * `checkConsistency()` calls the offline variant,
     * does **not** call the online variant,
     * and returns the offline method’s result.

   This guards against future regressions where `checkConsistency()` might accidentally call the online validator again.

## Tests

Executed locally:

* `mvn -pl core test` ✅

Test Results

The newly added regression test behaves as expected and passes successfully.