### PR TITLE
docs: Add @author tag to ModelBuilderReuseTest

### DIFF
--- a/core/test/org/sbml/jsbml/util/ModelBuilderReuseTest.java
+++ b/core/test/org/sbml/jsbml/util/ModelBuilderReuseTest.java
@@ -32,6 +32,8 @@ import org.sbml.jsbml.Unit;
 
 /**
  * Tests for the reuse and clash-detection behaviour in {@link ModelBuilder}.
+ * 
+ * @author Deepak Yadav
  */
 public class ModelBuilderReuseTest {
 


### PR DESCRIPTION
### Description
This is a quick follow-up to the recently merged ModelBuilder clash-prevention feature (PR #272) to add the missing `@author` tag to the `ModelBuilderReuseTest` class, as requested in the final review.

### Testing
Verified that `jsbml-core` continues to compile and test cleanly locally.