### PR TITLE
Fix #98: Implement toSBML() for all SBase inheritors

### DIFF
--- a/core/src/org/sbml/jsbml/AbstractSBase.java
+++ b/core/src/org/sbml/jsbml/AbstractSBase.java
@@ -3423,5 +3423,19 @@ public abstract class AbstractSBase extends AbstractTreeNode implements SBase {
     //    }
 
   }
+  
+  /*
+   * (non-Javadoc)
+   * @see org.sbml.jsbml.SBase#toSBML()
+   */
+  @Override
+  public String toSBML() {
+    try {
+      return new org.sbml.jsbml.xml.stax.SBMLWriter().writeToString(this);
+    } catch (Exception e) {
+      logger.error("Could not generate SBML string for " + getElementName(), e);
+      return "";
+    }
+  }
 
 }

--- a/core/src/org/sbml/jsbml/SBase.java
+++ b/core/src/org/sbml/jsbml/SBase.java
@@ -1308,4 +1308,12 @@ public interface SBase extends TreeNodeWithChangeSupport {
    */
   public void unsetName();
 
+  /**
+   * Returns a string that consists of the partial SBML describing this object.
+   * This is primarily provided for testing and debugging purposes.
+   *
+   * @return the XML representation of this element as a String.
+   */
+  public String toSBML();
+
 }

--- a/core/src/org/sbml/jsbml/xml/stax/SBMLWriter.java
+++ b/core/src/org/sbml/jsbml/xml/stax/SBMLWriter.java
@@ -1201,5 +1201,85 @@ public class SBMLWriter {
       return stream.toString();
     }
   }
+  /**
+   * Writes the given {@link SBase} to an in-memory XML {@link String}.
+   * * @param sbase the {@link SBase} element.
+   * @return the XML representation of the {@link SBase} as a String.
+   * @throws XMLStreamException if any error occur while creating the XML document.
+   * @throws SBMLException if any error is detected.
+   */
+  public String writeToString(SBase sbase) throws XMLStreamException, SBMLException {
+    if (sbase == null) {
+      return "";
+    }
+    if (sbase instanceof SBMLDocument) {
+      return writeSBMLToString((SBMLDocument) sbase);
+    }
+
+    initializePackageParsers();
+
+    StringWriter stream = new StringWriter();
+    WstxOutputFactory factory = new WstxOutputFactory();
+    SMOutputFactory smFactory = new SMOutputFactory(factory);
+    XMLStreamWriter2 streamWriter = smFactory.createStax2Writer(stream);
+
+    SMRootFragment outputDocument = SMOutputFactory.createOutputFragment(streamWriter);
+    
+    String SBMLNamespace = sbase.getNamespace();
+    if (SBMLNamespace == null) {
+      SBMLNamespace = JSBML.getNamespaceFrom(sbase.getLevel(), sbase.getVersion());
+    }
+    
+    SMOutputContext context = outputDocument.getContext();
+    context.setIndentation('\n' + createIndentationString(indentCount), 1, 2);
+    SMNamespace namespace = context.getNamespace(SBMLNamespace);
+    namespace.setPreferredPrefix("");
+
+    SMOutputElement smOutputElement = outputDocument.addElement(namespace, sbase.getElementName());
+
+    SBMLObjectForXML xmlObject = new SBMLObjectForXML();
+    xmlObject.setName(sbase.getElementName());
+    xmlObject.setNamespace(SBMLNamespace);
+    xmlObject.addAttributes(sbase.writeXMLAttributes());
+
+    if (sbase.getDeclaredNamespaces().size() > 0) {
+      for (String prefix : sbase.getDeclaredNamespaces().keySet()) {
+        if (!prefix.equals("xmlns")) {
+          String namespaceURI = sbase.getDeclaredNamespaces().get(prefix);
+          String namespacePrefix = prefix.substring(prefix.indexOf(':') + 1);
+          streamWriter.setPrefix(namespacePrefix, namespaceURI);
+          xmlObject.getAttributes().put(prefix, namespaceURI);
+        }
+      }
+    }
+
+    Iterator<Map.Entry<String, String>> it = xmlObject.getAttributes().entrySet().iterator();
+    while (it.hasNext()) {
+      Entry<String, String> entry = it.next();
+      smOutputElement.addAttribute(entry.getKey(), entry.getValue());
+    }
+
+    int indent = 0;
+    if (sbase.isSetNotes()) {
+      writeNotes(sbase, smOutputElement, streamWriter, SBMLNamespace, indent + indentCount);
+    }
+    if (sbase.isSetAnnotation()) {
+      writeAnnotation(sbase, smOutputElement, streamWriter, indent + indentCount, false);
+    }
+    
+    if (sbase.getChildCount() > 0) {
+      smOutputElement.addCharacters("\n");
+      writeSBMLElements(xmlObject, smOutputElement, streamWriter, sbase, indent + indentCount);
+    }
+
+    try {
+      streamWriter.writeEndDocument();
+      streamWriter.close();
+    } catch (XMLStreamException e) {
+      // Ignored for fragments
+    }
+
+    return stream.toString();
+  }
 
 }


### PR DESCRIPTION
## Overview
This PR resolves **Issue #98**, bringing JSBML to parity with the libSBML API by introducing the `toSBML()` method to all `SBase` inheritors. This allows developers to easily retrieve the XML string representation of any isolated SBML element (e.g., a single `Species` or `Reaction`) for testing and debugging.

## Changes Made
* **`SBMLWriter.java`**: Added a new `writeToString(SBase sbase)` method. This method leverages StaxMate's `createOutputFragment` to generate an XML fragment for any generic `SBase` element without requiring a full `SBMLDocument` wrapper.
* **`SBase.java`**: Declared the `toSBML()` method in the core interface.
* **`AbstractSBase.java`**: Implemented `toSBML()` to securely call the new `SBMLWriter.writeToString(this)` functionality, exposing it to all JSBML components.

## Validation
* Successfully compiled the core module (`mvn clean test-compile -pl core`).
* Passed all core tests (`mvn test -pl core`).

**Closes #98**