### PR TITLE
docs: Add @author tag to SBaseRefIndicesCheck

### DIFF
--- a/extensions/arrays/src/org/sbml/jsbml/ext/arrays/validator/constraints/SBaseRefIndicesCheck.java
+++ b/extensions/arrays/src/org/sbml/jsbml/ext/arrays/validator/constraints/SBaseRefIndicesCheck.java
@@ -14,6 +14,7 @@ import org.sbml.jsbml.validator.offline.factory.SBMLErrorCodes;
 /**
  * Checks that if an SBaseRef points to an array (an object with dimensions),
  * it must have index objects to dereference it to a scalar.
+ * 
  * @author Deepak Yadav
  */
 public class SBaseRefIndicesCheck extends ArraysConstraint {

--- a/extensions/arrays/src/org/sbml/jsbml/ext/arrays/validator/constraints/SBaseRefIndicesCheck.java
+++ b/extensions/arrays/src/org/sbml/jsbml/ext/arrays/validator/constraints/SBaseRefIndicesCheck.java
@@ -14,6 +14,7 @@ import org.sbml.jsbml.validator.offline.factory.SBMLErrorCodes;
 /**
  * Checks that if an SBaseRef points to an array (an object with dimensions),
  * it must have index objects to dereference it to a scalar.
+ * @author Deepak Yadav
  */
 public class SBaseRefIndicesCheck extends ArraysConstraint {
 


### PR DESCRIPTION
### Description
This is a quick follow-up to the recently merged Arrays Validation Rule (PR #290) to add the missing `@author` tag to the `SBaseRefIndicesCheck` class, as requested in the final review.

### Testing
Verified that the `arrays` extension module continues to compile and test cleanly locally.