### PR TITLE
Guard SBMLReader annotation processing against ClassCastException (#264)

### DIFF
--- a/core/src/org/sbml/jsbml/xml/stax/SBMLReader.java
+++ b/core/src/org/sbml/jsbml/xml/stax/SBMLReader.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Stack;
 
+
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
@@ -75,6 +76,8 @@ import org.sbml.jsbml.xml.parsers.XMLNodeReader;
 
 import com.ctc.wstx.api.WstxInputProperties;
 import com.ctc.wstx.stax.WstxInputFactory;
+
+import static java.text.MessageFormat.format;
 
 
 /**
@@ -856,14 +859,16 @@ public class SBMLReader {
                   annoReader.processAnnotation((SBase) parent); // or take the second element in the stack ??
                 }
               } else {
-                logger.error("End of <annotation>: expected parent of Annotation to be an SBase but found "
-                    + (parent == null ? "null" : parent.getClass().getCanonicalName())
-                    + ". Skipping annotation parsing.");
+                logger.error(format(
+                    "End of <annotation>: expected parent of Annotation to be an SBase but found {0}. Skipping annotation parsing.",
+                    parent == null ? "null" : parent.getClass().getCanonicalName()
+                ));
               }
             } else {
-              logger.error("End of <annotation>: expected top stack element to be an Annotation but found "
-                  + (lastElement == null ? "null" : lastElement.getClass().getCanonicalName())
-                  + ". Skipping annotation parsing.");
+              logger.error(format(
+                  "End of <annotation>: expected top stack element to be an Annotation but found {0}. Skipping annotation parsing.",
+                  lastElement == null ? "null" : lastElement.getClass().getCanonicalName()
+              ));
             }
             
           } else if (isInsideAnnotation) {

--- a/core/test/org/sbml/jsbml/test/SBMLReaderAnnotationCastTest.java
+++ b/core/test/org/sbml/jsbml/test/SBMLReaderAnnotationCastTest.java
@@ -22,6 +22,8 @@ package org.sbml.jsbml.test;
 
 import static org.junit.Assert.assertNotNull;
 
+import java.io.InputStream;
+
 import org.junit.Test;
 import org.sbml.jsbml.SBMLDocument;
 import org.sbml.jsbml.SBMLReader;
@@ -33,22 +35,17 @@ import org.sbml.jsbml.SBMLReader;
  */
 public class SBMLReaderAnnotationCastTest {
 
+  private static final String RESOURCE = "annotation-cast-example.xml";
+
   @Test
   public void layoutInModelAnnotationDoesNotThrow() throws Exception {
-    String xml =
-        "<sbml xmlns=\"http://www.sbml.org/sbml/level2/version4\" " +
-        "      xmlns:layout=\"http://www.sbml.org/sbml/level3/version1/layout/version1\" " +
-        "      level=\"2\" version=\"4\">" +
-        "  <model id=\"m\">" +
-        "    <annotation>" +
-        "      <layout:listOfLayouts>" +
-        "        <layout:layout id=\"L1\"/>" +
-        "      </layout:listOfLayouts>" +
-        "    </annotation>" +
-        "  </model>" +
-        "</sbml>";
+    SBMLDocument doc;
 
-    SBMLDocument doc = new SBMLReader().readSBMLFromString(xml);
+    // Load the XML from the resource file
+    try (InputStream is = SBMLReaderAnnotationCastTest.class.getResourceAsStream(RESOURCE)) {
+      assertNotNull("Test SBML resource not found: " + RESOURCE, is);
+      doc = new SBMLReader().readSBMLFromStream(is);
+    }
 
     // If we reach here, no ClassCastException (or other exception) was thrown.
     assertNotNull(doc);

--- a/core/test/org/sbml/jsbml/test/annotation-cast-example.xml
+++ b/core/test/org/sbml/jsbml/test/annotation-cast-example.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbml xmlns="http://www.sbml.org/sbml/level2/version4"
+      xmlns:layout="http://www.sbml.org/sbml/level3/version1/layout/version1"
+      level="2" version="4">
+  <model id="m">
+    <annotation>
+      <layout:listOfLayouts>
+        <layout:layout id="L1"/>
+      </layout:listOfLayouts>
+    </annotation>
+  </model>
+</sbml>


### PR DESCRIPTION
This PR addresses sbmlteam/jsbml#264.

## Problem

For some SBML models (e.g. certain BioModels/COPASI exports), reading the file with JSBML fails with:

```text
java.lang.ClassCastException: org.sbml.jsbml.xml.XMLNode cannot be cast to org.sbml.jsbml.Annotation
    at org.sbml.jsbml.xml.stax.SBMLReader.readXMLFromLVLEventReader(SBMLReader.java:851)
```

The discussion on #264 and #263 indicates that this occurs when the model annotation contains nested layout elements, e.g. a `layout:listOfLayouts` inside `<model><annotation>…</annotation></model>`.

Root cause
In the StAX-based reader:

`core/src/org/sbml/jsbml/xml/stax/SBMLReader.java`

within the `event.isEndElement()` handling, at the end of an `<annotation>` element, the code did:

```java
if (currentNode.getLocalPart().equals("annotation") && isSBMLelement)
{
  isInsideAnnotation = false;
  annotationDeepness = -1;

  // calling the annotation parsers
  for (AnnotationReader annoReader : annotationParsers) {
    annoReader.processAnnotation((SBase) ((Annotation) lastElement).getParent()); // or take the second element in the stack ??
  }
}
```
This unconditionally casts `lastElement` to `Annotation` and its parent to `SBase`.
If, for some models, the top of the internal stack is an `XMLNode` instead of an `Annotation`, this cast fails with the reported `ClassCastException`, aborting parsing.

Several comments on `#264` suggested that JSBML should instead log an error and continue, checking the type before the cast.

Fix
In `SBMLReader`, the `annotation` end-element handling is now guarded by type checks:

```java
if (currentNode.getLocalPart().equals("annotation") && isSBMLelement)
{
  isInsideAnnotation = false;
  annotationDeepness = -1;

  // calling the annotation parsers, but be robust against unexpected stack contents
  if (lastElement instanceof Annotation) {
    Annotation annotation = (Annotation) lastElement;
    Object parent = annotation.getParent();

    if (parent instanceof SBase) {
      for (AnnotationReader annoReader : annotationParsers) {
        annoReader.processAnnotation((SBase) parent); // or take the second element in the stack ??
      }
    } else {
      logger.error("End of <annotation>: expected parent of Annotation to be an SBase but found "
          + (parent == null ? "null" : parent.getClass().getCanonicalName())
          + ". Skipping annotation parsing.");
    }
  } else {
    logger.error("End of <annotation>: expected top stack element to be an Annotation but found "
        + (lastElement == null ? "null" : lastElement.getClass().getCanonicalName())
        + ". Skipping annotation parsing.");
  }
}
```

Behavior:

  - Valid case (unchanged):

    - If `lastElement` is an `Annotation` and its parent is an `SBase`, `AnnotationReader.processAnnotation(...)` is called exactly as before.

  - Invalid / unexpected case (was crashing before):

    - If `lastElement` is not an `Annotation`, or its parent is not an `SBase`, JSBML now:

      - logs an error via the existing `Logger`, and

      - skips calling the annotation parsers for this annotation,

      - but continues parsing the rest of the SBML document.

Thus we avoid the `ClassCastException` while still surfacing that something is off in the annotation structure.

New test
Added a regression-style test:

- `core/test/org/sbml/jsbml/test/SBMLReaderAnnotationCastTest.java`

```java
public class SBMLReaderAnnotationCastTest {

  @Test
  public void layoutInModelAnnotationDoesNotThrow() throws Exception {
    String xml =
        "<sbml xmlns=\"http://www.sbml.org/sbml/level2/version4\" " +
        "      xmlns:layout=\"http://www.sbml.org/sbml/level3/version1/layout/version1\" " +
        "      level=\"2\" version=\"4\">" +
        "  <model id=\"m\">" +
        "    <annotation>" +
        "      <layout:listOfLayouts>" +
        "        <layout:layout id=\"L1\"/>" +
        "      </layout:listOfLayouts>" +
        "    </annotation>" +
        "  </model>" +
        "</sbml>";

    SBMLDocument doc = new SBMLReader().readSBMLFromString(xml);

    // If we reach here, no ClassCastException (or other exception) was thrown.
    assertNotNull(doc);
    assertNotNull(doc.getModel());
  }
}
```

This exercises an SBML L2V4 document whose model annotation contains a `layout:listOfLayouts` element, mirroring the situation described in #264, and verifies that `readSBMLFromString(...)` returns a document with a model (i.e., no exception was thrown).

Tests
Executed locally:

- `mvn -pl core test` ✅

I do not have the exact `BioModels` files mentioned in #264 on this machine, but this change narrowly guards the cast that previously failed and adds a unit test to cover a representative layout-in-annotation scenario.