### PR TITLE
Fix: Update initDefaults() visibility to public across all extensions

### DIFF
--- a/extensions/dyn/src/org/sbml/jsbml/ext/dyn/DynElement.java
+++ b/extensions/dyn/src/org/sbml/jsbml/ext/dyn/DynElement.java
@@ -58,7 +58,7 @@ public class DynElement extends AbstractNamedSBase implements UniqueNamedSBase {
   /**
    * Initializes custom Class attributes
    * */
-  private void initDefaults() {
+  public void initDefaults() {
     setPackageVersion(-1);
     packageName = DynConstants.shortLabel;
     idRef = null;

--- a/extensions/dyn/src/org/sbml/jsbml/ext/dyn/SpatialComponent.java
+++ b/extensions/dyn/src/org/sbml/jsbml/ext/dyn/SpatialComponent.java
@@ -60,7 +60,7 @@ UniqueNamedSBase {
   /**
    * Initializes custom Class attributes
    * */
-  private void initDefaults() {
+  public void initDefaults() {
     setPackageVersion(-1);
     packageName = DynConstants.shortLabel;
     variable = null;

--- a/extensions/fbc/src/org/sbml/jsbml/ext/fbc/GeneProductAssociation.java
+++ b/extensions/fbc/src/org/sbml/jsbml/ext/fbc/GeneProductAssociation.java
@@ -59,7 +59,7 @@ public class GeneProductAssociation extends AbstractNamedSBase implements Unique
   /**
    * Initializes the default values.
    */
-  private void initDefaults() {
+  public void initDefaults() {
     setPackageVersion(-1);
     packageName = FBCConstants.shortLabel;
   }

--- a/extensions/fbc/src/org/sbml/jsbml/ext/fbc/ListOfObjectives.java
+++ b/extensions/fbc/src/org/sbml/jsbml/ext/fbc/ListOfObjectives.java
@@ -88,7 +88,7 @@ public class ListOfObjectives extends ListOf<Objective> {
   /**
    * Initializes default values.
    */
-  private void initDefaults() {
+  public void initDefaults() {
     setPackageVersion(-1);
     packageName = FBCConstants.shortLabel;
     setSBaseListType(ListOf.Type.other);

--- a/extensions/fbc/src/org/sbml/jsbml/ext/fbc/LogicalOperator.java
+++ b/extensions/fbc/src/org/sbml/jsbml/ext/fbc/LogicalOperator.java
@@ -270,7 +270,7 @@ public abstract class LogicalOperator extends AbstractSBase implements Associati
   /**
    * 
    */
-  private void initDefaults() {
+  public void initDefaults() {
     setPackageVersion(-1);
     packageName = FBCConstants.shortLabel;
   }

--- a/extensions/fbc/src/org/sbml/jsbml/ext/fbc/Objective.java
+++ b/extensions/fbc/src/org/sbml/jsbml/ext/fbc/Objective.java
@@ -401,7 +401,7 @@ public class Objective extends AbstractNamedSBase implements UniqueNamedSBase {
   /**
    * 
    */
-  private void initDefaults() {
+  public void initDefaults() {
     setPackageVersion(-1);
     packageName = FBCConstants.shortLabel;
   }

--- a/extensions/groups/src/org/sbml/jsbml/ext/groups/Group.java
+++ b/extensions/groups/src/org/sbml/jsbml/ext/groups/Group.java
@@ -517,7 +517,7 @@ public class Group extends AbstractNamedSBase implements UniqueNamedSBase {
   /**
    * 
    */
-  private void initDefaults() {
+  public void initDefaults() {
     packageName = GroupsConstants.shortLabel;
     setPackageVersion(-1);
   }

--- a/extensions/groups/src/org/sbml/jsbml/ext/groups/Member.java
+++ b/extensions/groups/src/org/sbml/jsbml/ext/groups/Member.java
@@ -63,7 +63,7 @@ public class Member extends AbstractNamedSBase  implements UniqueNamedSBase {
   /**
    * 
    */
-  private void initDefaults() {
+  public void initDefaults() {
     packageName = GroupsConstants.shortLabel;
     setPackageVersion(-1);
   }

--- a/extensions/layout/src/org/sbml/jsbml/ext/layout/Curve.java
+++ b/extensions/layout/src/org/sbml/jsbml/ext/layout/Curve.java
@@ -259,7 +259,7 @@ public class Curve extends AbstractSBase implements ICurve {
   /**
    * 
    */
-  private void initDefaults() {
+  public void initDefaults() {
     setPackageVersion(-1);
     packageName = LayoutConstants.shortLabel;
   }

--- a/extensions/layout/src/org/sbml/jsbml/ext/layout/CurveSegment.java
+++ b/extensions/layout/src/org/sbml/jsbml/ext/layout/CurveSegment.java
@@ -244,7 +244,7 @@ public abstract class CurveSegment extends AbstractSBase {
   /**
    * 
    */
-  private void initDefaults() {
+  public void initDefaults() {
     setPackageVersion(-1);
     packageName = LayoutConstants.shortLabel;
   }

--- a/extensions/layout/src/org/sbml/jsbml/ext/layout/Dimensions.java
+++ b/extensions/layout/src/org/sbml/jsbml/ext/layout/Dimensions.java
@@ -152,7 +152,7 @@ public class Dimensions extends AbstractNamedSBase implements UniqueNamedSBase {
   /**
    * 
    */
-  private void initDefaults() {
+  public void initDefaults() {
     setPackageVersion(-1);
     packageName = LayoutConstants.shortLabel;
 

--- a/extensions/render/src/org/sbml/jsbml/ext/render/RenderCurveSegment.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/RenderCurveSegment.java
@@ -199,7 +199,7 @@ public abstract class RenderCurveSegment extends AbstractSBase implements Point3
   /**
    * 
    */
-  private void initDefaults() {
+  public void initDefaults() {
     setPackageVersion(-1);
     packageName = RenderConstants.shortLabel;
   }


### PR DESCRIPTION
### Problem
The build on `master` was failing across multiple extension modules (`dyn`, `fbc`, `groups`, `layout`, `render`) with the compilation error:
`attempting to assign weaker access privileges; was public`

This occurred because the `initDefaults()` method in the core `SBase` interface was recently updated to `public`, but the inheriting classes in the extension modules were still using weaker access modifiers (package-private or protected), causing a strict Java inheritance conflict.

### Solution
Updated the method signature of `initDefaults()` to `public` in all affected extension files, including:
- `DynElement` & `SpatialComponent` (dyn)
- `GeneProductAssociation`, `ListOfObjectives`, `Objective`, `LogicalOperator` (fbc)
- `Member`, `Group` (groups)
- `Dimensions`, `Curve`, `CurveSegment` (layout)
- `RenderCurveSegment` (render)

### Testing
Ran a full `mvn test` from the root directory and verified a 100% clean build and test pass across all 17 modules.