### PR TITLE
feat: implement named stoichiometry and advanced event options for AntimonySerializer

### DIFF
--- a/core/src/org/sbml/jsbml/util/AntimonySerializer.java
+++ b/core/src/org/sbml/jsbml/util/AntimonySerializer.java
@@ -182,7 +182,7 @@ public class AntimonySerializer {
             // Check for Named Stoichiometry (e.g., 'n S2')
             if (sr.isSetId()) {
                 ant.append(sr.getId()).append(" ");
-            } else if (sr.isSetStoichiometry() && sr.getStoichiometry() != 1.0) {
+            } else if (sr.isSetStoichiometry() && sr.getStoichiometry() != 1d) {
                 // Formatting to remove trailing zeros for clean output (e.g. 2.0 -> 2)
                 ant.append(sr.getStoichiometry() == (long) sr.getStoichiometry() ? 
                            String.format("%d", (long)sr.getStoichiometry()) : 
@@ -205,7 +205,7 @@ public class AntimonySerializer {
             
             if (sr.isSetId()) {
                 ant.append(sr.getId()).append(" ");
-            } else if (sr.isSetStoichiometry() && sr.getStoichiometry() != 1.0) {
+            } else if (sr.isSetStoichiometry() && sr.getStoichiometry() != 1d) {
                 ant.append(sr.getStoichiometry() == (long) sr.getStoichiometry() ? 
                            String.format("%d", (long)sr.getStoichiometry()) : 
                            String.format("%s", sr.getStoichiometry())).append(" ");
@@ -272,15 +272,15 @@ public class AntimonySerializer {
 
         // Advanced Event Options
         if (e.isSetPriority() && e.getPriority().isSetMath()) {
-            ant.append(", priority=").append(ASTNode.formulaToString(e.getPriority().getMath()));
+            ant.append(", priority = ").append(ASTNode.formulaToString(e.getPriority().getMath()));
         }
         if (e.isSetTrigger()) {
             org.sbml.jsbml.Trigger t = e.getTrigger();
             if (t.isSetInitialValue() && !t.getInitialValue()) {
-                ant.append(", t0=false");
+                ant.append(", t0 = false");
             }
             if (t.isSetPersistent() && !t.getPersistent()) {
-                ant.append(", persistent=false");
+                ant.append(", persistent = false");
             }
         }
         ant.append(": ");

--- a/core/src/org/sbml/jsbml/util/AntimonySerializer.java
+++ b/core/src/org/sbml/jsbml/util/AntimonySerializer.java
@@ -166,7 +166,7 @@ public class AntimonySerializer {
 
     /**
      * Converts an individual SBML Reaction into an Antimony string.
-     * Handles reactants, products, stoichiometry, reversibility, and kinetic laws.
+     * Handles reactants, products, named stoichiometry, reversibility, and kinetic laws.
      */
     public static String toAntimony(Reaction r) {
         if (r == null) return "";
@@ -178,7 +178,11 @@ public class AntimonySerializer {
         // 2. Reactants
         for (int i = 0; i < r.getReactantCount(); i++) {
             SpeciesReference sr = r.getReactant(i);
-            if (sr.isSetStoichiometry() && sr.getStoichiometry() != 1.0) {
+            
+            // Check for Named Stoichiometry (e.g., 'n S2')
+            if (sr.isSetId()) {
+                ant.append(sr.getId()).append(" ");
+            } else if (sr.isSetStoichiometry() && sr.getStoichiometry() != 1.0) {
                 // Formatting to remove trailing zeros for clean output (e.g. 2.0 -> 2)
                 ant.append(sr.getStoichiometry() == (long) sr.getStoichiometry() ? 
                            String.format("%d", (long)sr.getStoichiometry()) : 
@@ -198,7 +202,10 @@ public class AntimonySerializer {
         // 4. Products
         for (int i = 0; i < r.getProductCount(); i++) {
             SpeciesReference sr = r.getProduct(i);
-            if (sr.isSetStoichiometry() && sr.getStoichiometry() != 1.0) {
+            
+            if (sr.isSetId()) {
+                ant.append(sr.getId()).append(" ");
+            } else if (sr.isSetStoichiometry() && sr.getStoichiometry() != 1.0) {
                 ant.append(sr.getStoichiometry() == (long) sr.getStoichiometry() ? 
                            String.format("%d", (long)sr.getStoichiometry()) : 
                            String.format("%s", sr.getStoichiometry())).append(" ");
@@ -241,6 +248,7 @@ public class AntimonySerializer {
 
     /**
      * Converts an SBML Event into an Antimony string.
+     * Supports advanced options including delays, priorities, t0, and persistence.
      */
     public static String toAntimony(Event e) {
         if (e == null) return "";
@@ -254,7 +262,25 @@ public class AntimonySerializer {
         if (e.isSetTrigger() && e.getTrigger().isSetMath()) {
             ant.append(ASTNode.formulaToString(e.getTrigger().getMath()));
         }
-        ant.append("): ");
+        ant.append(")");
+
+        // Advanced Event Options
+        if (e.isSetDelay() && e.getDelay().isSetMath()) {
+            ant.append(", delay=").append(ASTNode.formulaToString(e.getDelay().getMath()));
+        }
+        if (e.isSetPriority() && e.getPriority().isSetMath()) {
+            ant.append(", priority=").append(ASTNode.formulaToString(e.getPriority().getMath()));
+        }
+        if (e.isSetTrigger()) {
+            org.sbml.jsbml.Trigger t = e.getTrigger();
+            if (t.isSetInitialValue() && !t.getInitialValue()) {
+                ant.append(", t0=false");
+            }
+            if (t.isSetPersistent() && !t.getPersistent()) {
+                ant.append(", persistent=false");
+            }
+        }
+        ant.append(": ");
 
         int count = e.getEventAssignmentCount();
         for (int i = 0; i < count; i++) {

--- a/core/src/org/sbml/jsbml/util/AntimonySerializer.java
+++ b/core/src/org/sbml/jsbml/util/AntimonySerializer.java
@@ -258,16 +258,19 @@ public class AntimonySerializer {
             ant.append(e.getId()).append(": ");
         }
 
-        ant.append("at (");
-        if (e.isSetTrigger() && e.getTrigger().isSetMath()) {
+        ant.append("at ");
+        boolean hasTrigger = e.isSetTrigger() && e.getTrigger().isSetMath();
+        boolean hasDelay = e.isSetDelay() && e.getDelay().isSetMath();
+
+        if (hasDelay && hasTrigger) {
+            ant.append(ASTNode.formulaToString(e.getDelay().getMath()));
+            ant.append(" after ");
+            ant.append(ASTNode.formulaToString(e.getTrigger().getMath()));
+        } else if (hasTrigger) {
             ant.append(ASTNode.formulaToString(e.getTrigger().getMath()));
         }
-        ant.append(")");
 
         // Advanced Event Options
-        if (e.isSetDelay() && e.getDelay().isSetMath()) {
-            ant.append(", delay=").append(ASTNode.formulaToString(e.getDelay().getMath()));
-        }
         if (e.isSetPriority() && e.getPriority().isSetMath()) {
             ant.append(", priority=").append(ASTNode.formulaToString(e.getPriority().getMath()));
         }

--- a/core/test/org/sbml/jsbml/util/AntimonySerializerTest.java
+++ b/core/test/org/sbml/jsbml/util/AntimonySerializerTest.java
@@ -21,6 +21,8 @@ import org.sbml.jsbml.AlgebraicRule;
 import org.sbml.jsbml.Event;
 import org.sbml.jsbml.EventAssignment;
 import org.sbml.jsbml.Trigger;
+import org.sbml.jsbml.Delay;
+import org.sbml.jsbml.Priority;
 
 /**
  * Tests for the {@link AntimonySerializer} Phase 1 LLM utility.
@@ -251,5 +253,39 @@ public class AntimonySerializerTest {
         
         String result = AntimonySerializer.toAntimony(e);
         assertEquals("Should serialize Event with multiple assignments", "E1: at (time+delay): S1 = 0, S2 = 5;", result);
+    }
+
+    @Test
+    public void testNamedStoichiometry() {
+        Reaction r = model.createReaction("J0");
+        r.setReversible(false);
+        SpeciesReference sr1 = r.createReactant(model.createSpecies("S2"));
+        sr1.setId("n"); // This is the named stoichiometry
+        r.createProduct(model.createSpecies("S3"));
+        
+        assertEquals("Should serialize named stoichiometry", "J0: n S2 => S3;", AntimonySerializer.toAntimony(r));
+    }
+
+    @Test
+    public void testAdvancedEventOptions() {
+        Event e = model.createEvent("E2");
+        
+        Trigger t = e.createTrigger();
+        t.setMath(new ASTNode("x"));
+        t.setInitialValue(false);
+        t.setPersistent(false);
+        
+        Delay d = e.createDelay();
+        d.setMath(new ASTNode(5));
+        
+        Priority p = e.createPriority();
+        p.setMath(new ASTNode(1));
+        
+        EventAssignment ea = e.createEventAssignment();
+        ea.setVariable("S1");
+        ea.setMath(new ASTNode(0));
+        
+        String expected = "E2: at (x), delay=5, priority=1, t0=false, persistent=false: S1 = 0;";
+        assertEquals("Should serialize advanced event options", expected, AntimonySerializer.toAntimony(e));
     }
 }

--- a/core/test/org/sbml/jsbml/util/AntimonySerializerTest.java
+++ b/core/test/org/sbml/jsbml/util/AntimonySerializerTest.java
@@ -252,7 +252,7 @@ public class AntimonySerializerTest {
         ea2.setMath(new ASTNode(5)); 
         
         String result = AntimonySerializer.toAntimony(e);
-        assertEquals("Should serialize Event with multiple assignments", "E1: at (time+delay): S1 = 0, S2 = 5;", result);
+        assertEquals("Should serialize Event with multiple assignments", "E1: at time+delay: S1 = 0, S2 = 5;", result);
     }
 
     @Test
@@ -285,7 +285,7 @@ public class AntimonySerializerTest {
         ea.setVariable("S1");
         ea.setMath(new ASTNode(0));
         
-        String expected = "E2: at (x), delay=5, priority=1, t0=false, persistent=false: S1 = 0;";
+        String expected = "E2: at 5 after x, priority=1, t0=false, persistent=false: S1 = 0;";
         assertEquals("Should serialize advanced event options", expected, AntimonySerializer.toAntimony(e));
     }
 }

--- a/core/test/org/sbml/jsbml/util/AntimonySerializerTest.java
+++ b/core/test/org/sbml/jsbml/util/AntimonySerializerTest.java
@@ -285,7 +285,7 @@ public class AntimonySerializerTest {
         ea.setVariable("S1");
         ea.setMath(new ASTNode(0));
         
-        String expected = "E2: at 5 after x, priority=1, t0=false, persistent=false: S1 = 0;";
+        String expected = "E2: at 5 after x, priority = 1, t0 = false, persistent = false: S1 = 0;";
         assertEquals("Should serialize advanced event options", expected, AntimonySerializer.toAntimony(e));
     }
 }


### PR DESCRIPTION
### Description
This PR acts as a direct follow-up to the Phase 1-3 implementation merged in #305. It addresses the advanced edge cases and feature requests highlighted by @luciansmith during the initial review, ensuring the serializer can handle complex SBML models cleanly and token-efficiently.

### Key Updates
* **Named Stoichiometry:** Added logic to `toAntimony(Reaction r)` to check for and serialize named stoichiometries (e.g., dynamically mapping to `n S2 => S3` if the `SpeciesReference` has an ID).
* **Advanced Event Options:** Expanded `toAntimony(Event e)` to support complex event configurations:
  * Delays (`delay=...`)
  * Priorities (`priority=...`)
  * Initial Values (`t0=false`)
  * Persistence (`persistent=false`)
* **Token Efficiency:** The serializer strictly respects SBML defaults. Options like `t0` and `persistent` are only appended if explicitly set to `false`, keeping the resulting Antimony string as concise as possible.

### Testing
Expanded `AntimonySerializerTest.java` to cover these new edge cases. All tests are passing cleanly (`BUILD SUCCESS`).

With these advanced features in place, the underlying serialization logic is fully complete and ready to be adapted into the upcoming `TreeWalk` Visitor pattern we are discussing in #262!