### PR TITLE
Fix #249: Correct unary operator precedence in ASTNode FormulaParser

### DIFF
--- a/core/src/org/sbml/jsbml/math/parser/FormulaParser.jj
+++ b/core/src/org/sbml/jsbml/math/parser/FormulaParser.jj
@@ -351,9 +351,9 @@ private ASTNode TermLvl2() :
   ASTNode node = null;
 }
 {
-  leftChild = TermLvl3()
+  leftChild = UnaryTerm()
   (
-    < DIVIDE > rightChild = TermLvl3()
+    < DIVIDE > rightChild = UnaryTerm()
     {
       Integer left, right;
       left = getInteger(leftChild);
@@ -372,7 +372,7 @@ private ASTNode TermLvl2() :
         leftChild = node;
       }
     }
-  | < TIMES > rightChild = TermLvl3()
+  | < TIMES > rightChild = UnaryTerm()
     {
       node = new ASTNode('*');
       node.addChild(leftChild);
@@ -382,6 +382,29 @@ private ASTNode TermLvl2() :
   )*
   {
     return leftChild;
+  }
+}
+
+private ASTNode UnaryTerm() :
+{
+  ASTNode node = null;
+}
+{
+  < MINUS > node = UnaryTerm()
+  {
+    ASTNode uiMinus = new ASTNode('-');
+    uiMinus.addChild(node);
+    return uiMinus;
+  }
+| < NOT > node = UnaryTerm()
+  {
+    ASTNode not = new ASTNode(Type.LOGICAL_NOT);
+    not.addChild(node);
+    return not;
+  }
+| node = TermLvl3()
+  {
+    return node;
   }
 }
 
@@ -640,7 +663,9 @@ private ASTNode Primary() throws NumberFormatException :
       vector.addChild(node);
     }
   )*
-  < RIGHT_BRACES >  {	selector.addChild(vector);
+  < RIGHT_BRACES >
+  {
+	selector.addChild(vector);
   }
   ( < LEFT_BRACKET >
     (node = TermLvl1())
@@ -660,18 +685,7 @@ private ASTNode Primary() throws NumberFormatException :
   {
     return vector;
   }
-| < MINUS > node = Primary()
-  {
-    ASTNode uiMinus = new ASTNode('-');
-    uiMinus.addChild(node);
-    return uiMinus;
-  }
-| < NOT > node = TermLvl1()
-  {
-    ASTNode not = new ASTNode(Type.LOGICAL_NOT);
-    not.addChild(node);
-    return not;
-  }
+  
 | < LOG > child = Primary()
   {
     node = new ASTNode(Type.FUNCTION_LN);

--- a/core/test/org/sbml/jsbml/text/parser/FormulaParserTest.java
+++ b/core/test/org/sbml/jsbml/text/parser/FormulaParserTest.java
@@ -1,0 +1,20 @@
+package org.sbml.jsbml.text.parser;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.sbml.jsbml.ASTNode;
+
+public class FormulaParserTest {
+    @Test
+    public void testUnaryPrecedenceIssue249() throws Exception {
+        // Verify exponentiation happens BEFORE unary minus
+        ASTNode node1 = ASTNode.parseFormula("-x^y");
+        Assert.assertEquals(ASTNode.Type.MINUS, node1.getType());
+        Assert.assertEquals(1, node1.getChildCount());
+        Assert.assertEquals(ASTNode.Type.POWER, node1.getChild(0).getType());
+        
+        // Verify that unary operators wrapped in parentheses do not throw a ParseException
+        ASTNode node2 = ASTNode.parseFormula("(konm * (-1.0) / koffm)");
+        Assert.assertNotNull(node2);
+    }
+}


### PR DESCRIPTION
## Overview
This PR resolves **Issue #249** by correcting the operator precedence for unary minus (`-`) and logical NOT (`not` / `!`) in the Level 1/2 `FormulaParser.jj`.

## Changes Made
Previously, the rules for `<MINUS>` and `<NOT>` were located at the very bottom of the parsing hierarchy inside the `Primary()` method. Because of this, the parser gave unary operators the highest possible precedence, incorrectly parsing expressions like `-x^y` as `(-x)^y`. This also caused the parser to throw a `ParseException` when encountering standard parenthetical expressions involving unary operators, such as `(-1.0)`.

I updated `FormulaParser.jj` by:
* Removing the unary operators from `Primary()`.
* Introducing a new `UnaryTerm()` parsing level directly below `TermLvl2()` (Multiplication/Division) and above `TermLvl3()` (Exponentiation).
* Regenerating the parser via JavaCC.

## Validation
* `mvn clean compile` runs cleanly, and the JavaCC parser generates successfully.
* Tested against expressions like `(konm * (-1.0) / koffm)` to ensure the `ParseException` is no longer thrown.

**Resolves #249**