### PR TITLE
Fix #93: Add initDefaults and hasRequiredAttributes to SBase interface

### DIFF
--- a/core/src/org/sbml/jsbml/AbstractSBase.java
+++ b/core/src/org/sbml/jsbml/AbstractSBase.java
@@ -3365,6 +3365,40 @@ public abstract class AbstractSBase extends AbstractTreeNode implements SBase {
    * @param sb the SBase
    * @return a map of all the declared namespaces in the SBML tree, visible to the given {@link SBase}.
    */
+
+  /*
+   * (non-Javadoc)
+   * @see org.sbml.jsbml.SBase#initDefaults(int, int)
+   */
+  @Override
+  public void initDefaults(int level, int version) {
+    // There are no default values for the base attributes of SBase.
+    // Subclasses will override this method to set their specific defaults.
+  }
+
+  /*
+   * (non-Javadoc)
+   * @see org.sbml.jsbml.SBase#initDefaults()
+   */
+  @Override
+  public void initDefaults() {
+    if (isSetLevelAndVersion()) {
+      initDefaults(getLevel(), getVersion());
+    }
+  }
+
+  /*
+   * (non-Javadoc)
+   * @see org.sbml.jsbml.SBase#hasRequiredAttributes()
+   */
+  @Override
+  public boolean hasRequiredAttributes() {
+    if (isIdMandatory() && !isSetId()) {
+      return false;
+    }
+    return true;
+  }
+
   public static HashMap<String, String> getAllDeclaredNamespaces(SBase sb) {
 
     HashMap<String, String> namespaceMap = new HashMap<String, String>();

--- a/core/src/org/sbml/jsbml/CompartmentType.java
+++ b/core/src/org/sbml/jsbml/CompartmentType.java
@@ -129,7 +129,7 @@ UniqueNamedSBase {
    * this type can actually be used in the defined SBML Level/Version
    * combination.
    */
-  private void initDefaults() {
+  public void initDefaults() {
     if (isSetLevelAndVersion() &&
         ((getLevelAndVersion().compareTo(Integer.valueOf(2), Integer.valueOf(2)) < 0) ||
             (getLevelAndVersion().compareTo(Integer.valueOf(3), Integer.valueOf(1)) >= 0))) {

--- a/core/src/org/sbml/jsbml/SBMLDocument.java
+++ b/core/src/org/sbml/jsbml/SBMLDocument.java
@@ -1158,7 +1158,7 @@ public class SBMLDocument extends AbstractSBase {
   /**
    * 
    */
-  private void initDefaults() {
+  public void initDefaults() {
   }
 
 

--- a/core/src/org/sbml/jsbml/SBase.java
+++ b/core/src/org/sbml/jsbml/SBase.java
@@ -1308,4 +1308,29 @@ public interface SBase extends TreeNodeWithChangeSupport {
    */
   public void unsetName();
 
+/**
+   * Initializes the default values of this {@link SBase} instance according
+   * to the specifications of the given SBML Level and Version combination.
+   *
+   * @param level   the SBML Level.
+   * @param version the SBML Version within the Level.
+   */
+  public void initDefaults(int level, int version);
+
+  /**
+   * Initializes the default values of this {@link SBase} instance according
+   * to the specifications of its currently set SBML Level and Version.
+   * <p>
+   * If the Level and Version are not set, this method should have no effect.
+   */
+  public void initDefaults();
+
+  /**
+   * Returns {@code true} if all required attributes for this {@link SBase} 
+   * object have been set.
+   *
+   * @return {@code true} if all required attributes are set, {@code false} otherwise.
+   */
+  public boolean hasRequiredAttributes();
+
 }

--- a/core/src/org/sbml/jsbml/SpeciesType.java
+++ b/core/src/org/sbml/jsbml/SpeciesType.java
@@ -127,7 +127,7 @@ public class SpeciesType extends AbstractNamedSBase implements UniqueNamedSBase 
    * this type can actually be used in the defined SBML Level/Version
    * combination.
    */
-  private void initDefaults() {
+  public void initDefaults() {
     if (isSetLevelAndVersion() &&
         ((getLevelAndVersion().compareTo(Integer.valueOf(2), Integer.valueOf(2)) < 0) ||
             (getLevelAndVersion().compareTo(Integer.valueOf(3), Integer.valueOf(1)) >= 0))) {


### PR DESCRIPTION
## Overview
This PR resolves **Issue #93** by establishing a standard way to initialize default values and check for required attributes across all `SBase` elements. 

## Changes Made
* **`SBase.java`**: Added method signatures for `initDefaults(int level, int version)`, `initDefaults()`, and `hasRequiredAttributes()`.
* **`AbstractSBase.java`**: Provided the base implementations for these methods so they propagate to all subclasses. `initDefaults` is intentionally empty at this level, while `hasRequiredAttributes()` checks `isIdMandatory()`.
* **Inheritance Fixes**: Updated `SBMLDocument.java`, `CompartmentType.java`, and `SpeciesType.java` to elevate their existing `initDefaults()` methods to `public` to satisfy the new interface contract.

## Validation
* Successfully compiled the core module (`mvn clean test-compile -pl core`).
* Passed all core tests (`mvn test -pl core`).

**Closes #93**