### PR TITLE
Fix #120: Implement canonicalize() method in ASTNode

### DIFF
--- a/core/src/org/sbml/jsbml/ASTNode.java
+++ b/core/src/org/sbml/jsbml/ASTNode.java
@@ -5032,4 +5032,28 @@ public class ASTNode extends AbstractTreeNode {
     return plugins;
   }
 
+  /**
+	 * Converts generic NAME or FUNCTION nodes to specific MathML function or 
+	 * constant nodes if their name matches a predefined MathML construct.
+	 * This method recursively traverses the entire AST tree.
+	 */
+	public void canonicalize() {
+		// Check if this node is a generic Name or Function with a valid string
+		if ((getType() == Type.NAME || getType() == Type.FUNCTION) && getName() != null) {
+			
+			// See if the name matches a known MathML constant or function
+			Type specificType = Type.getTypeFor(getName());
+			
+			// If it's a known type, update this node!
+			if (specificType != Type.UNKNOWN && specificType != getType()) {
+				setType(specificType);
+			}
+		}
+		
+		// Recursively canonicalize all child nodes in the tree
+		for (ASTNode child : getChildren()) {
+			child.canonicalize();
+		}
+	}
+
 }

--- a/core/src/org/sbml/jsbml/ASTNode.java
+++ b/core/src/org/sbml/jsbml/ASTNode.java
@@ -5046,7 +5046,7 @@ public class ASTNode extends AbstractTreeNode {
 			
 			// If it's a known type, update this node!
 			if (specificType != Type.UNKNOWN && specificType != getType()) {
-				setType(specificType);
+				setType(getName()); // Pass the string to ensure values like Double.NaN are initialized
 			}
 		}
 		

--- a/core/test/org/sbml/jsbml/test/sbml/TestASTNode.java
+++ b/core/test/org/sbml/jsbml/test/sbml/TestASTNode.java
@@ -109,33 +109,36 @@ public class TestASTNode {
     node = null;
   }
    */
-  /*
-  // Not supported in JSBML (canonicalize method on ASTNode)
-  public void test_ASTNode_canonicalizeConstants()
-  {
-  ...
-	}
-
-  public void test_ASTNode_canonicalizeFunctions()
-  {
-  ...
-  }
-
-  public void test_ASTNode_canonicalizeFunctionsL1()
-  {
-  ...
-  }
-
-  public void test_ASTNode_canonicalizeLogical()
-  {
-  ...
-  }
-
-  public void test_ASTNode_canonicalizeRelational()
-  {
-  ...
-  }
+  /**
+   * Tests the new canonicalize() method for Issue #120
    */
+  @Test
+  public void test_ASTNode_canonicalize()
+  {
+    // Test canonicalizing a constant
+    ASTNode piNode = new ASTNode(ASTNode.Type.NAME);
+    piNode.setName("pi");
+    piNode.canonicalize();
+    assertTrue(piNode.getType() == ASTNode.Type.CONSTANT_PI);
+
+    // Test canonicalizing a function
+    ASTNode sinNode = new ASTNode(ASTNode.Type.FUNCTION);
+    sinNode.setName("sin");
+    sinNode.canonicalize();
+    assertTrue(sinNode.getType() == ASTNode.Type.FUNCTION_SIN);
+
+    // Test that it recursively fixes children
+    ASTNode root = new ASTNode(ASTNode.Type.PLUS);
+    ASTNode child1 = new ASTNode(ASTNode.Type.NAME);
+    child1.setName("true");
+    root.addChild(child1);
+    
+    // Run canonicalize on the parent
+    root.canonicalize();
+    
+    // Verify the child was fixed automatically
+    assertTrue(root.getChild(0).getType() == ASTNode.Type.CONSTANT_TRUE);
+  }
 
   /**
    * 


### PR DESCRIPTION
## Overview
This PR resolves **Issue #120** by implementing the requested `canonicalize()` method in the `ASTNode` class. This allows the tree to recursively check generic `NAME` or `FUNCTION` nodes and automatically convert them into their specific MathML types (e.g., `CONSTANT_PI`, `FUNCTION_SIN`) if they match a predefined construct.

## Changes Made
* Added `canonicalize()` to `ASTNode.java`. It recursively traverses the tree and uses `Type.getTypeFor(getName())` to safely identify and update node types.
* Updated `TestASTNode.java`. The original C++ ported tests for `canonicalize` were stubbed out as unsupported. I replaced the stub with a working JUnit test (`test_ASTNode_canonicalize`) that successfully verifies constant conversion, function conversion, and recursive traversal.

## Validation
* Successfully compiled `jsbml-core`.
* Verified `test_ASTNode_canonicalize` passes cleanly.

**Resolves #120**

_Note: The commit `b61aade5ae3be0d1a77cb5dc1db570dc23a15e5f` was previously missed due to my mistake and has now been added._