### PR TITLE
Clarify offline validation wording in SBMLDocument Javadoc (#246)

### DIFF
--- a/core/src/org/sbml/jsbml/SBMLDocument.java
+++ b/core/src/org/sbml/jsbml/SBMLDocument.java
@@ -581,7 +581,7 @@ public class SBMLDocument extends AbstractSBase {
   /**
    * Validates the {@link SBMLDocument}.
    *
-   * <p>The validation is currently performed using the JSBML internal
+   * <p>The validation is primarily performed using the JSBML internal
    * offline validator, see {@link #checkConsistencyOffline()}. The SBML.org
    * online validator (http://sbml.org/validator/) is still available via
    * {@link #checkConsistencyOnline()}.</p>


### PR DESCRIPTION
Small follow-up to PR #281 / issue #246.

In the review of #281, it was suggested to change the Javadoc sentence
from “The validation is currently performed …” to “The validation is primarily
performed …” to avoid implying that we might revert to online validation as the
default.

This PR makes that wording change in `SBMLDocument`:

```java
* <p>The validation is primarily performed using the JSBML internal
* offline validator, see {@link #checkConsistencyOffline()}. The SBML.org
* online validator (http://sbml.org/validator/) is still available via
* {@link #checkConsistencyOnline()}.</p>
```
No behavioral changes; only documentation text is updated.

- mvn -pl core test passes.