### PR TITLE
Refactor: Migrate from Log4j to SLF4J API in AbstractSBase (Resolves #217)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -129,6 +129,11 @@
       <artifactId>json-simple</artifactId>
       <version>1.1.1</version>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.32</version>
+    </dependency>
   </dependencies>
   
 </project>

--- a/core/src/org/sbml/jsbml/AbstractSBase.java
+++ b/core/src/org/sbml/jsbml/AbstractSBase.java
@@ -33,7 +33,8 @@ import javax.swing.tree.TreeNode;
 import javax.xml.stream.XMLStreamException;
 
 import org.sbml.jsbml.JSBML;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sbml.jsbml.CVTerm.Qualifier;
 import org.sbml.jsbml.ext.AbstractSBasePlugin;
 import org.sbml.jsbml.ext.SBasePlugin;
@@ -89,8 +90,8 @@ public abstract class AbstractSBase extends AbstractTreeNode implements SBase {
   /**
    * A logger for this class.
    */
-  private static final transient Logger logger             =
-      Logger.getLogger(AbstractSBase.class);
+  private static final transient Logger logger =
+    LoggerFactory.getLogger(AbstractSBase.class);
 
   /**
    * Generated serial version identifier.


### PR DESCRIPTION
## Overview
This PR addresses **Issue #217** by beginning the migration from the tightly-coupled Log4j framework to the SLF4J (Simple Logging Facade for Java) API.

## Changes Made
* Replaced `org.apache.log4j.Logger` imports with `org.slf4j.Logger` and `LoggerFactory` in `AbstractSBase.java`.
* Added the `slf4j-api` (v1.7.32) dependency to `core/pom.xml`.

By relying only on the SLF4J API, we prevent dependency conflicts for downstream users who may be utilizing different logging frameworks (Logback, JUL, etc.) in their own projects.

## Validation
* Compiled successfully.
* `mvn clean compile` passes cleanly on `jsbml-core`.