### PR TITLE
feat: introduce core TreeNodeVisitor pattern scaffolding (#262)

### DIFF
--- a/core/src/org/sbml/jsbml/ASTNode.java
+++ b/core/src/org/sbml/jsbml/ASTNode.java
@@ -5056,4 +5056,15 @@ public class ASTNode extends AbstractTreeNode {
 		}
 	}
 
+  /**
+   * Accepts a generic visitor to traverse this component.
+   *
+   * @param <T> the return type of the visitor
+   * @param visitor the visitor implementation
+   * @return the result of the visitor operation
+   */
+  public <T> T accept(TreeNodeVisitor<T> visitor) {
+    return visitor.visit(this);
+  }
+
 }

--- a/core/src/org/sbml/jsbml/AbstractSBase.java
+++ b/core/src/org/sbml/jsbml/AbstractSBase.java
@@ -3492,4 +3492,16 @@ public abstract class AbstractSBase extends AbstractTreeNode implements SBase {
     }
   }
 
+  /**
+   * Accepts a generic visitor to traverse this SBase component.
+   *
+   * @param <T> the return type of the visitor
+   * @param visitor the visitor implementation
+   * @return the result of the visitor operation
+   */
+  @Override
+  public <T> T accept(TreeNodeVisitor<T> visitor) {
+    return visitor.visit(this);
+  }
+
 }

--- a/core/src/org/sbml/jsbml/Annotation.java
+++ b/core/src/org/sbml/jsbml/Annotation.java
@@ -940,4 +940,15 @@ public class Annotation extends AnnotationElement {
     }
   }
 
+  /**
+   * Accepts a generic visitor to traverse this component.
+   *
+   * @param <T> the return type of the visitor
+   * @param visitor the visitor implementation
+   * @return the result of the visitor operation
+   */
+  public <T> T accept(TreeNodeVisitor<T> visitor) {
+    return visitor.visit(this);
+  }
+
 }

--- a/core/src/org/sbml/jsbml/CVTerm.java
+++ b/core/src/org/sbml/jsbml/CVTerm.java
@@ -28,6 +28,7 @@ import java.util.regex.Pattern;
 import javax.swing.tree.TreeNode;
 import javax.xml.stream.XMLStreamException;
 
+import org.sbml.jsbml.CVTerm.Qualifier;
 import org.sbml.jsbml.util.StringTools;
 import org.sbml.jsbml.util.TreeNodeAdapter;
 import org.sbml.jsbml.util.TreeNodeChangeEvent;
@@ -1403,6 +1404,17 @@ public class CVTerm extends AnnotationElement {
    */
   public void setUnknownQualifierName(String unknownQualifierName) {
     this.unknownQualifierName = unknownQualifierName;
+  }
+
+  /**
+   * Accepts a generic visitor to traverse this component.
+   *
+   * @param <T> the return type of the visitor
+   * @param visitor the visitor implementation
+   * @return the result of the visitor operation
+   */
+  public <T> T accept(TreeNodeVisitor<T> visitor) {
+    return visitor.visit(this);
   }
 
 }

--- a/core/src/org/sbml/jsbml/Creator.java
+++ b/core/src/org/sbml/jsbml/Creator.java
@@ -550,4 +550,15 @@ public class Creator extends AnnotationElement {
     firePropertyChange(TreeNodeChangeEvent.organization, oldValue, organisation);
   }
 
+  /**
+   * Accepts a generic visitor to traverse this component.
+   *
+   * @param <T> the return type of the visitor
+   * @param visitor the visitor implementation
+   * @return the result of the visitor operation
+   */
+  public <T> T accept(TreeNodeVisitor<T> visitor) {
+    return visitor.visit(this);
+  }
+
 }

--- a/core/src/org/sbml/jsbml/History.java
+++ b/core/src/org/sbml/jsbml/History.java
@@ -506,4 +506,16 @@ public class History extends AnnotationElement {
 	}
     return result.toString();
   }
+
+  /**
+   * Accepts a generic visitor to traverse this component.
+   *
+   * @param <T> the return type of the visitor
+   * @param visitor the visitor implementation
+   * @return the result of the visitor operation
+   */
+  public <T> T accept(TreeNodeVisitor<T> visitor) {
+    return visitor.visit(this);
+  }
+  
 }

--- a/core/src/org/sbml/jsbml/TreeNodeVisitor.java
+++ b/core/src/org/sbml/jsbml/TreeNodeVisitor.java
@@ -1,0 +1,30 @@
+package org.sbml.jsbml;
+
+import org.sbml.jsbml.util.TreeNodeWithChangeSupport;
+/**
+ * A generic visitor interface for traversing the JSBML tree structure.
+ * This allows external classes to operate on SBML components without 
+ * modifying the core classes.
+ *
+ * @param <T> The return type of the visitor operations.
+ * @author Deepak Yadav
+ */
+public interface TreeNodeVisitor<T> {
+
+    /**
+     * Primary traversal method for core SBML components.
+     *
+     * @param sbase the core SBML element to visit
+     * @return a result of type T
+     */
+    T visit(SBase sbase);
+
+    /**
+     * Fallback traversal method for auxiliary nodes (e.g., annotations, notes)
+     * that do not inherit from SBase but do inherit from TreeNodeWithChangeSupport.
+     *
+     * @param node the tree node to visit
+     * @return a result of type T
+     */
+    T visit(TreeNodeWithChangeSupport node);
+}

--- a/core/src/org/sbml/jsbml/TreeNodeVisitor.java
+++ b/core/src/org/sbml/jsbml/TreeNodeVisitor.java
@@ -1,12 +1,14 @@
 package org.sbml.jsbml;
 
 import org.sbml.jsbml.util.TreeNodeWithChangeSupport;
+
 /**
  * A generic visitor interface for traversing the JSBML tree structure.
- * This allows external classes to operate on SBML components without 
+ * This allows external classes to operate on SBML components without
  * modifying the core classes.
  *
- * @param <T> The return type of the visitor operations.
+ * @param <T> The return type of the visitor operations. Note that this generic 
+ * type may also be {@link Void} if nothing is to be returned.
  * @author Deepak Yadav
  */
 public interface TreeNodeVisitor<T> {

--- a/core/src/org/sbml/jsbml/ext/AbstractASTNodePlugin.java
+++ b/core/src/org/sbml/jsbml/ext/AbstractASTNodePlugin.java
@@ -31,6 +31,7 @@ import org.sbml.jsbml.ASTNode;
 import org.sbml.jsbml.AbstractTreeNode;
 import org.sbml.jsbml.SBMLDocument;
 import org.sbml.jsbml.SBase;
+import org.sbml.jsbml.TreeNodeVisitor;
 import org.sbml.jsbml.util.TreeNodeChangeEvent;
 
 /**
@@ -363,7 +364,7 @@ public abstract class AbstractASTNodePlugin extends AbstractTreeNode implements 
      * @return the result of the visitor operation
      */
     @Override
-    public <T> T accept(org.sbml.jsbml.TreeNodeVisitor<T> visitor) {
+    public <T> T accept(TreeNodeVisitor<T> visitor) {
         return visitor.visit(this);
     }
 

--- a/core/src/org/sbml/jsbml/ext/AbstractASTNodePlugin.java
+++ b/core/src/org/sbml/jsbml/ext/AbstractASTNodePlugin.java
@@ -355,4 +355,16 @@ public abstract class AbstractASTNodePlugin extends AbstractTreeNode implements 
     return new TreeMap<String, String>();
   }
 
+  /**
+     * Accepts a generic visitor to traverse this component.
+     *
+     * @param <T> the return type of the visitor
+     * @param visitor the visitor implementation
+     * @return the result of the visitor operation
+     */
+    @Override
+    public <T> T accept(org.sbml.jsbml.TreeNodeVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+
 }

--- a/core/src/org/sbml/jsbml/ext/AbstractSBasePlugin.java
+++ b/core/src/org/sbml/jsbml/ext/AbstractSBasePlugin.java
@@ -327,4 +327,16 @@ public abstract class AbstractSBasePlugin extends AbstractTreeNode implements SB
     return new TreeMap<String, String>();
   }
 
+  /**
+     * Accepts a generic visitor to traverse this component.
+     *
+     * @param <T> the return type of the visitor
+     * @param visitor the visitor implementation
+     * @return the result of the visitor operation
+     */
+    @Override
+    public <T> T accept(org.sbml.jsbml.TreeNodeVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+
 }

--- a/core/src/org/sbml/jsbml/ext/AbstractSBasePlugin.java
+++ b/core/src/org/sbml/jsbml/ext/AbstractSBasePlugin.java
@@ -30,6 +30,7 @@ import org.apache.log4j.Logger;
 import org.sbml.jsbml.AbstractTreeNode;
 import org.sbml.jsbml.SBMLDocument;
 import org.sbml.jsbml.SBase;
+import org.sbml.jsbml.TreeNodeVisitor;
 import org.sbml.jsbml.util.TreeNodeChangeEvent;
 
 /**
@@ -335,7 +336,7 @@ public abstract class AbstractSBasePlugin extends AbstractTreeNode implements SB
      * @return the result of the visitor operation
      */
     @Override
-    public <T> T accept(org.sbml.jsbml.TreeNodeVisitor<T> visitor) {
+    public <T> T accept(TreeNodeVisitor<T> visitor) {
         return visitor.visit(this);
     }
 

--- a/core/src/org/sbml/jsbml/math/ASTBoolean.java
+++ b/core/src/org/sbml/jsbml/math/ASTBoolean.java
@@ -24,6 +24,7 @@ import org.apache.log4j.Logger;
 import org.sbml.jsbml.ASTNode.Type;
 import org.sbml.jsbml.PropertyUndefinedError;
 import org.sbml.jsbml.SBMLException;
+import org.sbml.jsbml.TreeNodeVisitor;
 import org.sbml.jsbml.math.compiler.ASTNode2Compiler;
 import org.sbml.jsbml.math.compiler.ASTNode2Value;
 import org.sbml.jsbml.math.compiler.FormulaCompiler;
@@ -195,6 +196,17 @@ public class ASTBoolean extends AbstractASTNode {
       logger.error("Unable to create MathML");
       return null;
     }
+  }
+
+  /**
+   * Accepts a generic visitor to traverse this component.
+   *
+   * @param <T> the return type of the visitor
+   * @param visitor the visitor implementation
+   * @return the result of the visitor operation
+   */
+  public <T> T accept(TreeNodeVisitor<T> visitor) {
+    return visitor.visit(this);
   }
 
 }

--- a/core/src/org/sbml/jsbml/math/ASTCSymbolAvogadroNode.java
+++ b/core/src/org/sbml/jsbml/math/ASTCSymbolAvogadroNode.java
@@ -24,6 +24,7 @@ import org.apache.log4j.Logger;
 import org.sbml.jsbml.ASTNode;
 import org.sbml.jsbml.ASTNode.Type;
 import org.sbml.jsbml.PropertyUndefinedError;
+import org.sbml.jsbml.TreeNodeVisitor;
 import org.sbml.jsbml.math.compiler.ASTNode2Compiler;
 import org.sbml.jsbml.math.compiler.ASTNode2Value;
 import org.sbml.jsbml.util.Maths;
@@ -314,6 +315,17 @@ ASTCSymbolNode {
     String old = this.name;
     this.name = name;
     firePropertyChange(TreeNodeChangeEvent.name, old, this.name);
+  }
+
+  /**
+   * Accepts a generic visitor to traverse this component.
+   *
+   * @param <T> the return type of the visitor
+   * @param visitor the visitor implementation
+   * @return the result of the visitor operation
+   */
+  public <T> T accept(TreeNodeVisitor<T> visitor) {
+    return visitor.visit(this);
   }
 
 }

--- a/core/src/org/sbml/jsbml/math/ASTCSymbolDelayNode.java
+++ b/core/src/org/sbml/jsbml/math/ASTCSymbolDelayNode.java
@@ -25,6 +25,7 @@ import org.sbml.jsbml.ASTNode;
 import org.sbml.jsbml.ASTNode.Type;
 import org.sbml.jsbml.PropertyUndefinedError;
 import org.sbml.jsbml.SBMLException;
+import org.sbml.jsbml.TreeNodeVisitor;
 import org.sbml.jsbml.math.compiler.ASTNode2Compiler;
 import org.sbml.jsbml.math.compiler.ASTNode2Value;
 import org.sbml.jsbml.math.compiler.FormulaCompiler;
@@ -287,6 +288,17 @@ ASTCSymbolNode {
       logger.error("Unable to create MathML");
       return null;
     }
+  }
+
+  /**
+   * Accepts a generic visitor to traverse this component.
+   *
+   * @param <T> the return type of the visitor
+   * @param visitor the visitor implementation
+   * @return the result of the visitor operation
+   */
+  public <T> T accept(TreeNodeVisitor<T> visitor) {
+    return visitor.visit(this);
   }
 
 }

--- a/core/src/org/sbml/jsbml/math/ASTCSymbolTimeNode.java
+++ b/core/src/org/sbml/jsbml/math/ASTCSymbolTimeNode.java
@@ -25,6 +25,7 @@ import org.sbml.jsbml.ASTNode;
 import org.sbml.jsbml.ASTNode.Type;
 import org.sbml.jsbml.PropertyUndefinedError;
 import org.sbml.jsbml.SBMLException;
+import org.sbml.jsbml.TreeNodeVisitor;
 import org.sbml.jsbml.math.compiler.ASTNode2Compiler;
 import org.sbml.jsbml.math.compiler.ASTNode2Value;
 import org.sbml.jsbml.math.compiler.FormulaCompiler;
@@ -311,6 +312,17 @@ implements ASTCSymbolNode {
       logger.error("Unable to create MathML");
       return null;
     }
+  }
+
+  /**
+   * Accepts a generic visitor to traverse this component.
+   *
+   * @param <T> the return type of the visitor
+   * @param visitor the visitor implementation
+   * @return the result of the visitor operation
+   */
+  public <T> T accept(TreeNodeVisitor<T> visitor) {
+    return visitor.visit(this);
   }
 
 }

--- a/core/src/org/sbml/jsbml/math/ASTCiFunctionNode.java
+++ b/core/src/org/sbml/jsbml/math/ASTCiFunctionNode.java
@@ -28,6 +28,7 @@ import org.sbml.jsbml.FunctionDefinition;
 import org.sbml.jsbml.Model;
 import org.sbml.jsbml.PropertyUndefinedError;
 import org.sbml.jsbml.SBMLException;
+import org.sbml.jsbml.TreeNodeVisitor;
 import org.sbml.jsbml.math.compiler.ASTNode2Compiler;
 import org.sbml.jsbml.math.compiler.ASTNode2Value;
 import org.sbml.jsbml.math.compiler.FormulaCompiler;
@@ -365,6 +366,17 @@ ASTCSymbolBaseNode {
       logger.error("Unable to create MathML");
       return null;
     }
+  }
+
+  /**
+   * Accepts a generic visitor to traverse this component.
+   *
+   * @param <T> the return type of the visitor
+   * @param visitor the visitor implementation
+   * @return the result of the visitor operation
+   */
+  public <T> T accept(TreeNodeVisitor<T> visitor) {
+    return visitor.visit(this);
   }
 
 }

--- a/core/src/org/sbml/jsbml/math/ASTCiNumberNode.java
+++ b/core/src/org/sbml/jsbml/math/ASTCiNumberNode.java
@@ -31,6 +31,7 @@ import org.sbml.jsbml.Model;
 import org.sbml.jsbml.PropertyUndefinedError;
 import org.sbml.jsbml.QuantityWithUnit;
 import org.sbml.jsbml.SBMLException;
+import org.sbml.jsbml.TreeNodeVisitor;
 import org.sbml.jsbml.math.compiler.ASTNode2Compiler;
 import org.sbml.jsbml.math.compiler.ASTNode2Value;
 import org.sbml.jsbml.math.compiler.FormulaCompiler;
@@ -381,6 +382,17 @@ ASTCSymbolBaseNode {
       logger.error("Unable to create MathML");
       return null;
     }
+  }
+
+  /**
+   * Accepts a generic visitor to traverse this component.
+   *
+   * @param <T> the return type of the visitor
+   * @param visitor the visitor implementation
+   * @return the result of the visitor operation
+   */
+  public <T> T accept(TreeNodeVisitor<T> visitor) {
+    return visitor.visit(this);
   }
 
 }

--- a/core/src/org/sbml/jsbml/math/ASTCnNumberNode.java
+++ b/core/src/org/sbml/jsbml/math/ASTCnNumberNode.java
@@ -26,6 +26,7 @@ import org.sbml.jsbml.MathContainer;
 import org.sbml.jsbml.Model;
 import org.sbml.jsbml.PropertyUndefinedError;
 import org.sbml.jsbml.SBMLException;
+import org.sbml.jsbml.TreeNodeVisitor;
 import org.sbml.jsbml.Unit;
 import org.sbml.jsbml.UnitDefinition;
 import org.sbml.jsbml.math.compiler.ASTNode2Compiler;
@@ -386,6 +387,17 @@ public class ASTCnNumberNode<T> extends ASTNumber {
     String oldValue = units;
     units = null;
     firePropertyChange(TreeNodeChangeEvent.units, oldValue, null);
+  }
+
+  /**
+   * Accepts a generic visitor to traverse this component.
+   *
+   * @param <T> the return type of the visitor
+   * @param visitor the visitor implementation
+   * @return the result of the visitor operation
+   */
+  public <T> T accept(TreeNodeVisitor<T> visitor) {
+    return visitor.visit(this);
   }
 
 }

--- a/core/src/org/sbml/jsbml/math/ASTConstantNumber.java
+++ b/core/src/org/sbml/jsbml/math/ASTConstantNumber.java
@@ -24,6 +24,7 @@ import org.apache.log4j.Logger;
 import org.sbml.jsbml.ASTNode.Type;
 import org.sbml.jsbml.PropertyUndefinedError;
 import org.sbml.jsbml.SBMLException;
+import org.sbml.jsbml.TreeNodeVisitor;
 import org.sbml.jsbml.math.compiler.ASTNode2Compiler;
 import org.sbml.jsbml.math.compiler.ASTNode2Value;
 import org.sbml.jsbml.math.compiler.FormulaCompiler;
@@ -217,6 +218,17 @@ public class ASTConstantNumber extends ASTNumber {
       logger.error("Unable to create MathML");
       return null;
     }
+  }
+
+  /**
+   * Accepts a generic visitor to traverse this component.
+   *
+   * @param <T> the return type of the visitor
+   * @param visitor the visitor implementation
+   * @return the result of the visitor operation
+   */
+  public <T> T accept(TreeNodeVisitor<T> visitor) {
+    return visitor.visit(this);
   }
 
 }

--- a/core/src/org/sbml/jsbml/math/ASTFunction.java
+++ b/core/src/org/sbml/jsbml/math/ASTFunction.java
@@ -28,6 +28,7 @@ import org.sbml.jsbml.ASTNode.Type;
 import org.sbml.jsbml.CallableSBase;
 import org.sbml.jsbml.MathContainer;
 import org.sbml.jsbml.PropertyUndefinedError;
+import org.sbml.jsbml.TreeNodeVisitor;
 import org.sbml.jsbml.math.compiler.ASTNode2Compiler;
 import org.sbml.jsbml.math.compiler.ASTNode2Value;
 import org.sbml.jsbml.util.TreeNodeChangeEvent;
@@ -517,6 +518,17 @@ public class ASTFunction extends AbstractASTNode {
     List<ASTNode2> swap = that.listOfNodes;
     that.listOfNodes = listOfNodes;
     listOfNodes = swap;
+  }
+
+  /**
+   * Accepts a generic visitor to traverse this component.
+   *
+   * @param <T> the return type of the visitor
+   * @param visitor the visitor implementation
+   * @return the result of the visitor operation
+   */
+  public <T> T accept(TreeNodeVisitor<T> visitor) {
+    return visitor.visit(this);
   }
 
 }

--- a/core/src/org/sbml/jsbml/math/ASTUnknown.java
+++ b/core/src/org/sbml/jsbml/math/ASTUnknown.java
@@ -29,6 +29,7 @@ import javax.swing.tree.TreeNode;
 
 import org.sbml.jsbml.ASTNode.Type;
 import org.sbml.jsbml.MathContainer;
+import org.sbml.jsbml.TreeNodeVisitor;
 import org.sbml.jsbml.math.compiler.ASTNode2Compiler;
 import org.sbml.jsbml.math.compiler.ASTNode2Value;
 import org.sbml.jsbml.util.TreeNodeChangeListener;
@@ -618,6 +619,17 @@ public class ASTUnknown implements ASTNode2 {
     Collection<TreeNodeChangeListener> listeners, boolean recursive) {
     // TODO Auto-generated method stub
     return false;
+  }
+
+  /**
+   * Accepts a generic visitor to traverse this component.
+   *
+   * @param <T> the return type of the visitor
+   * @param visitor the visitor implementation
+   * @return the result of the visitor operation
+   */
+  public <T> T accept(TreeNodeVisitor<T> visitor) {
+    return visitor.visit(this);
   }
 
 }

--- a/core/src/org/sbml/jsbml/util/TreeNodeAdapter.java
+++ b/core/src/org/sbml/jsbml/util/TreeNodeAdapter.java
@@ -32,6 +32,7 @@ import javax.swing.tree.TreeNode;
 
 import org.sbml.jsbml.AbstractTreeNode;
 import org.sbml.jsbml.ListOf;
+import org.sbml.jsbml.TreeNodeVisitor;
 
 /**
  * <p>
@@ -294,6 +295,17 @@ public class TreeNodeAdapter extends AbstractTreeNode {
       return userObject.toString();
     }
     return super.toString();
+  }
+
+  /**
+   * Accepts a generic visitor to traverse this component.
+   *
+   * @param <T> the return type of the visitor
+   * @param visitor the visitor implementation
+   * @return the result of the visitor operation
+   */
+  public <T> T accept(TreeNodeVisitor<T> visitor) {
+    return visitor.visit(this);
   }
 
 }

--- a/core/src/org/sbml/jsbml/util/TreeNodeWithChangeSupport.java
+++ b/core/src/org/sbml/jsbml/util/TreeNodeWithChangeSupport.java
@@ -28,6 +28,7 @@ import java.util.Set;
 
 import javax.swing.tree.TreeNode;
 
+import org.sbml.jsbml.TreeNodeVisitor;
 import org.sbml.jsbml.util.filters.Filter;
 
 /**
@@ -320,5 +321,14 @@ Serializable {
    */
   public boolean addAllChangeListeners(
     Collection<TreeNodeChangeListener> listeners, boolean recursive);
+
+  /**
+   * Accepts a generic visitor to traverse this node.
+   *
+   * @param <T> the return type of the visitor
+   * @param visitor the visitor implementation
+   * @return the result of the visitor operation
+   */
+  public <T> T accept(TreeNodeVisitor<T> visitor);
 
 }

--- a/core/src/org/sbml/jsbml/xml/XMLNode.java
+++ b/core/src/org/sbml/jsbml/xml/XMLNode.java
@@ -28,6 +28,7 @@ import java.util.List;
 import javax.xml.stream.XMLStreamException;
 
 import org.sbml.jsbml.JSBML;
+import org.sbml.jsbml.TreeNodeVisitor;
 import org.sbml.jsbml.xml.parsers.SBMLRDFAnnotationParser;
 import org.sbml.jsbml.xml.parsers.XMLNodeWriter;
 import org.sbml.jsbml.xml.stax.SBMLReader;
@@ -766,6 +767,17 @@ public class XMLNode extends XMLToken {
     }
 
     return foundNodes;
+  }
+
+  /**
+   * Accepts a generic visitor to traverse this component.
+   *
+   * @param <T> the return type of the visitor
+   * @param visitor the visitor implementation
+   * @return the result of the visitor operation
+   */
+  public <T> T accept(TreeNodeVisitor<T> visitor) {
+    return visitor.visit(this);
   }
 
 }

--- a/core/test/org/sbml/jsbml/TreeNodeVisitorTest.java
+++ b/core/test/org/sbml/jsbml/TreeNodeVisitorTest.java
@@ -1,0 +1,53 @@
+package org.sbml.jsbml;
+
+import org.junit.Test;
+import org.sbml.jsbml.util.TreeNodeWithChangeSupport;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for the {@link TreeNodeVisitor} scaffolding.
+ * Ensures the generic Visitor Pattern interfaces can be implemented and traversed.
+ *
+ * @author Deepak Yadav
+ */
+public class TreeNodeVisitorTest {
+
+    /**
+     * A simple dummy implementation to prove the generic interface works.
+     * We use Integer as our <T> to act as a visit counter.
+     */
+    class DummyVisitor implements TreeNodeVisitor<Integer> {
+        int nodesVisited = 0;
+
+        @Override
+        public Integer visit(SBase sbase) {
+            nodesVisited++;
+            return nodesVisited;
+        }
+
+        @Override
+        public Integer visit(TreeNodeWithChangeSupport node) {
+            nodesVisited++;
+            return nodesVisited;
+        }
+    }
+
+    @Test
+    public void testVisitorAcceptance() {
+        // Instantiate our custom visitor
+        DummyVisitor visitor = new DummyVisitor();
+        
+        // ASTNode is one of the core components that received the accept() method in PR #312
+        ASTNode dummyNode = new ASTNode(ASTNode.Type.PLUS);
+        
+        // Execute the accept method. This proves that ASTNode can take a TreeNodeVisitor,
+        // route it to the correct visit() method, and return the generic <T> type.
+        Integer result = dummyNode.accept(visitor);
+        
+        // Verify the visitor successfully entered the node and updated its internal state
+        assertEquals("Visitor should have recorded exactly 1 visit", 1, visitor.nodesVisited);
+        
+        // Verify that the accept() method successfully returned the <T> (Integer) value
+        assertEquals("The accept method should return the value from the visitor", Integer.valueOf(1), result);
+    }
+}

--- a/extensions/render/src/org/sbml/jsbml/ext/render/RelAbsVector.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/RelAbsVector.java
@@ -22,6 +22,7 @@ package org.sbml.jsbml.ext.render;
 import javax.swing.tree.TreeNode;
 
 import org.sbml.jsbml.AbstractTreeNode;
+import org.sbml.jsbml.ext.layout.BoundingBox;
 
 /**
  * Implements the RelAbsVector-datatype defined in the render-specification:
@@ -327,4 +328,17 @@ public class RelAbsVector extends AbstractTreeNode {
   public boolean getAllowsChildren() {
     return false;
   }
+
+  /**
+     * Accepts a generic visitor to traverse this component.
+     *
+     * @param <T> the return type of the visitor
+     * @param visitor the visitor implementation
+     * @return the result of the visitor operation
+     */
+    @Override
+    public <T> T accept(org.sbml.jsbml.TreeNodeVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+
 }

--- a/extensions/render/src/org/sbml/jsbml/ext/render/RelAbsVector.java
+++ b/extensions/render/src/org/sbml/jsbml/ext/render/RelAbsVector.java
@@ -22,6 +22,7 @@ package org.sbml.jsbml.ext.render;
 import javax.swing.tree.TreeNode;
 
 import org.sbml.jsbml.AbstractTreeNode;
+import org.sbml.jsbml.TreeNodeVisitor;
 import org.sbml.jsbml.ext.layout.BoundingBox;
 
 /**
@@ -337,7 +338,7 @@ public class RelAbsVector extends AbstractTreeNode {
      * @return the result of the visitor operation
      */
     @Override
-    public <T> T accept(org.sbml.jsbml.TreeNodeVisitor<T> visitor) {
+    public <T> T accept(TreeNodeVisitor<T> visitor) {
         return visitor.visit(this);
     }
 


### PR DESCRIPTION
### Description
This PR implements the foundational architecture for the `TreeNodeVisitor` pattern discussed in #262. It provides a clean, generic way to traverse the JSBML AST without modifying core classes for every new feature.

### Key Changes
* **`TreeNodeVisitor<T>`:** Created the core interface with `visit(SBase)` as the primary method and `visit(TreeNodeWithChangeSupport)` as the fallback for auxiliary nodes.
* **`TreeNodeWithChangeSupport`:** Added the `<T> T accept(TreeNodeVisitor<T> visitor)` contract to the root interface.
* **Java 7 Compliance:** Since JSBML enforces Java 7 (which does not support `default` interface methods), the `accept` method implementation has been explicitly injected into the 18 required base classes (e.g., `AbstractSBase`, `ASTNode`, `XMLNode`, and the various math nodes).

All core tests are passing cleanly locally. 

This PR serves purely as the structural scaffolding. Once this architecture is approved and merged, we can begin adapting tools like the `AntimonySerializer` to actively utilize this visitor!