### PR TITLE
Fix: Integrate offline validation for SBase unit assignments

### DIFF
--- a/core/src/org/sbml/jsbml/AbstractNamedSBaseWithUnit.java
+++ b/core/src/org/sbml/jsbml/AbstractNamedSBaseWithUnit.java
@@ -317,7 +317,6 @@ implements NamedSBaseWithDerivedUnit, SBaseWithUnit {
             if (error != null) {
               doc.getErrorLog().add(error);
             }
-            if (setLevelAndVersion(isSetNotes())) {
           } else {
             unitsID = oldUnits;
             throw new IllegalArgumentException(MessageFormat.format(

--- a/core/src/org/sbml/jsbml/AbstractNamedSBaseWithUnit.java
+++ b/core/src/org/sbml/jsbml/AbstractNamedSBaseWithUnit.java
@@ -317,7 +317,9 @@ implements NamedSBaseWithDerivedUnit, SBaseWithUnit {
             if (error != null) {
               doc.getErrorLog().add(error);
             }
+            if (setLevelAndVersion(isSetNotes())) {
           } else {
+            unitsID = oldUnits;
             throw new IllegalArgumentException(MessageFormat.format(
               JSBML.ILLEGAL_UNIT_EXCEPTION_MSG, units));
           }

--- a/core/src/org/sbml/jsbml/AbstractNamedSBaseWithUnit.java
+++ b/core/src/org/sbml/jsbml/AbstractNamedSBaseWithUnit.java
@@ -24,6 +24,7 @@ import java.text.MessageFormat;
 import org.apache.log4j.Logger;
 import org.sbml.jsbml.Unit.Kind;
 import org.sbml.jsbml.util.TreeNodeChangeEvent;
+import org.sbml.jsbml.validator.offline.factory.SBMLErrorCodes;
 
 /**
  * This simple implementation of the interfaces
@@ -283,7 +284,7 @@ implements NamedSBaseWithDerivedUnit, SBaseWithUnit {
   @Override
   public void setUnits(String units) {
     if ((units != null) && (units.trim().length() == 0)) {
-      units = null; // If we pass the empty String or null, the value is reset.
+      units = null;
     }
 
     String oldUnits = unitsID;
@@ -292,24 +293,32 @@ implements NamedSBaseWithDerivedUnit, SBaseWithUnit {
       unitsID = null;
     } else {
       units = units.trim();
+      unitsID = units;
 
       boolean illegalArgument = false;
 
       if (!Unit.isValidUnit(getModel(), units)) {
-        illegalArgument = true; // TODO - make use of the offline validation once attributes validation is in place.
+        illegalArgument = true;
       }
+      
       if (illegalArgument) {
         if (!isReadingInProgress()) {
-          throw new IllegalArgumentException(MessageFormat.format(
-            JSBML.ILLEGAL_UNIT_EXCEPTION_MSG, units));
+          SBMLDocument doc = getSBMLDocument();
+          if (doc != null && doc.getErrorLog() != null) {
+            doc.getErrorLog().add(new SBMLError(
+              MessageFormat.format(JSBML.ILLEGAL_UNIT_EXCEPTION_MSG, units)
+            ));
+          } else {
+            throw new IllegalArgumentException(MessageFormat.format(
+              JSBML.ILLEGAL_UNIT_EXCEPTION_MSG, units));
+          }
         } else {
           logger.info(MessageFormat.format(JSBML.ILLEGAL_UNIT_EXCEPTION_MSG, units));
         }
       }
-      unitsID = units;
     }
 
-    if (oldUnits != unitsID) {
+    if (oldUnits != null ? !oldUnits.equals(unitsID) : unitsID != null) {
       firePropertyChange(TreeNodeChangeEvent.units, oldUnits, unitsID);
     }
   }

--- a/core/src/org/sbml/jsbml/AbstractNamedSBaseWithUnit.java
+++ b/core/src/org/sbml/jsbml/AbstractNamedSBaseWithUnit.java
@@ -25,6 +25,7 @@ import org.apache.log4j.Logger;
 import org.sbml.jsbml.Unit.Kind;
 import org.sbml.jsbml.util.TreeNodeChangeEvent;
 import org.sbml.jsbml.validator.SyntaxChecker;
+import org.sbml.jsbml.validator.offline.factory.SBMLErrorCodes;
 import org.sbml.jsbml.validator.offline.factory.SBMLErrorFactory;
 
 /**
@@ -296,7 +297,6 @@ implements NamedSBaseWithDerivedUnit, SBaseWithUnit {
       units = units.trim();
       unitsID = units;
 
-      // Use the generic SId syntax checker with the current level and version
       boolean isSyntaxValid = SyntaxChecker.isValidId(units, getLevel(), getVersion());
       boolean isReferenceValid = isSyntaxValid && Unit.isValidUnit(getModel(), units);
 
@@ -304,13 +304,19 @@ implements NamedSBaseWithDerivedUnit, SBaseWithUnit {
         if (!isReadingInProgress()) {
           SBMLDocument doc = getSBMLDocument();
           if (doc != null && doc.getErrorLog() != null) {
-            int errorCode = !isSyntaxValid ? 10311 : 10313;
+            int errorCode = !isSyntaxValid ? SBMLErrorCodes.CORE_10311 : SBMLErrorCodes.CORE_10313;
             
-            doc.getErrorLog().add(SBMLErrorFactory.createError(
+            org.sbml.jsbml.SBMLError error = SBMLErrorFactory.createError(
               errorCode, 
               getLevel(), 
-              getVersion()
-            ));
+              getVersion(),
+              false, // Let the factory fetch the official SBML specification message!
+              this
+            );
+
+            if (error != null) {
+              doc.getErrorLog().add(error);
+            }
           } else {
             throw new IllegalArgumentException(MessageFormat.format(
               JSBML.ILLEGAL_UNIT_EXCEPTION_MSG, units));

--- a/core/src/org/sbml/jsbml/AbstractNamedSBaseWithUnit.java
+++ b/core/src/org/sbml/jsbml/AbstractNamedSBaseWithUnit.java
@@ -24,7 +24,8 @@ import java.text.MessageFormat;
 import org.apache.log4j.Logger;
 import org.sbml.jsbml.Unit.Kind;
 import org.sbml.jsbml.util.TreeNodeChangeEvent;
-import org.sbml.jsbml.validator.offline.factory.SBMLErrorCodes;
+import org.sbml.jsbml.validator.SyntaxChecker;
+import org.sbml.jsbml.validator.offline.factory.SBMLErrorFactory;
 
 /**
  * This simple implementation of the interfaces
@@ -295,18 +296,20 @@ implements NamedSBaseWithDerivedUnit, SBaseWithUnit {
       units = units.trim();
       unitsID = units;
 
-      boolean illegalArgument = false;
+      // Use the generic SId syntax checker with the current level and version
+      boolean isSyntaxValid = SyntaxChecker.isValidId(units, getLevel(), getVersion());
+      boolean isReferenceValid = isSyntaxValid && Unit.isValidUnit(getModel(), units);
 
-      if (!Unit.isValidUnit(getModel(), units)) {
-        illegalArgument = true;
-      }
-      
-      if (illegalArgument) {
+      if (!isSyntaxValid || !isReferenceValid) {
         if (!isReadingInProgress()) {
           SBMLDocument doc = getSBMLDocument();
           if (doc != null && doc.getErrorLog() != null) {
-            doc.getErrorLog().add(new SBMLError(
-              MessageFormat.format(JSBML.ILLEGAL_UNIT_EXCEPTION_MSG, units)
+            int errorCode = !isSyntaxValid ? 10311 : 10313;
+            
+            doc.getErrorLog().add(SBMLErrorFactory.createError(
+              errorCode, 
+              getLevel(), 
+              getVersion()
             ));
           } else {
             throw new IllegalArgumentException(MessageFormat.format(

--- a/core/src/org/sbml/jsbml/AbstractNamedSBaseWithUnit.java
+++ b/core/src/org/sbml/jsbml/AbstractNamedSBaseWithUnit.java
@@ -298,19 +298,36 @@ implements NamedSBaseWithDerivedUnit, SBaseWithUnit {
       unitsID = units;
 
       boolean isSyntaxValid = SyntaxChecker.isValidId(units, getLevel(), getVersion());
-      boolean isReferenceValid = isSyntaxValid && Unit.isValidUnit(getModel(), units);
+      
+      boolean isReferenceValid = false;
+      if (isSyntaxValid) {
+        Model m = getModel();
+        boolean definedInModel = (m != null) && (m.getUnitDefinition(units) != null);
+        isReferenceValid = definedInModel
+            || Unit.isUnitKind(units, getLevel(), getVersion())
+            || Unit.isPredefined(units, getLevel());
+      }
 
       if (!isSyntaxValid || !isReferenceValid) {
         if (!isReadingInProgress()) {
           SBMLDocument doc = getSBMLDocument();
           if (doc != null && doc.getErrorLog() != null) {
-            int errorCode = !isSyntaxValid ? SBMLErrorCodes.CORE_10311 : SBMLErrorCodes.CORE_10313;
+            int errorCode;
+            if (!isSyntaxValid) {
+              errorCode = SBMLErrorCodes.CORE_10311;
+            } else {
+              if (getLevel() > 2 || (getLevel() == 2 && getVersion() >= 5)) {
+                errorCode = SBMLErrorCodes.CORE_10313;
+              } else {
+                errorCode = SBMLErrorCodes.CORE_99303;
+              }
+            }
             
             org.sbml.jsbml.SBMLError error = SBMLErrorFactory.createError(
               errorCode, 
               getLevel(), 
               getVersion(),
-              false, // Let the factory fetch the official SBML specification message!
+              false,
               this
             );
 

--- a/core/test/org/sbml/jsbml/xml/test/TestAbstractNamedSBaseWithUnits.java
+++ b/core/test/org/sbml/jsbml/xml/test/TestAbstractNamedSBaseWithUnits.java
@@ -139,6 +139,8 @@ public class TestAbstractNamedSBaseWithUnits {
     int initialErrorCount = doc.getErrorLog().getErrorCount();
     sbase.setUnits("123 invalid syntax!"); // Malformed SId
     org.junit.Assert.assertEquals("Error count should increment", initialErrorCount + 1, doc.getErrorLog().getErrorCount());
+    org.junit.Assert.assertEquals("Should log CORE_10311 for invalid UnitSId syntax",
+      (long) SBMLErrorCodes.CORE_10311, (long) doc.getErrorLog().getError(initialErrorCount).getCode());
   }
 
   /**
@@ -151,6 +153,8 @@ public class TestAbstractNamedSBaseWithUnits {
     int initialErrorCount = doc.getErrorLog().getErrorCount();
     sbase.setUnits("valid_syntax_but_missing"); // Valid SId, but not defined in model or built-ins
     org.junit.Assert.assertEquals("Error count should increment", initialErrorCount + 1, doc.getErrorLog().getErrorCount());
+    org.junit.Assert.assertEquals("Should log CORE_10313 for missing unit reference",
+      (long) SBMLErrorCodes.CORE_10313, (long) doc.getErrorLog().getError(initialErrorCount).getCode());
   }
 
   /**

--- a/core/test/org/sbml/jsbml/xml/test/TestAbstractNamedSBaseWithUnits.java
+++ b/core/test/org/sbml/jsbml/xml/test/TestAbstractNamedSBaseWithUnits.java
@@ -26,9 +26,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.sbml.jsbml.AbstractNamedSBaseWithUnit;
 import org.sbml.jsbml.Model;
+import org.sbml.jsbml.Parameter;
 import org.sbml.jsbml.SBMLDocument;
 import org.sbml.jsbml.Unit;
 import org.sbml.jsbml.UnitDefinition;
+import org.sbml.jsbml.validator.offline.factory.SBMLErrorCodes;
 
 
 /**
@@ -125,6 +127,40 @@ public class TestAbstractNamedSBaseWithUnits {
   @Test
   public void testIsPredefinedUnitsID() {
     assertTrue(!sbase.isPredefinedUnitsID(kind.toString().toLowerCase()));
+  }
+
+  /**
+   * Test method for {@link org.sbml.jsbml.AbstractNamedSBaseWithUnit#setUnits(java.lang.String)}
+   * when an invalid unit syntax is set on an attached node.
+   */
+  @Test
+  public void testSetInvalidUnitSyntaxWithDocumentLogsError() {
+    SBMLDocument doc = sbase.getSBMLDocument();
+    int initialErrorCount = doc.getErrorLog().getErrorCount();
+    sbase.setUnits("123 invalid syntax!"); // Malformed SId
+    org.junit.Assert.assertEquals("Error count should increment", initialErrorCount + 1, doc.getErrorLog().getErrorCount());
+  }
+
+  /**
+   * Test method for {@link org.sbml.jsbml.AbstractNamedSBaseWithUnit#setUnits(java.lang.String)}
+   * when an undefined unit is set on an attached node.
+   */
+  @Test
+  public void testSetMissingUnitReferenceWithDocumentLogsError() {
+    SBMLDocument doc = sbase.getSBMLDocument();
+    int initialErrorCount = doc.getErrorLog().getErrorCount();
+    sbase.setUnits("valid_syntax_but_missing"); // Valid SId, but not defined in model or built-ins
+    org.junit.Assert.assertEquals("Error count should increment", initialErrorCount + 1, doc.getErrorLog().getErrorCount());
+  }
+
+  /**
+   * Test method for {@link org.sbml.jsbml.AbstractNamedSBaseWithUnit#setUnits(java.lang.String)}
+   * when an invalid unit is set on an isolated node.
+   */
+  @Test(expected = IllegalArgumentException.class)
+  public void testSetInvalidUnitWithoutDocumentThrowsException() {
+    Parameter isolatedParam = new Parameter(3, 1);
+    isolatedParam.setUnits("invalid syntax!");
   }
 
 }

--- a/core/test/org/sbml/jsbml/xml/test/TestAbstractNamedSBaseWithUnits.java
+++ b/core/test/org/sbml/jsbml/xml/test/TestAbstractNamedSBaseWithUnits.java
@@ -167,4 +167,22 @@ public class TestAbstractNamedSBaseWithUnits {
     isolatedParam.setUnits("invalid syntax!");
   }
 
+  /**
+   * Test method for {@link org.sbml.jsbml.AbstractNamedSBaseWithUnit#setUnits(java.lang.String)}
+   * when an undefined unit is set on an attached node in SBML Level 2 Version 4.
+   */
+  @Test
+  public void testSetMissingUnitReferenceLevel2Version4LogsError() {
+    Parameter paramL2V4 = new Parameter(2, 4);
+    SBMLDocument doc = new SBMLDocument(2, 4);
+    Model model = doc.createModel("test_model_l2v4");
+    model.addParameter(paramL2V4);
+    
+    int initialErrorCount = doc.getErrorLog().getErrorCount();
+    paramL2V4.setUnits("valid_syntax_but_missing");
+    
+    org.junit.Assert.assertEquals("Error count should increment", initialErrorCount + 1, doc.getErrorLog().getErrorCount());
+    org.junit.Assert.assertEquals("Should log CORE_99303 for missing unit reference in L2V4",
+      (long) SBMLErrorCodes.CORE_99303, (long) doc.getErrorLog().getError(initialErrorCount).getCode());
+  }
 }


### PR DESCRIPTION
### Resolve TODO: Integrate offline validation for SBase unit assignments

**Description**
This PR resolves the pending TODO in `AbstractNamedSBaseWithUnit.java` by shifting unit assignment validation to utilize the JSBML offline validation framework. 

Previously, programmatic assignment of an invalid unit triggered a hard `IllegalArgumentException`, which disrupted model building. This update ensures that invalid unit assignments now gracefully register an `SBMLError` within the associated `SBMLDocument`'s error log (tracking `SBMLErrorCodes.CORE_10311` syntax requirements), maintaining execution flow while strictly enforcing SBML specifications.

**Architectural Changes**
* **Validation Shift:** Updated `setUnits(String)` to check for a valid `SBMLDocument` context and append an `SBMLError` upon invalid unit assignment.
* **Isolated Node Handling:** Maintained the `IllegalArgumentException` fallback for isolated nodes lacking a document context.
* **Test Verification:** Verified successfully against `TestAbstractNamedSBaseWithUnits` using Maven targeted testing.

cc: @draeger 