### PR TITLE
Fix #133: Recursively resolve array dimensions in parent objects

### DIFF
--- a/extensions/arrays/src/org/sbml/jsbml/ext/arrays/ArraysSBasePlugin.java
+++ b/extensions/arrays/src/org/sbml/jsbml/ext/arrays/ArraysSBasePlugin.java
@@ -544,14 +544,39 @@ public class ArraysSBasePlugin extends AbstractSBasePlugin implements IdManager{
 
   /**
    * Gets an element from the listOfDimensions, with the given id.
+   * If the dimension is not found on this object, it recursively 
+   * searches the parent hierarchy (Fix for Issue #133).
    *
    * @param fieldId the id of the {@link Dimension} element to get.
    * @return an element from the listOfDimensions with the given id or {@code null}.
    */
   public Dimension getDimension(String fieldId) {
+    // Check the current object's dimensions first
     if (isSetListOfDimensions()) {
-      return getListOfDimensions().get(fieldId);
+      Dimension dim = getListOfDimensions().get(fieldId);
+      if (dim != null) {
+        return dim;
+      }
     }
+    
+    // If not found locally, traverse up the parent hierarchy!
+    if (isSetExtendedSBase()) {
+      SBase parent = getExtendedSBase().getParentSBMLObject();
+      while (parent != null) {
+        ArraysSBasePlugin parentPlugin = (ArraysSBasePlugin) parent.getExtension(ArraysConstants.shortLabel);
+        
+        if (parentPlugin != null && parentPlugin.isSetListOfDimensions()) {
+          Dimension dim = parentPlugin.getListOfDimensions().get(fieldId);
+          if (dim != null) {
+            return dim;
+          }
+        }
+        // Move one level higher in the tree
+        parent = parent.getParentSBMLObject();
+      }
+    }
+    
+    // Still not found
     return null;
   }
 


### PR DESCRIPTION
## Overview
This PR resolves **Issue #133** where array validation incorrectly threw a "not a dimension id" error when a child object (e.g., an `EventAssignment`) referenced a dimension defined on its parent (e.g., an `Event`).

## Changes Made
* Updated `getDimension(String fieldId)` in `ArraysSBasePlugin.java`. 
* Previously, the method only checked the current object's `ListOfDimensions`, returning `null` if the dimension wasn't defined locally.
* The method now includes a fallback loop that traverses up the SBML tree (`getParentSBMLObject()`), checking the `ArraysSBasePlugin` of each parent to recursively resolve the dimension ID.

## Validation
* Successfully compiled the `jsbml-arrays` extension package.

**Resolves #133**